### PR TITLE
fix: in star make excludes a list

### DIFF
--- a/macros/sql/star.sql
+++ b/macros/sql/star.sql
@@ -12,14 +12,11 @@
     {% endif %}
 
     {%- set include_cols = [] %}
-    {%- set exclude_cols_lower_cased = [] %}
-    {%- for col in except -%}
-      {% do exclude_cols_lower_cased.append(col|lower) %}
-    {%- endfor %}
     {%- set cols = adapter.get_columns_in_relation(from) -%}
+    {%- set except = except | map("lower") | list %}
     {%- for col in cols -%}
 
-        {%- if col.column|lower not in exclude_cols_lower_cased -%}
+        {%- if col.column|lower not in except -%}
             {% do include_cols.append(col.column) %}
 
         {%- endif %}

--- a/macros/sql/star.sql
+++ b/macros/sql/star.sql
@@ -12,11 +12,14 @@
     {% endif %}
 
     {%- set include_cols = [] %}
+    {%- set exclude_cols_lower_cased = [] %}
+    {%- for col in except -%}
+      {% do exclude_cols_lower_cased.append(col|lower) %}
+    {%- endfor %}
     {%- set cols = adapter.get_columns_in_relation(from) -%}
-
     {%- for col in cols -%}
 
-        {%- if col.column|lower not in except|lower -%}
+        {%- if col.column|lower not in exclude_cols_lower_cased -%}
             {% do include_cols.append(col.column) %}
 
         {%- endif %}


### PR DESCRIPTION
This is a:
- [ X] bug fix PR with no breaking changes — please ensure the base branch is `master`
- [ ] new functionality — please ensure the base branch is the latest `dev/` branch
- [ ] a breaking change — please ensure the base branch is the latest `dev/` branch

## Description & motivation
The feature added in 0.7.2 which allowed for star excludes to be case insensitive appears to have brought in an issue causing columns to get incorrectly dropped. https://github.com/dbt-labs/dbt-utils/issues/417

It looks like this is due to the |lower command turning a list into a string - this fixes that by looping over the columns to exclude and lowercasing them individually. 

## Checklist
- [ ] I have verified that these changes work locally on the following warehouses (Note: it's okay if you do not have access to all warehouses, this helps us understand what has been covered)
    - [ X] BigQuery
    - [ ] Postgres
    - [ ] Redshift
    - [ ] Snowflake
- [ ] I have "dispatched" any new macro(s) so non-core adapters can also use them (e.g. [the `star()` source](https://github.com/fishtown-analytics/dbt-utils/blob/master/macros/sql/star.sql))
- [ ] I have updated the README.md (if applicable)
- [ ] I have added tests & descriptions to my models (and macros if applicable)
- [ ] I have added an entry to CHANGELOG.md
