### PR TITLE
Fix: "except" field in Star macro handles cross db column casing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # dbt-utils Next
 
+# dbt-utils v0.7.1
+## Fixes
+* "except" columns in the star macro handles case sensitivity ([#397](https://github.com/dbt-labs/dbt-utils/pull/397) [@danieldiamond](https://github.com/danieldiamond))
 
 # dbt-utils v0.7.0
 ## Breaking changes

--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -1,7 +1,7 @@
 name: 'dbt_utils'
 version: '0.7.0'
 
-require-dbt-version: [">=0.20.0", "<0.21.0"]
+require-dbt-version: [">=0.20.0", "<0.21.1"]
 
 config-version: 2
 

--- a/macros/sql/star.sql
+++ b/macros/sql/star.sql
@@ -14,9 +14,11 @@
     {%- set include_cols = [] %}
     {%- set cols = adapter.get_columns_in_relation(from) -%}
 
+    {#-- Perform case insensitive check against except columns  #}
+    {% set except = except | map('upper') | list %}
     {%- for col in cols -%}
 
-        {%- if col.column not in except -%}
+        {%- if col.column.upper() not in except -%}
             {% do include_cols.append(col.column) %}
 
         {%- endif %}


### PR DESCRIPTION
This is a:
- [ ] bug fix PR with no breaking changes — please ensure the base branch is `master`
- [x] new functionality — please ensure the base branch is the latest `dev/` branch
- [ ] a breaking change — please ensure the base branch is the latest `dev/` branch

## Description & motivation
<!---
Describe your changes, and why you're making them.
-->

## Checklist
- [ ] I have verified that these changes work locally on the following warehouses (Note: it's okay if you do not have access to all warehouses, this helps us understand what has been covered)
    - [ ] BigQuery
    - [ ] Postgres
    - [x] Redshift
    - [x] Snowflake
- [ ] I have "dispatched" any new macro(s) so non-core adapters can also use them (e.g. [the `star()` source](https://github.com/fishtown-analytics/dbt-utils/blob/master/macros/sql/star.sql))
- [ ] I have updated the README.md (if applicable)
- [ ] I have added tests & descriptions to my models (and macros if applicable)
- [x] I have added an entry to CHANGELOG.md
