### PR TITLE
Fix SQL 42000 on Exasol

### DIFF
--- a/macros/schema_tests/equality.sql
+++ b/macros/schema_tests/equality.sql
@@ -64,9 +64,9 @@ b_minus_a as (
 
 unioned as (
 
-    select 'a_minus_b' as which_diff, * from a_minus_b
+    select 'a_minus_b' as which_diff, a_minus_b.* from a_minus_b
     union all
-    select 'b_minus_a' as which_diff, * from b_minus_a
+    select 'b_minus_a' as which_diff, b_minus_a.* from b_minus_a
 
 )
 


### PR DESCRIPTION
This is a:
- [x] bug fix PR with no breaking changes — please ensure the base branch is `master`
- [-] new functionality — please ensure the base branch is the latest `dev/` branch
- [-] a breaking change — please ensure the base branch is the latest `dev/` branch

## Description & motivation
<!---
" SQL-Error [42000]: syntax error, unexpected '*' "
If you specify the * in the unioned with their respectiv names <name>.* you do not receive the SQL Error posted above. This should not inflict any further problems since it is redundant for most DBs.
-->

## Checklist
- [x] I have verified that these changes work locally on the following warehouses (Note: it's okay if you do not have access to all warehouses, this helps us understand what has been covered)
    - [ ] BigQuery
    - [ ] Postgres
    - [ ] Redshift
    - [ ] Snowflake
- [x] I have "dispatched" any new macro(s) so non-core adapters can also use them (e.g. [the `star()` source](https://github.com/fishtown-analytics/dbt-utils/blob/master/macros/sql/star.sql))
- [x] I have updated the README.md (if applicable)
- [x] I have added tests & descriptions to my models (and macros if applicable)
- [ ] I have added an entry to CHANGELOG.md
