### PR TITLE
Update dbt_project.yml

### DIFF
--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -1,5 +1,5 @@
 name: 'dbt_utils'
-version: '0.1.0'
+version: '0.7.0'
 
 require-dbt-version: [">=0.20.0", "<0.21.0"]
 


### PR DESCRIPTION
The version is incorrect in dbt_project.yml file, changing it to the correct version.

motivation:
The incorrect version in dbt_project.yml is causing bugs in codegen package since codegen 0.4.0 requires dbt_utils version [">=0.6.2", "<0.8.0"]
 