### PR TITLE
return default in get_column_values if no execute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@ If you were relying on the position to match up your optional arguments, this ma
 ## Under the hood
 * Update the default implementation of concat macro to use `||` operator ([#373](https://github.com/fishtown-analytics/dbt-utils/pull/314) from [@ChristopheDuong](https://github.com/ChristopheDuong)). Note this may be a breaking change for adapters that support `concat()` but not `||`, such as Apache Spark.
 - Use `power()` instead of `pow()` in `generate_series()` and `haversine_distance()` as they are synonyms in most SQL dialects, but some dialects only have `power()` ([#354](https://github.com/fishtown-analytics/dbt-utils/pull/354) from [@swanderz](https://github.com/swanderz))
+- Make `get_column_values` return the default value passed as a parameter instead of an empty string before compilation ([#304](https://github.com/dbt-labs/dbt-utils/pull/386) from [@jmriego](https://github.com/jmriego)
 
 # dbt-utils v0.6.6
 

--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -1,7 +1,7 @@
 name: 'dbt_utils'
 version: '0.1.0'
 
-require-dbt-version: [">=0.20.0", "<0.21.0"]
+require-dbt-version: [">=0.20.0", "<=1.0.0"]
 
 config-version: 2
 

--- a/macros/sql/get_column_values.sql
+++ b/macros/sql/get_column_values.sql
@@ -6,7 +6,7 @@
 
     {#-- Prevent querying of db in parsing mode. This works because this macro does not create any new refs. #}
     {%- if not execute -%}
-        {{ return('') }}
+        {{ return(default) }}
     {% endif %}
 
     {%- set target_relation = adapter.get_relation(database=table.database,

--- a/macros/sql/get_column_values.sql
+++ b/macros/sql/get_column_values.sql
@@ -3,7 +3,9 @@
 {% endmacro %}
 
 {% macro default__get_column_values(table, column, order_by='count(*) desc', max_records=none, default=none) -%}
-
+{% if default is none %}
+    {% set default = [] %}
+{% endif %}
     {#-- Prevent querying of db in parsing mode. This works because this macro does not create any new refs. #}
     {%- if not execute -%}
         {{ return(default) }}


### PR DESCRIPTION
This is a:
- [x] bug fix PR with no breaking changes — please ensure the base branch is `master`
- [ ] new functionality — please ensure the base branch is the latest `dev/` branch
- [ ] a breaking change — please ensure the base branch is the latest `dev/` branch

## Description & motivation
Fixes #304 
I think get_column_values should return default if not executing.
The issue I'm describing is that this function has a default parameter that will be returned if no data is found. But if DBT is not on execution mode, it will return an empty string
https://github.com/fishtown-analytics/dbt-utils/blob/c8389533cc7f00823c50d08d904cdfa5f714ec8b/macros/sql/get_column_values.sql#L17

Using this simple code will trigger a warning as columns will default to an empty string if no execute:
```
{% set rep_types = dbt_utils.get_column_values(source_table, 'rep_type', default=[]) %}
{{ dbt_utils.surrogate_key(columns) }} AS row_hash
```

## Checklist
- [x] I have verified that these changes work locally on the following warehouses (Note: it's okay if you do not have access to all warehouses, this helps us understand what has been covered)
    - [x] BigQuery
    - [ ] Postgres
    - [ ] Redshift
    - [ ] Snowflake
- [x] I have "dispatched" any new macro(s) so non-core adapters can also use them (e.g. [the `star()` source](https://github.com/fishtown-analytics/dbt-utils/blob/master/macros/sql/star.sql))
- [x] I have updated the README.md (if applicable)
- [x] I have added tests & descriptions to my models (and macros if applicable)
- [x] I have added an entry to CHANGELOG.md
