### PR TITLE
Support `where` in `sequential_values`

### DIFF
--- a/README.md
+++ b/README.md
@@ -421,11 +421,13 @@ seeds:
           - dbt_utils.sequential_values:
               interval: 1
               datepart: 'hour'
+              where: "updated_at >= '2021-01-01'"
 ```
 
 **Args:**
 * `interval` (default=1): The gap between two sequential values
 * `datepart` (default=None): Used when the gaps are a unit of time. If omitted, the test will check for a numeric gap.
+* `where` (default=1=1): If it is set, the test will check only on data matched with the condition.
 
 #### unique_combination_of_columns ([source](macros/schema_tests/unique_combination_of_columns.sql))
 This test confirms that the combination of columns is unique. For example, the

--- a/integration_tests/models/schema_tests/schema.yml
+++ b/integration_tests/models/schema_tests/schema.yml
@@ -157,7 +157,7 @@ models:
               inclusive: true
               where: "id <> -1"
 
-  - name: test_recency
+  - name: test_sequential_values
     columns:
       - name: id
         tests:

--- a/integration_tests/models/schema_tests/schema.yml
+++ b/integration_tests/models/schema_tests/schema.yml
@@ -157,3 +157,54 @@ models:
               inclusive: true
               where: "id <> -1"
 
+  - name: test_recency
+    columns:
+      - name: id
+        tests:
+          - dbt_utils.sequential_values:
+              interval: 1
+      - name: hour_interval
+        tests:
+          - dbt_utils.sequential_values:
+              interval: 1
+              datepart: "hour"
+      - name: day_interval
+        tests:
+          - dbt_utils.sequential_values:
+              interval: 1
+              datepart: "day"
+      - name: month_interval
+        tests:
+          - dbt_utils.sequential_values:
+              interval: 1
+              datepart: "month"
+      - name: year_interval
+        tests:
+          - dbt_utils.sequential_values:
+              interval: 1
+              datepart: "year"
+      - name: two_hours_interval
+        tests:
+          - dbt_utils.sequential_values:
+              interval: 2
+              datepart: "hour"
+      - name: two_days_interval
+        tests:
+          - dbt_utils.sequential_values:
+              interval: 2
+              datepart: "day"
+      - name: two_months_interval
+        tests:
+          - dbt_utils.sequential_values:
+              interval: 2
+              datepart: "month"
+      - name: two_years_interval
+        tests:
+          - dbt_utils.sequential_values:
+              interval: 2
+              datepart: "year"
+      - name: conditional_id
+        tests:
+          - dbt_utils.sequential_values:
+              interval: 1
+              where: "id >= 5"

--- a/integration_tests/models/schema_tests/schema.yml
+++ b/integration_tests/models/schema_tests/schema.yml
@@ -163,22 +163,22 @@ models:
         tests:
           - dbt_utils.sequential_values:
               interval: 1
-      - name: hour_interval
+      - name: one_hour_interval
         tests:
           - dbt_utils.sequential_values:
               interval: 1
               datepart: "hour"
-      - name: day_interval
+      - name: one_day_interval
         tests:
           - dbt_utils.sequential_values:
               interval: 1
               datepart: "day"
-      - name: month_interval
+      - name: one_month_interval
         tests:
           - dbt_utils.sequential_values:
               interval: 1
               datepart: "month"
-      - name: year_interval
+      - name: one_year_interval
         tests:
           - dbt_utils.sequential_values:
               interval: 1

--- a/integration_tests/models/schema_tests/test_sequential_values.sql
+++ b/integration_tests/models/schema_tests/test_sequential_values.sql
@@ -1,0 +1,20 @@
+{% if target.type == 'postgres' %}
+select
+    i AS id,
+    -- interval = 1
+    date '2021-01-01' + make_interval(hours => i) AS hour_interval,
+    date '2021-01-01' + make_interval(days => i) AS day_interval,
+    date '2021-01-01' + make_interval(months => i) AS month_interval,
+    date '2021-01-01' + make_interval(years => i) AS year_interval,
+    -- interval = 2
+    date '2021-01-01' + make_interval(hours => i * 2) AS two_hours_interval,
+    date '2021-01-01' + make_interval(days => i * 2) AS two_days_interval,
+    date '2021-01-01' + make_interval(months => i * 2) AS two_month_interval,
+    date '2021-01-01' + make_interval(years => i * 2) AS two_years_interval,
+    case
+        when i >= 5 then i
+        else 0
+    end AS conditional_id
+from
+    generate_series(1, 10) i;
+{% endif %}

--- a/integration_tests/models/schema_tests/test_sequential_values.sql
+++ b/integration_tests/models/schema_tests/test_sequential_values.sql
@@ -16,5 +16,5 @@ select
         else 0
     end AS conditional_id
 from
-    generate_series(1, 10) i;
+    generate_series(1, 10) i
 {% endif %}

--- a/integration_tests/models/schema_tests/test_sequential_values.sql
+++ b/integration_tests/models/schema_tests/test_sequential_values.sql
@@ -2,14 +2,14 @@
 select
     i AS id,
     -- interval = 1
-    date '2021-01-01' + make_interval(hours => i) AS hour_interval,
-    date '2021-01-01' + make_interval(days => i) AS day_interval,
-    date '2021-01-01' + make_interval(months => i) AS month_interval,
-    date '2021-01-01' + make_interval(years => i) AS year_interval,
+    date '2021-01-01' + make_interval(hours => i) AS one_hour_interval,
+    date '2021-01-01' + make_interval(days => i) AS one_day_interval,
+    date '2021-01-01' + make_interval(months => i) AS one_month_interval,
+    date '2021-01-01' + make_interval(years => i) AS one_year_interval,
     -- interval = 2
     date '2021-01-01' + make_interval(hours => i * 2) AS two_hours_interval,
     date '2021-01-01' + make_interval(days => i * 2) AS two_days_interval,
-    date '2021-01-01' + make_interval(months => i * 2) AS two_month_interval,
+    date '2021-01-01' + make_interval(months => i * 2) AS two_months_interval,
     date '2021-01-01' + make_interval(years => i * 2) AS two_years_interval,
     case
         when i >= 5 then i

--- a/macros/schema_tests/sequential_values.sql
+++ b/macros/schema_tests/sequential_values.sql
@@ -1,10 +1,10 @@
-{% test sequential_values(model, column_name, interval=1, datepart=None) %}
+{% test sequential_values(model, column_name, interval=1, datepart=None, where="1=1") %}
 
-  {{ return(adapter.dispatch('test_sequential_values', 'dbt_utils')(model, column_name, interval, datepart)) }}
+  {{ return(adapter.dispatch('test_sequential_values', 'dbt_utils')(model, column_name, interval, datepart, where)) }}
 
 {% endtest %}
 
-{% macro default__test_sequential_values(model, column_name, interval=1, datepart=None) %}
+{% macro default__test_sequential_values(model, column_name, interval=1, datepart=None, where="1=1") %}
 
 with windowed as (
 
@@ -14,6 +14,9 @@ with windowed as (
             order by {{ column_name }}
         ) as previous_{{ column_name }}
     from {{ model }}
+    {% if where %}
+    where {{ where }}
+    {% endif %}
 ),
 
 validation_errors as (


### PR DESCRIPTION
This is a:
- [ ] bug fix PR with no breaking changes — please ensure the base branch is `master`
- [x] new functionality — please ensure the base branch is the latest `dev/` branch
- [ ] a breaking change — please ensure the base branch is the latest `dev/` branch

## Description & motivation
As some schema tests support `where`, it would be good to support it in `sequential_values`.

## Checklist
- [ ] I have verified that these changes work locally on the following warehouses (Note: it's okay if you do not have access to all warehouses, this helps us understand what has been covered)
    - [ ] BigQuery
    - [ ] Postgres
    - [ ] Redshift
    - [ ] Snowflake
- [ ] I have "dispatched" any new macro(s) so non-core adapters can also use them (e.g. [the `star()` source](https://github.com/fishtown-analytics/dbt-utils/blob/master/macros/sql/star.sql))
- [x] I have updated the README.md (if applicable)
- [x] I have added tests & descriptions to my models (and macros if applicable)
- [ ] I have added an entry to CHANGELOG.md
