### PR TITLE
fix: not_null_proportion test deprecation warning and performance 

### DIFF
--- a/macros/schema_tests/not_null_proportion.sql
+++ b/macros/schema_tests/not_null_proportion.sql
@@ -1,5 +1,5 @@
 {% macro test_not_null_proportion(model) %}
-  {{ return(adapter.dispatch('test_not_null_proportion', macro_namespace = 'dbt_utils')(model, **kwargs)) }}
+  {{ return(adapter.dispatch('test_not_null_proportion', 'dbt_utils')(model, **kwargs)) }}
 {% endmacro %}
 
 {% macro default__test_not_null_proportion(model) %}

--- a/macros/schema_tests/not_null_proportion.sql
+++ b/macros/schema_tests/not_null_proportion.sql
@@ -1,5 +1,5 @@
 {% macro test_not_null_proportion(model) %}
-  {{ return(adapter.dispatch('test_not_null_proportion', packages = dbt_utils._get_utils_namespaces())(model, **kwargs)) }}
+  {{ return(adapter.dispatch('test_not_null_proportion', macro_namespace = 'dbt_utils')(model, **kwargs)) }}
 {% endmacro %}
 
 {% macro default__test_not_null_proportion(model) %}
@@ -9,7 +9,7 @@
 {% set at_most = kwargs.get('at_most', kwargs.get('arg', 1)) %}
 
 with validation as (
-  select 
+  select
     sum(case when {{ column_name }} is null then 0 else 1 end) / cast(count(*) as numeric) as not_null_proportion
   from {{ model }}
 ),
@@ -19,8 +19,8 @@ validation_errors as (
   from validation
   where not_null_proportion < {{ at_least }} or not_null_proportion > {{ at_most }}
 )
-select 
-  count(*)
+select
+  *
 from validation_errors
 
 {% endmacro %}

--- a/macros/sql/star.sql
+++ b/macros/sql/star.sql
@@ -12,11 +12,21 @@
     {% endif %}
 
     {%- set include_cols = [] %}
+    {%- set exclude_cols_lower_cased = [] %}
+    {%- for col in except -%}
+      {% do exclude_cols_lower_cased.append(col|lower) %}
+    {%- endfor %}
     {%- set cols = adapter.get_columns_in_relation(from) -%}
+<<<<<<< HEAD
     {%- set except = except | map("lower") | list %}
     {%- for col in cols -%}
 
         {%- if col.column|lower not in except -%}
+=======
+    {%- for col in cols -%}
+
+        {%- if col.column|lower not in exclude_cols_lower_cased -%}
+>>>>>>> 5261bbad97a8665210bc35ca0e31f2459c85faf5
             {% do include_cols.append(col.column) %}
 
         {%- endif %}

--- a/macros/sql/star.sql
+++ b/macros/sql/star.sql
@@ -12,10 +12,6 @@
     {% endif %}
 
     {%- set include_cols = [] %}
-    {%- set exclude_cols_lower_cased = [] %}
-    {%- for col in except -%}
-      {% do exclude_cols_lower_cased.append(col|lower) %}
-    {%- endfor %}
     {%- set cols = adapter.get_columns_in_relation(from) -%}
     {%- set except = except | map("lower") | list %}
     {%- for col in cols -%}


### PR DESCRIPTION
Two changes on the not_null_proportion.
1. Changed the dispatch to use 'macro_namespace' to avoid deprecation warning
2. Changed the final select to be * instead of count(*) to avoid false positive results.

This is a:
- [X ] bug fix PR with no breaking changes — please ensure the base branch is `master`
- [ ] new functionality — please ensure the base branch is the latest `dev/` branch
- [ ] a breaking change — please ensure the base branch is the latest `dev/` branch

## Description & motivation
<!---
Describe your changes, and why you're making them.
-->

## Checklist
- [X] I have verified that these changes work locally on the following warehouses (Note: it's okay if you do not have access to all warehouses, this helps us understand what has been covered)
    - [X] BigQuery
    - [ ] Postgres
    - [ ] Redshift
    - [ ] Snowflake
