### PR TITLE
change the name of the last with statement

### DIFF
--- a/macros/schema_tests/equal_rowcount.sql
+++ b/macros/schema_tests/equal_rowcount.sql
@@ -22,7 +22,7 @@ b as (
     select count(*) as count_b from {{ compare_model }}
 
 ),
-final as (
+final_counts as (
 
     select
         count_a,
@@ -33,6 +33,6 @@ final as (
 
 )
 
-select * from final
+select * from final_counts
 
 {% endmacro %}


### PR DESCRIPTION
This is a:
- [x] bug fix PR with no breaking changes — please ensure the base branch is `master`
- [-] new functionality — please ensure the base branch is the latest `dev/` branch
- [-] a breaking change — please ensure the base branch is the latest `dev/` branch

## Description & motivation
<!---
Final should be changed since there are DBs that use it in their syntax and so this schema test can't run on those DBs. One example is Exasol.
I named it final_counts because it contains the final counts of the two tables we are comparing.
-->

## Checklist
- [x] I have verified that these changes work locally on the following warehouses (Note: it's okay if you do not have access to all warehouses, this helps us understand what has been covered)
    - [ ] BigQuery
    - [ ] Postgres
    - [ ] Redshift
    - [ ] Snowflake
- [x] I have "dispatched" any new macro(s) so non-core adapters can also use them (e.g. [the `star()` source](https://github.com/fishtown-analytics/dbt-utils/blob/master/macros/sql/star.sql))
- [x] I have updated the README.md (if applicable)
- [x] I have added tests & descriptions to my models (and macros if applicable)
- [ ] I have added an entry to CHANGELOG.md
