### PR TITLE
Log whole row in accepted range

### DIFF
--- a/macros/schema_tests/accepted_range.sql
+++ b/macros/schema_tests/accepted_range.sql
@@ -5,7 +5,7 @@
 {% macro default__test_accepted_range(model, column_name, min_value=none, max_value=none, inclusive=true) %}
 
 with meet_condition as(
-  select {{ column_name }}
+  select *
   from {{ model }}
 ),
 


### PR DESCRIPTION
This is a:
- [ ] bug fix PR with no breaking changes — please ensure the base branch is `master`
- [x] new functionality — please ensure the base branch is the latest `dev/` branch
- [ ] a breaking change — please ensure the base branch is the latest `dev/` branch

## Description & motivation
With the new store failures feature in 0.20.0, we want the whole row stored instead of just the column you are interrogating. This gives you the context required to be able to productively debug test failures. This brings the behaviour in line with what `expression_is_true` does.

## Checklist
- [ ] I have verified that these changes work locally on the following warehouses (Note: it's okay if you do not have access to all warehouses, this helps us understand what has been covered)
    - [ ] BigQuery
    - [ ] Postgres
    - [x] Redshift
    - [ ] Snowflake
- [x] I have "dispatched" any new macro(s) so non-core adapters can also use them (e.g. [the `star()` source](https://github.com/fishtown-analytics/dbt-utils/blob/master/macros/sql/star.sql))
- [x] I have updated the README.md (if applicable)
- [x] I have added tests & descriptions to my models (and macros if applicable)
- [ ] I have added an entry to CHANGELOG.md
