### PR TITLE
Bump upper bound to <0.22

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
-# dbt-utils Next
+# dbt-utils v0.7.1
+
+## Under the hood
+
+- Declare compatibility with dbt v0.21.0, which has no breaking changes for this package ([#398](https://github.com/fishtown-analytics/dbt-utils/pull/398))
 
 
 # dbt-utils v0.7.0

--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -1,7 +1,7 @@
 name: 'dbt_utils'
 version: '0.7.0'
 
-require-dbt-version: [">=0.20.0", "<0.21.0"]
+require-dbt-version: [">=0.20.0", "<0.22.0"]
 
 config-version: 2
 


### PR DESCRIPTION
This is a:
- [ ] bug fix PR with no breaking changes — please ensure the base branch is `master`
- [ ] new functionality — please ensure the base branch is the latest `dev/` branch
- [ ] a breaking change — please ensure the base branch is the latest `dev/` branch
- [x] non-breaking change to add new version compatibility

## Description & motivation

- dbt v0.21 (currently in beta) shouldn't have any breaking changes for `dbt-utils`, so we can add compatibility as a patch release

## Checklist
- [x] I have verified that these changes work locally on the following warehouses (Note: it's okay if you do not have access to all warehouses, this helps us understand what has been covered)
    - [x] BigQuery
    - [x] Postgres
    - [x] Redshift
    - [x] Snowflake
- ~I have "dispatched" any new macro(s) so non-core adapters can also use them (e.g. [the `star()` source](https://github.com/fishtown-analytics/dbt-utils/blob/master/macros/sql/star.sql))~
- ~I have updated the README.md (if applicable)~
- ~I have added tests & descriptions to my models (and macros if applicable)~
- [x] I have added an entry to CHANGELOG.md
