### PR TITLE
Modernize legacy insert by period materialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 - Declare compatibility with dbt v0.21.0, which has no breaking changes for this package ([#398](https://github.com/fishtown-analytics/dbt-utils/pull/398))
 
+## Features
+* Modernize the `insert_by_period` materialization and make it Snowflake-compatible. 
 
 # dbt-utils v0.7.0
 ## Breaking changes

--- a/README.md
+++ b/README.md
@@ -1079,8 +1079,8 @@ with events as (
 * `stop_date`: literal date or timestamp (default=current_timestamp)
 
 **Caveats:**
-* This materialization is compatible with dbt 0.10.1.
-* This materialization has been written for Redshift.
+* This materialization is compatible with dbt 0.21.0.
+* This materialization has been written primarily for Snowflake.
 * This materialization can only be used for a model where records are not expected to change after they are created.
 * Any model post-hooks that use `{{ this }}` will fail using this materialization. For example:
 ```yaml

--- a/README.md
+++ b/README.md
@@ -1082,16 +1082,6 @@ with events as (
 * This materialization is compatible with dbt 0.21.0.
 * This materialization has been written primarily for Snowflake.
 * This materialization can only be used for a model where records are not expected to change after they are created.
-* Any model post-hooks that use `{{ this }}` will fail using this materialization. For example:
-```yaml
-models:
-    project-name:
-        post-hook: "grant select on {{ this }} to db_reader"
-```
-A useful workaround is to change the above post-hook to:
-```yaml
-        post-hook: "grant select on {{ this.schema }}.{{ this.name }} to db_reader"
-```
 
 ----
 

--- a/integration_tests/models/materializations/expected_insert_by_period.sql
+++ b/integration_tests/models/materializations/expected_insert_by_period.sql
@@ -1,7 +1,7 @@
 {{
 	config(
 		materialized = 'view',
-		enabled=(target.type == 'redshift')
+		enabled=(target.type == 'redshift' or target.type == 'snowflake')
 	)
 }}
 

--- a/integration_tests/models/materializations/expected_insert_by_period.sql
+++ b/integration_tests/models/materializations/expected_insert_by_period.sql
@@ -1,7 +1,6 @@
 {{
 	config(
-		materialized = 'view',
-		enabled=(target.type == 'redshift' or target.type == 'snowflake')
+		materialized = 'view'
 	)
 }}
 

--- a/integration_tests/models/materializations/test_insert_by_period.sql
+++ b/integration_tests/models/materializations/test_insert_by_period.sql
@@ -4,8 +4,7 @@
 		period = 'month',
 		timestamp_field = 'created_at',
 		start_date = '2018-01-01',
-		stop_date = '2018-06-01',
-		enabled=(target.type == 'redshift' or target.type == 'snowflake')
+		stop_date = '2018-06-01'
 	)
 }}
 

--- a/integration_tests/models/materializations/test_insert_by_period.sql
+++ b/integration_tests/models/materializations/test_insert_by_period.sql
@@ -5,7 +5,7 @@
 		timestamp_field = 'created_at',
 		start_date = '2018-01-01',
 		stop_date = '2018-06-01',
-		enabled=(target.type == 'redshift')
+		enabled=(target.type == 'redshift' or target.type == 'snowflake')
 	)
 }}
 

--- a/macros/materializations/helpers.sql
+++ b/macros/materializations/helpers.sql
@@ -1,4 +1,8 @@
 {% macro check_for_period_filter(model_unique_id, sql) %}
+    {{ return(adapter.dispatch('check_for_period_filter', 'dbt_utils')(model_unique_id, sql)) }}
+{% endmacro %}
+
+{% macro default__check_for_period_filter(model_unique_id, sql) %}
     {%- if sql.find('__PERIOD_FILTER__') == -1 -%}
         {%- set error_message -%}
         Model '{{ model_unique_id }}' does not include the required string '__PERIOD_FILTER__' in its sql

--- a/macros/materializations/helpers.sql
+++ b/macros/materializations/helpers.sql
@@ -18,10 +18,15 @@
 {% macro default__get_period_boundaries(target_schema, target_table, timestamp_field, start_date, stop_date, period) -%}
 
   {% call statement('period_boundaries', fetch_result=True) -%}
+    {{ dbt_utils.log_info(model) }}
+    {%- set model_name = model['name'] -%}
+    
     {%- set target_schema_msg = " [DEBUG] (get_period_boundaries) target schema is: " ~ target_schema -%}
     {%- set target_table_msg = " [DEBUG] (get_period_boundaries) target table is: " ~ target_table -%}
+    {%- set model_name_msg = " [DEBUG] (get_period_boundaries) model[name] is: " ~ model_name -%}
     {{ dbt_utils.log_info(target_schema_msg) }}
     {{ dbt_utils.log_info(target_table_msg) }}
+    {{ dbt_utils.log_info(model_name_msg) }}
     
     with data as (
       select
@@ -32,7 +37,7 @@
                                 "nullif('" ~ stop_date ~ "','')::timestamp")}},
             {{dbt_utils.current_timestamp()}}
           ) as stop_timestamp
-      from "{{target_schema}}"."{{target_table}}"
+      from "{{target_schema}}"."{{model_name}}"
     )
 
     select

--- a/macros/materializations/helpers.sql
+++ b/macros/materializations/helpers.sql
@@ -28,6 +28,35 @@
 
 {%- endmacro %}
 
+{% macro snowflake__get_period_boundaries(target_schema, target_table, timestamp_field, start_date, stop_date, period) -%}
+
+  {% call statement('period_boundaries', fetch_result=True) -%}
+    {%- set model_name = model['name'] -%}
+    
+    with data as (
+      select
+          coalesce(max({{timestamp_field}}), '{{start_date}}')::timestamp as start_timestamp,
+          coalesce(
+            {{dbt_utils.dateadd('millisecond',
+                                -1,
+                                "nullif('" ~ stop_date ~ "','')::timestamp")}},
+            {{dbt_utils.current_timestamp()}}
+          ) as stop_timestamp
+      from {{target.schema}}.{{model_name}}
+    )
+
+    select
+      start_timestamp,
+      stop_timestamp,
+      {{dbt_utils.datediff('start_timestamp',
+                           'stop_timestamp',
+                           period)}}  + 1 as num_periods
+    from data
+  {%- endcall %}
+
+{%- endmacro %}
+
+
 {% macro get_period_sql(target_cols_csv, sql, timestamp_field, period, start_timestamp, stop_timestamp, offset) -%}
     {{ return(adapter.dispatch('get_period_sql', 'dbt_utils')(target_cols_csv, sql, timestamp_field, period, start_timestamp, stop_timestamp, offset)) }}
 {% endmacro %}
@@ -38,6 +67,24 @@
     ("{{timestamp_field}}" >  '{{start_timestamp}}'::timestamp + interval '{{offset}} {{period}}' and
      "{{timestamp_field}}" <= '{{start_timestamp}}'::timestamp + interval '{{offset}} {{period}}' + interval '1 {{period}}' and
      "{{timestamp_field}}" <  '{{stop_timestamp}}'::timestamp)
+  {%- endset -%}
+
+  {%- set filtered_sql = sql | replace("__PERIOD_FILTER__", period_filter) -%}
+
+  select
+    {{target_cols_csv}}
+  from (
+    {{filtered_sql}}
+  )
+
+{%- endmacro %}
+
+{% macro snowflake__get_period_sql(target_cols_csv, sql, timestamp_field, period, start_timestamp, stop_timestamp, offset) -%}
+
+  {%- set period_filter -%}
+    ({{timestamp_field}} >  '{{start_timestamp}}'::timestamp + interval '{{offset}} {{period}}' and
+     {{timestamp_field}} <= '{{start_timestamp}}'::timestamp + interval '{{offset}} {{period}}' + interval '1 {{period}}' and
+     {{timestamp_field}} <  '{{stop_timestamp}}'::timestamp)
   {%- endset -%}
 
   {%- set filtered_sql = sql | replace("__PERIOD_FILTER__", period_filter) -%}

--- a/macros/materializations/helpers.sql
+++ b/macros/materializations/helpers.sql
@@ -1,3 +1,12 @@
+{% macro check_for_period_filter(model_unique_id, sql) %}
+    {%- if sql.find('__PERIOD_FILTER__') == -1 -%}
+        {%- set error_message -%}
+        Model '{{ model_unique_id }}' does not include the required string '__PERIOD_FILTER__' in its sql
+        {%- endset -%}
+        {{ exceptions.raise_compiler_error(error_message) }}
+    {%- endif -%}
+{% endmacro %}
+
 {% macro get_period_boundaries(target_schema, target_table, timestamp_field, start_date, stop_date, period) -%}
     {{ return(adapter.dispatch('get_period_boundaries', 'dbt_utils')(target_schema, target_table, timestamp_field, start_date, stop_date, period)) }}
 {% endmacro %}

--- a/macros/materializations/helpers.sql
+++ b/macros/materializations/helpers.sql
@@ -18,6 +18,11 @@
 {% macro default__get_period_boundaries(target_schema, target_table, timestamp_field, start_date, stop_date, period) -%}
 
   {% call statement('period_boundaries', fetch_result=True) -%}
+    {%- set target_schema_msg = " [DEBUG] (get_period_boundaries) target schema is: " ~ target_schema -%}
+    {%- set target_table_msg = " [DEBUG] (get_period_boundaries) target table is: " ~ target_table -%}
+    {{ dbt_utils.log_info(target_schema_msg) }}
+    {{ dbt_utils.log_info(target_table_msg) }}
+    
     with data as (
       select
           coalesce(max("{{timestamp_field}}"), '{{start_date}}')::timestamp as start_timestamp,

--- a/macros/materializations/helpers.sql
+++ b/macros/materializations/helpers.sql
@@ -1,0 +1,51 @@
+{% macro get_period_boundaries(target_schema, target_table, timestamp_field, start_date, stop_date, period) -%}
+    {{ return(adapter.dispatch('get_period_boundaries', 'dbt_utils')(target_schema, target_table, timestamp_field, start_date, stop_date, period)) }}
+{% endmacro %}
+
+{% macro default__get_period_boundaries(target_schema, target_table, timestamp_field, start_date, stop_date, period) -%}
+
+  {% call statement('period_boundaries', fetch_result=True) -%}
+    with data as (
+      select
+          coalesce(max("{{timestamp_field}}"), '{{start_date}}')::timestamp as start_timestamp,
+          coalesce(
+            {{dbt_utils.dateadd('millisecond',
+                                -1,
+                                "nullif('" ~ stop_date ~ "','')::timestamp")}},
+            {{dbt_utils.current_timestamp()}}
+          ) as stop_timestamp
+      from "{{target_schema}}"."{{target_table}}"
+    )
+
+    select
+      start_timestamp,
+      stop_timestamp,
+      {{dbt_utils.datediff('start_timestamp',
+                           'stop_timestamp',
+                           period)}}  + 1 as num_periods
+    from data
+  {%- endcall %}
+
+{%- endmacro %}
+
+{% macro get_period_sql(target_cols_csv, sql, timestamp_field, period, start_timestamp, stop_timestamp, offset) -%}
+    {{ return(adapter.dispatch('get_period_sql', 'dbt_utils')(target_cols_csv, sql, timestamp_field, period, start_timestamp, stop_timestamp, offset)) }}
+{% endmacro %}
+
+{% macro default__get_period_sql(target_cols_csv, sql, timestamp_field, period, start_timestamp, stop_timestamp, offset) -%}
+
+  {%- set period_filter -%}
+    ("{{timestamp_field}}" >  '{{start_timestamp}}'::timestamp + interval '{{offset}} {{period}}' and
+     "{{timestamp_field}}" <= '{{start_timestamp}}'::timestamp + interval '{{offset}} {{period}}' + interval '1 {{period}}' and
+     "{{timestamp_field}}" <  '{{stop_timestamp}}'::timestamp)
+  {%- endset -%}
+
+  {%- set filtered_sql = sql | replace("__PERIOD_FILTER__", period_filter) -%}
+
+  select
+    {{target_cols_csv}}
+  from (
+    {{filtered_sql}}
+  )
+
+{%- endmacro %}

--- a/macros/materializations/helpers.sql
+++ b/macros/materializations/helpers.sql
@@ -88,7 +88,7 @@
     {{target_cols_csv}}
   from (
     {{filtered_sql}}
-  )
+  ) as t -- has to have an alias
 
 {%- endmacro %}
 

--- a/macros/materializations/helpers.sql
+++ b/macros/materializations/helpers.sql
@@ -18,15 +18,7 @@
 {% macro default__get_period_boundaries(target_schema, target_table, timestamp_field, start_date, stop_date, period) -%}
 
   {% call statement('period_boundaries', fetch_result=True) -%}
-    {{ dbt_utils.log_info(model) }}
     {%- set model_name = model['name'] -%}
-    
-    {%- set target_schema_msg = " [DEBUG] (get_period_boundaries) target schema is: " ~ target_schema -%}
-    {%- set target_table_msg = " [DEBUG] (get_period_boundaries) target table is: " ~ target_table -%}
-    {%- set model_name_msg = " [DEBUG] (get_period_boundaries) model[name] is: " ~ model_name -%}
-    {{ dbt_utils.log_info(target_schema_msg) }}
-    {{ dbt_utils.log_info(target_table_msg) }}
-    {{ dbt_utils.log_info(model_name_msg) }}
     
     with data as (
       select

--- a/macros/materializations/insert_by_period_materialization.sql
+++ b/macros/materializations/insert_by_period_materialization.sql
@@ -1,5 +1,13 @@
 
 {% materialization insert_by_period, default -%}
+  {%- if sql.find('__PERIOD_FILTER__') == -1 -%}
+    {%- set error_message -%}
+      Model '{{ model.unique_id }}' does not include the required string '__PERIOD_FILTER__' in its sql
+    {%- endset -%}
+    {{ exceptions.raise_compiler_error(error_message) }}
+  {%- endif -%}
+
+  {%- set start_date = config.require('start_date') -%}
 
   {% set unique_key = config.get('unique_key') %}
 
@@ -38,7 +46,7 @@
 
   {% if existing_relation is none %}
       {% set build_sql = create_table_as(False, target_relation, sql) %}
-{% elif trigger_full_refresh %}
+  {% elif trigger_full_refresh %}
       {#-- Make sure the backup doesn't exist so we don't encounter issues with the rename below #}
       {% set tmp_identifier = model['name'] + '__dbt_tmp' %}
       {% set backup_identifier = model['name'] + '__dbt_backup' %}

--- a/macros/materializations/insert_by_period_materialization.sql
+++ b/macros/materializations/insert_by_period_materialization.sql
@@ -10,7 +10,7 @@
   -- Configuration (others)
   {%- set unique_key = config.get('unique_key') -%}
   {%- set stop_date = config.get('stop_date') or '' -%}}
-  {%- set period = config.get('period') or 'hour' -%}
+  {%- set period = config.get('period') or 'week' -%}
 
   {% set target_relation = this.incorporate(type='table') %}
   {% set existing_relation = load_relation(this) %}

--- a/macros/materializations/insert_by_period_materialization.sql
+++ b/macros/materializations/insert_by_period_materialization.sql
@@ -12,12 +12,7 @@
   {%- set stop_date = config.get('stop_date') or '' -%}}
   {%- set period = config.get('period') or 'week' -%}
 
-  {{ dbt_utils.log_info("[DEBUG] Parameters are set!") }}
-
   {% set target_relation = this.incorporate(type='table') %}
-
-  {%- set target_msg = "[DEBUG] Target is set to be " ~ target_relation -%}
-  {{ dbt_utils.log_info(target_msg) }}
 
   {% set existing_relation = load_relation(this) %}
   {% set tmp_relation = make_temp_relation(target_relation) %}
@@ -43,12 +38,8 @@
 
   {{ run_hooks(pre_hooks, inside_transaction=False) }}
 
-  {{ dbt_utils.log_info("[DEBUG] Prehooks (outside transaction) are done!") }}
-
   -- `BEGIN` happens here:
   {{ run_hooks(pre_hooks, inside_transaction=True) }}
-
-  {{ dbt_utils.log_info("[DEBUG] Prehooks (inside transaction) are done!") }}
 
   {% set to_drop = [] %}
 
@@ -60,20 +51,11 @@
       {%- set empty_sql = sql | replace("__PERIOD_FILTER__", 'false') -%} 
       {% set build_sql = create_table_as(False, target_relation, empty_sql) %}
 
-      {{ dbt_utils.log_info("[DEBUG] Within 'if existing_relation is none or trigger_full_refresh'!") }}
-      {%- set existing_relation_msg = "[DEBUG] Existing relation is: " ~ existing_relation -%}
-      {%- set trigger_full_refresh_msg = "[DEBUG] Trigger full refresh flag is: " ~ trigger_full_refresh -%}
-      {{ dbt_utils.log_info(existing_relation_msg) }}
-      {{ dbt_utils.log_info(trigger_full_refresh_msg) }}
-
       {% call statement("main") %}
-          {{ dbt_utils.log_info("[DEBUG] Executing the following:") }}
-          {{ dbt_utils.log_info(build_sql) }}
           {{ build_sql }}
       {% endcall %}
   {% endif %}
 
-  {{ dbt_utils.log_info("[DEBUG] We have an empty table now.") }}
   -- Now that we have an empty table, let's put something in it.
 
   {% set _ = dbt_utils.get_period_boundaries(schema,
@@ -86,31 +68,17 @@
   {%- set stop_timestamp = load_result('period_boundaries')['data'][0][1] | string -%}
   {%- set num_periods = load_result('period_boundaries')['data'][0][2] | int -%}
 
-
-  {%- set start_timestamp_msg = "[DEBUG] Start timestamp is: " ~ start_timestamp -%}
-  {%- set stop_timestamp_msg = "[DEBUG] End timestamp is: " ~ stop_timestamp -%}
-  {%- set num_periods_msg = "[DEBUG] Number of periods: " ~ num_periods ~ " " ~ period ~ "(s)" -%}
-  {{ dbt_utils.log_info(start_timestamp_msg) }}
-  {{ dbt_utils.log_info(stop_timestamp_msg) }}
-  {{ dbt_utils.log_info(num_periods_msg) }}
-
   {% set target_columns = adapter.get_columns_in_relation(target_relation) %}
   {%- set target_cols_csv = target_columns | map(attribute='quoted') | join(', ') -%}
 
   {%- set loop_vars = {'sum_rows_inserted': 0} -%}
 
   {% for i in range(num_periods) -%} 
-    {%- set loop_enter_msg = "[DEBUG] Entering the " ~ (i + 1) ~ ". iteration of the loop." -%}
-    {{ dbt_utils.log_info(loop_enter_msg) }}
-
     {%- set msg = "Running for " ~ period ~ " " ~ (i + 1) ~ " of " ~ num_periods -%}
     {{ dbt_utils.log_info(msg) }}
 
     {%- set tmp_identifier_suffix = '__dbt_incremental_period_' ~ i ~ '_tmp' -%}
     {% set tmp_relation = make_temp_relation(target_relation, tmp_identifier_suffix) %}
-
-    {%- set tmp_relation_msg = "[DEBUG] (Within loop) Termporary relation is: " ~ tmp_relation -%}
-    {{ dbt_utils.log_info(tmp_relation_msg) }}
 
     {% set tmp_table_sql = dbt_utils.get_period_sql(target_cols_csv,
                                                        sql,
@@ -129,8 +97,6 @@
     {%- set name = 'main-' ~ i -%}
     {% set build_sql = incremental_upsert(tmp_relation, target_relation, unique_key=unique_key) %}
     {% call statement(name, fetch_result=True) -%}
-      {{ dbt_utils.log_info("[DEBUG] (Within loop) Executing the following:") }}
-      {{ dbt_utils.log_info(build_sql) }}
       {{ build_sql }}
     {%- endcall %}
 
@@ -147,8 +113,6 @@
     {%- set msg = "Ran completed for " ~ period ~ " " ~ ( i + 1 ) ~ " of " ~ num_periods ~ "; " ~ rows_inserted ~ " records inserted" -%}
     {{ dbt_utils.log_info(msg) }}
   {%- endfor %}
-
-  {{ dbt_utils.log_info("[DEBUG] Out of the loop.") }}
 
   {% do persist_docs(target_relation, model) %}
 

--- a/macros/materializations/insert_by_period_materialization.sql
+++ b/macros/materializations/insert_by_period_materialization.sql
@@ -1,12 +1,7 @@
 
 {% materialization insert_by_period, default -%}
   -- If there is no __PERIOD_FILTER__ specified, raise error. (Maybe create a macro for this.)
-  {%- if sql.find('__PERIOD_FILTER__') == -1 -%}
-    {%- set error_message -%}
-      Model '{{ model.unique_id }}' does not include the required string '__PERIOD_FILTER__' in its sql
-    {%- endset -%}
-    {{ exceptions.raise_compiler_error(error_message) }}
-  {%- endif -%}
+  {{ dbt_utils.check_for_period_filter(model.unique_id, sql) }}
 
   -- Configuration (required)
   {%- set timestamp_field = config.require('timestamp_field') -%}

--- a/macros/materializations/insert_by_period_materialization.sql
+++ b/macros/materializations/insert_by_period_materialization.sql
@@ -76,9 +76,8 @@
     {%- set msg = "Running for " ~ period ~ " " ~ (i + 1) ~ " of " ~ num_periods -%}
     {{ dbt_utils.log_info(msg) }}
 
-    {%- set tmp_identifier = model['name'] ~ '__dbt_incremental_period_' ~ i ~ '_tmp' -%}
-    {%- set tmp_relation = api.Relation.create(identifier=tmp_identifier,
-                                              schema=schema, type='table') -%}
+    {%- set tmp_identifier_suffix = '__dbt_incremental_period_' ~ i ~ '_tmp' -%}
+    {% set tmp_relation = make_temp_relation(target_relation, tmp_identifier_suffix) %}
 
     {% set tmp_table_sql = dbt_utils.get_period_sql(target_cols_csv,
                                                        sql,

--- a/macros/materializations/insert_by_period_materialization.sql
+++ b/macros/materializations/insert_by_period_materialization.sql
@@ -1,5 +1,6 @@
 
 {% materialization insert_by_period, default -%}
+  -- If there is no __PERIOD_FILTER__ specified, raise error. (Maybe create a macro for this.)
   {%- if sql.find('__PERIOD_FILTER__') == -1 -%}
     {%- set error_message -%}
       Model '{{ model.unique_id }}' does not include the required string '__PERIOD_FILTER__' in its sql
@@ -7,9 +8,14 @@
     {{ exceptions.raise_compiler_error(error_message) }}
   {%- endif -%}
 
+  -- Configuration (required)
+  {%- set timestamp_field = config.require('timestamp_field') -%}
   {%- set start_date = config.require('start_date') -%}
 
-  {% set unique_key = config.get('unique_key') %}
+  -- Configuration (others)
+  {%- set unique_key = config.get('unique_key') -%}
+  {%- set stop_date = config.get('stop_date') or '' -%}}
+  {%- set period = config.get('period') or 'day' -%}
 
   {% set target_relation = this.incorporate(type='table') %}
   {% set existing_relation = load_relation(this) %}

--- a/macros/materializations/insert_by_period_materialization.sql
+++ b/macros/materializations/insert_by_period_materialization.sql
@@ -1,189 +1,89 @@
-{% macro get_period_boundaries(target_schema, target_table, timestamp_field, start_date, stop_date, period) -%}
-    {{ return(adapter.dispatch('get_period_boundaries', 'dbt_utils')(target_schema, target_table, timestamp_field, start_date, stop_date, period)) }}
-{% endmacro %}
-
-{% macro default__get_period_boundaries(target_schema, target_table, timestamp_field, start_date, stop_date, period) -%}
-
-  {% call statement('period_boundaries', fetch_result=True) -%}
-    with data as (
-      select
-          coalesce(max("{{timestamp_field}}"), '{{start_date}}')::timestamp as start_timestamp,
-          coalesce(
-            {{dbt_utils.dateadd('millisecond',
-                                -1,
-                                "nullif('" ~ stop_date ~ "','')::timestamp")}},
-            {{dbt_utils.current_timestamp()}}
-          ) as stop_timestamp
-      from "{{target_schema}}"."{{target_table}}"
-    )
-
-    select
-      start_timestamp,
-      stop_timestamp,
-      {{dbt_utils.datediff('start_timestamp',
-                           'stop_timestamp',
-                           period)}}  + 1 as num_periods
-    from data
-  {%- endcall %}
-
-{%- endmacro %}
-
-{% macro get_period_sql(target_cols_csv, sql, timestamp_field, period, start_timestamp, stop_timestamp, offset) -%}
-    {{ return(adapter.dispatch('get_period_sql', 'dbt_utils')(target_cols_csv, sql, timestamp_field, period, start_timestamp, stop_timestamp, offset)) }}
-{% endmacro %}
-
-{% macro default__get_period_sql(target_cols_csv, sql, timestamp_field, period, start_timestamp, stop_timestamp, offset) -%}
-
-  {%- set period_filter -%}
-    ("{{timestamp_field}}" >  '{{start_timestamp}}'::timestamp + interval '{{offset}} {{period}}' and
-     "{{timestamp_field}}" <= '{{start_timestamp}}'::timestamp + interval '{{offset}} {{period}}' + interval '1 {{period}}' and
-     "{{timestamp_field}}" <  '{{stop_timestamp}}'::timestamp)
-  {%- endset -%}
-
-  {%- set filtered_sql = sql | replace("__PERIOD_FILTER__", period_filter) -%}
-
-  select
-    {{target_cols_csv}}
-  from (
-    {{filtered_sql}}
-  )
-
-{%- endmacro %}
 
 {% materialization insert_by_period, default -%}
-  {%- set timestamp_field = config.require('timestamp_field') -%}
-  {%- set start_date = config.require('start_date') -%}
-  {%- set stop_date = config.get('stop_date') or '' -%}}
-  {%- set period = config.get('period') or 'week' -%}
 
-  {%- if sql.find('__PERIOD_FILTER__') == -1 -%}
-    {%- set error_message -%}
-      Model '{{ model.unique_id }}' does not include the required string '__PERIOD_FILTER__' in its sql
-    {%- endset -%}
-    {{ exceptions.raise_compiler_error(error_message) }}
-  {%- endif -%}
+  {% set unique_key = config.get('unique_key') %}
 
-  {%- set identifier = model['name'] -%}
+  {% set target_relation = this.incorporate(type='table') %}
+  {% set existing_relation = load_relation(this) %}
+  {% set tmp_relation = make_temp_relation(target_relation) %}
+  {%- set full_refresh_mode = (should_full_refresh()) -%}
 
-  {%- set old_relation = adapter.get_relation(database=database, schema=schema, identifier=identifier) -%}
-  {%- set target_relation = api.Relation.create(identifier=identifier, schema=schema, type='table') -%}
+  {% set on_schema_change = incremental_validate_on_schema_change(config.get('on_schema_change'), default='ignore') %}
 
-  {%- set non_destructive_mode = (flags.NON_DESTRUCTIVE == True) -%}
-  {%- set full_refresh_mode = (flags.FULL_REFRESH == True) -%}
+  {% set tmp_identifier = model['name'] + '__dbt_tmp' %}
+  {% set backup_identifier = model['name'] + "__dbt_backup" %}
 
-  {%- set exists_as_table = (old_relation is not none and old_relation.is_table) -%}
-  {%- set exists_not_as_table = (old_relation is not none and not old_relation.is_table) -%}
+  -- the intermediate_ and backup_ relations should not already exist in the database; get_relation
+  -- will return None in that case. Otherwise, we get a relation that we can drop
+  -- later, before we try to use this name for the current operation. This has to happen before
+  -- BEGIN, in a separate transaction
+  {% set preexisting_intermediate_relation = adapter.get_relation(identifier=tmp_identifier, 
+                                                                  schema=schema,
+                                                                  database=database) %}                                               
+  {% set preexisting_backup_relation = adapter.get_relation(identifier=backup_identifier,
+                                                            schema=schema,
+                                                            database=database) %}
+  {{ drop_relation_if_exists(preexisting_intermediate_relation) }}
+  {{ drop_relation_if_exists(preexisting_backup_relation) }}
 
-  {%- set should_truncate = (non_destructive_mode and full_refresh_mode and exists_as_table) -%}
-  {%- set should_drop = (not should_truncate and (full_refresh_mode or exists_not_as_table)) -%}
-  {%- set force_create = (flags.FULL_REFRESH and not flags.NON_DESTRUCTIVE) -%}
+  {{ run_hooks(pre_hooks, inside_transaction=False) }}
 
-  -- setup
-  {% if old_relation is none -%}
-    -- noop
-  {%- elif should_truncate -%}
-    {{adapter.truncate_relation(old_relation)}}
-  {%- elif should_drop -%}
-    {{adapter.drop_relation(old_relation)}}
-    {%- set old_relation = none -%}
-  {%- endif %}
+  -- `BEGIN` happens here:
+  {{ run_hooks(pre_hooks, inside_transaction=True) }}
 
-  {{run_hooks(pre_hooks, inside_transaction=False)}}
+  {% set to_drop = [] %}
 
-  -- `begin` happens here, so `commit` after it to finish the transaction
-  {{run_hooks(pre_hooks, inside_transaction=True)}}
-  {% call statement() -%}
-    begin; -- make extra sure we've closed out the transaction
-    commit;
-  {%- endcall %}
+  {# -- first check whether we want to full refresh for source view or config reasons #}
+  {% set trigger_full_refresh = (full_refresh_mode or existing_relation.is_view) %}
 
-  -- build model
-  {% if force_create or old_relation is none -%}
-    {# Create an empty target table -#}
-    {% call statement('main') -%}
-      {%- set empty_sql = sql | replace("__PERIOD_FILTER__", 'false') -%}
-      {{create_table_as(False, target_relation, empty_sql)}};
-    {%- endcall %}
-  {%- endif %}
+  {% if existing_relation is none %}
+      {% set build_sql = create_table_as(False, target_relation, sql) %}
+{% elif trigger_full_refresh %}
+      {#-- Make sure the backup doesn't exist so we don't encounter issues with the rename below #}
+      {% set tmp_identifier = model['name'] + '__dbt_tmp' %}
+      {% set backup_identifier = model['name'] + '__dbt_backup' %}
+      {% set intermediate_relation = existing_relation.incorporate(path={"identifier": tmp_identifier}) %}
+      {% set backup_relation = existing_relation.incorporate(path={"identifier": backup_identifier}) %}
 
-  {% set _ = dbt_utils.get_period_boundaries(schema,
-                                              identifier,
-                                              timestamp_field,
-                                              start_date,
-                                              stop_date,
-                                              period) %}
-  {%- set start_timestamp = load_result('period_boundaries')['data'][0][0] | string -%}
-  {%- set stop_timestamp = load_result('period_boundaries')['data'][0][1] | string -%}
-  {%- set num_periods = load_result('period_boundaries')['data'][0][2] | int -%}
+      {% set build_sql = create_table_as(False, intermediate_relation, sql) %}
+      {% set need_swap = true %}
+      {% do to_drop.append(backup_relation) %}
+  {% else %}
+    {% do run_query(create_table_as(True, tmp_relation, sql)) %}
+    {% do adapter.expand_target_column_types(
+             from_relation=tmp_relation,
+             to_relation=target_relation) %}
+    {% do process_schema_changes(on_schema_change, tmp_relation, existing_relation) %}
+    {% set build_sql = incremental_upsert(tmp_relation, target_relation, unique_key=unique_key) %}
+  
+  {% endif %}
 
-  {% set target_columns = adapter.get_columns_in_relation(target_relation) %}
-  {%- set target_cols_csv = target_columns | map(attribute='quoted') | join(', ') -%}
-  {%- set loop_vars = {'sum_rows_inserted': 0} -%}
+  {% call statement("main") %}
+      {{ build_sql }}
+  {% endcall %}
 
-  -- commit each period as a separate transaction
-  {% for i in range(num_periods) -%}
-    {%- set msg = "Running for " ~ period ~ " " ~ (i + 1) ~ " of " ~ (num_periods) -%}
-    {{ dbt_utils.log_info(msg) }}
+  {% if need_swap %} 
+      {% do adapter.rename_relation(target_relation, backup_relation) %} 
+      {% do adapter.rename_relation(intermediate_relation, target_relation) %} 
+  {% endif %}
 
-    {%- set tmp_identifier = model['name'] ~ '__dbt_incremental_period' ~ i ~ '_tmp' -%}
-    {%- set tmp_relation = api.Relation.create(identifier=tmp_identifier,
-                                               schema=schema, type='table') -%}
-    {% call statement() -%}
-      {% set tmp_table_sql = dbt_utils.get_period_sql(target_cols_csv,
-                                                       sql,
-                                                       timestamp_field,
-                                                       period,
-                                                       start_timestamp,
-                                                       stop_timestamp,
-                                                       i) %}
-      {{dbt.create_table_as(True, tmp_relation, tmp_table_sql)}}
-    {%- endcall %}
+  {% do persist_docs(target_relation, model) %}
 
-    {{adapter.expand_target_column_types(from_relation=tmp_relation,
-                                         to_relation=target_relation)}}
-    {%- set name = 'main-' ~ i -%}
-    {% call statement(name, fetch_result=True) -%}
-      insert into {{target_relation}} ({{target_cols_csv}})
-      (
-          select
-              {{target_cols_csv}}
-          from {{tmp_relation.include(schema=False)}}
-      );
-    {%- endcall %}
-    {% set result = load_result('main-' ~ i) %}
-    {% if 'response' in result.keys() %} {# added in v0.19.0 #}
-        {% set rows_inserted = result['response']['rows_affected'] %}
-    {% else %} {# older versions #}
-        {% set rows_inserted = result['status'].split(" ")[2] | int %}
-    {% endif %}
-    
-    {%- set sum_rows_inserted = loop_vars['sum_rows_inserted'] + rows_inserted -%}
-    {%- if loop_vars.update({'sum_rows_inserted': sum_rows_inserted}) %} {% endif -%}
+  {% if existing_relation is none or existing_relation.is_view or should_full_refresh() %}
+    {% do create_indexes(target_relation) %}
+  {% endif %}
 
-    {%- set msg = "Ran for " ~ period ~ " " ~ (i + 1) ~ " of " ~ (num_periods) ~ "; " ~ rows_inserted ~ " records inserted" -%}
-    {{ dbt_utils.log_info(msg) }}
+  {{ run_hooks(post_hooks, inside_transaction=True) }}
 
-  {%- endfor %}
+  -- `COMMIT` happens here
+  {% do adapter.commit() %}
 
-  {% call statement() -%}
-    begin;
-  {%- endcall %}
+  {% for rel in to_drop %}
+      {% do adapter.drop_relation(rel) %}
+  {% endfor %}
 
-  {{run_hooks(post_hooks, inside_transaction=True)}}
+  {{ run_hooks(post_hooks, inside_transaction=False) }}
 
-  {% call statement() -%}
-    commit;
-  {%- endcall %}
-
-  {{run_hooks(post_hooks, inside_transaction=False)}}
-
-  {%- set status_string = "INSERT " ~ loop_vars['sum_rows_inserted'] -%}
-
-  {% call noop_statement('main', status_string) -%}
-    -- no-op
-  {%- endcall %}
-
-  -- Return the relations created in this materialization
-  {{ return({'relations': [target_relation]}) }}  
+  {{ return({'relations': [target_relation]}) }}
 
 {%- endmaterialization %}

--- a/macros/materializations/insert_by_period_materialization.sql
+++ b/macros/materializations/insert_by_period_materialization.sql
@@ -45,7 +45,8 @@
   {% set trigger_full_refresh = (full_refresh_mode or existing_relation.is_view) %}
 
   {% if existing_relation is none %}
-      {% set build_sql = create_table_as(False, target_relation, sql) %}
+      {%- set empty_sql = sql | replace("__PERIOD_FILTER__", 'false') -%} -- We create an empty table
+      {% set build_sql = create_table_as(False, target_relation, empty_sql) %}
   {% elif trigger_full_refresh %}
       {#-- Make sure the backup doesn't exist so we don't encounter issues with the rename below #}
       {% set tmp_identifier = model['name'] + '__dbt_tmp' %}

--- a/run_test.sh
+++ b/run_test.sh
@@ -24,8 +24,6 @@ if [[ ! -z $3 ]]; then _seeds="--select $3 --full-refresh"; fi
 
 dbt deps --target $1
 dbt seed --target $1 $_seeds
-if [ $1 == 'redshift' ]; then
-    dbt run -x -m test_insert_by_period --full-refresh --target redshift
-fi
+dbt run -x -m test_insert_by_period --full-refresh --target $1
 dbt run -x --target $1 $_models
 dbt test -x --target $1 $_models


### PR DESCRIPTION
This is a:
- [X] bug fix PR with no breaking changes — please ensure the base branch is `master`
- [ ] new functionality — please ensure the base branch is the latest `dev/` branch
- [ ] a breaking change — please ensure the base branch is the latest `dev/` branch

## Description & motivation

The goal of this change is to get the `insert_by_period` materialization compatible with Snowflake while using the currently latest dbt (0.21.0b2) and keeping the same functionality. 

The `insert_by_period` materialization was introduced in [this discourse post](https://discourse.getdbt.com/t/a-materialization-for-problematic-initial-builds/60) and the intention behind it is to help with “problematic” initial builds of data models. Here, problematic means that some tables are just so large and/or complex that a simple `--full-refresh` is not adequate because the build will be incredibly slow, inefficient, and can even get stuck.

Unfortunately, the currently available version does not support Snowflake and it’s [advised to refactor](https://github.com/dbt-labs/dbt-utils/pull/189) it by using the refreshed code for the [incremental](https://github.com/dbt-labs/dbt/blob/0.21.latest/core/dbt/include/global_project/macros/materializations/incremental/incremental.sql) materialization as a good starting point. As a result, this change resolves dbt-labs/dbt-labs-experimental-features#32.

The materialization itself was completely built from the current incremental materialization and the modifications done to it was inspired by the [original](https://github.com/dbt-labs/dbt-utils/blob/master/macros/materializations/insert_by_period_materialization.sql) `insert_by_period`.

The macros that were originally in the `insert_by_period.sql` was moved to a `helpers.sql` file where the Snowflake version of `get_period_boundaries()`, and `get_period_sql()` are introduced. Also, a new `check_for_period_filter()` macro has been added.

The materialization seems fully functional and so far works as expected, nevertheless, I'm still testing it against production models. 

### Ideas 

1. Currently, in the config we can only set a period of `day`, `week`, `month`, etc... as a unit. However, we might want to build our models fortnightly (ie. 2-week chunks). We could introduce an optional configuration that lets us use a configurable number of `period`s as a chunk. The fortnightly example could look like this:
```sql
{{
    config(
        materialized = "insert_by_period",
        timestamp_field = "created_at",
        period = 'week',
        interval_size = 2,
        start_date = "2021-01-01",
        stop_date = "2021-08-31"
    )
}}
```
2. In some of our more complex models with multiple sources, we might need to offset the `__PERIOD_FILTER__` by some time (for example a month lookback time, but it should be configurable). Currently, this materialization doesn't support this, but that is surely a shortcoming for some of our models where `insert_by_period` would come in handy because of their massive size & complexity. Also, it seems like our team is not the only ones who bumped into this: dbt-labs/dbt-utils#394

### A weird behavior

The materialization can produce a weird behavior if it’s executed on an already existing model because the “last incremental run” may have a _very_ short overlap with the specified date range. Let’s take the following config as an example:

```sql
{{
    config(
        materialized = "insert_by_period",
        timestamp_field = "created_at",
        period = 'day',
        start_date = "2021-08-28",
        stop_date = "2021-08-31"
    )
}}
```

This is going to build a model with events `2021-08-28 < created_at < 2021-08-31`, so it will have 3 days, thus in 3 steps it will be built, given it’s a fresh start and the run is uninterrupted. After building the 1st day, if the run is terminated, the next run will have 3 steps, again. It's not unlikely, that the last step will only insert a handful of events (many magnitudes smaller, than the previous ones). Like on this CLI output:

![Screen Shot 2021-08-31 at 17 05 03](https://user-images.githubusercontent.com/16547122/131537350-9088850f-8f9c-4ee7-8599-3bf5e772e3c2.png)

This may raise some eyebrows, but it makes perfect sense if we look at the query’s where clause - which is basically this:

```sql
where created_at > '2021-08-30 23:59:59.852'::timestamp 
   and  created_at <= '2021-08-31 23:59:59.852'::timestamp -- this isn't relevant at all
   and  created_at <  '2021-08-30 23:59:59.999'::timestamp)
```
So the last iteration is only looking for events that happened between `2021-08-30 23:59:59.852` and `2021-08-30 23:59:59.999`, which is far from even being a second. It would be nice to deal with this, so it won't cause suspicion that something is buggy.

This is most conspicuous for large models with a lot of events. 

## Checklist
- [X] I have verified that these changes work locally on the following warehouses (Note: it's okay if you do not have access to all warehouses, this helps us understand what has been covered)
    - [ ] BigQuery
    - [ ] Postgres
    - [ ] Redshift
    - [X] Snowflake
- [X] I have "dispatched" any new macro(s) so non-core adapters can also use them (e.g. [the `star()` source](https://github.com/fishtown-analytics/dbt-utils/blob/master/macros/sql/star.sql))
- [x] I have updated the README.md (if applicable)
- [x] I have added tests & descriptions to my models (and macros if applicable)
- [x] I have added an entry to CHANGELOG.md
