### PR TITLE
use column name in group by in get_column_values

### DIFF
--- a/macros/sql/get_column_values.sql
+++ b/macros/sql/get_column_values.sql
@@ -32,7 +32,7 @@
                 {{ column }} as value
 
             from {{ target_relation }}
-            group by 1
+            group by {{ column }}
             order by {{ order_by }}
 
             {% if max_records is not none %}


### PR DESCRIPTION
Most database engines (e.g. all SQL Server versions) don't support grouping by the position of the column.

This is a:
- [x] bug fix PR with no breaking changes — please ensure the base branch is `master`
- [ ] new functionality — please ensure the base branch is the latest `dev/` branch
- [ ] a breaking change — please ensure the base branch is the latest `dev/` branch

## Description & motivation
The current version of get_column_values doesn't work on database engines other than the subset which supports the position of the column in GROUP BY statements.

## Checklist
- [ ] I have verified that these changes work locally on the following warehouses (Note: it's okay if you do not have access to all warehouses, this helps us understand what has been covered)
    - [ ] BigQuery
    - [ ] Postgres
    - [ ] Redshift
    - [ ] Snowflake
- [ ] I have "dispatched" any new macro(s) so non-core adapters can also use them (e.g. [the `star()` source](https://github.com/fishtown-analytics/dbt-utils/blob/master/macros/sql/star.sql))
- [ ] I have updated the README.md (if applicable)
- [ ] I have added tests & descriptions to my models (and macros if applicable)
- [ ] I have added an entry to CHANGELOG.md
