### PR TITLE
PR - lowercase `except` values in star()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 - Declare compatibility with dbt v0.21.0, which has no breaking changes for this package ([#398](https://github.com/fishtown-analytics/dbt-utils/pull/398))
 
+## Features
+
+- Allow user to provide any case type when defining the `exclude` argument in `dbt_utils.star()` ([#403](https://github.com/dbt-labs/dbt-utils/pull/403))
+
 
 # dbt-utils v0.7.0
 ## Breaking changes

--- a/integration_tests/models/sql/test_star.sql
+++ b/integration_tests/models/sql/test_star.sql
@@ -1,6 +1,3 @@
-
--- TODO : Should the star macro use a case-insensitive comparison for the `except` field on Snowflake?
-
 {% set exclude_field = 'field_3' %}
 
 

--- a/integration_tests/models/sql/test_star.sql
+++ b/integration_tests/models/sql/test_star.sql
@@ -1,7 +1,7 @@
 
 -- TODO : Should the star macro use a case-insensitive comparison for the `except` field on Snowflake?
 
-{% set exclude_field = 'FIELD_3' if target.type == 'snowflake' else 'field_3' %}
+{% set exclude_field = 'field_3' %}
 
 
 with data as (

--- a/macros/sql/star.sql
+++ b/macros/sql/star.sql
@@ -16,7 +16,7 @@
 
     {%- for col in cols -%}
 
-        {%- if col.column not in except -%}
+        {%- if col.column|lower not in except|lower -%}
             {% do include_cols.append(col.column) %}
 
         {%- endif %}


### PR DESCRIPTION
resolves https://github.com/dbt-labs/dbt-utils/issues/402

This is a:
- [x] bug fix PR with no breaking changes — please ensure the base branch is `master`
- [ ] new functionality — please ensure the base branch is the latest `dev/` branch
- [ ] a breaking change — please ensure the base branch is the latest `dev/` branch

## Description & motivation
<!---
Describe your changes, and why you're making them.
-->

This PR allows a user to put their `except` values in whatever case they want when calling them within `dbt_utils.star()`

`{{ dbt_utils.star(from=ref('my_model', except=["col_a","col_b"])` == `{{ dbt_utils.star(from=ref('my_model', except=["COL_A","Col_B"])`

## Checklist
- [x] I have verified that these changes work locally on the following warehouses (Note: it's okay if you do not have access to all warehouses, this helps us understand what has been covered)
    - [ ] BigQuery
    - [ ] Postgres
    - [ ] Redshift
    - [x] Snowflake
- [x] I have "dispatched" any new macro(s) so non-core adapters can also use them (e.g. [the `star()` source](https://github.com/fishtown-analytics/dbt-utils/blob/master/macros/sql/star.sql))
- [x] I have updated the README.md (if applicable)
- [x] I have added tests & descriptions to my models (and macros if applicable)
- [x] I have added an entry to CHANGELOG.md
