### PR TITLE
support timestamp field in recency schema test

### DIFF
--- a/macros/schema_tests/recency.sql
+++ b/macros/schema_tests/recency.sql
@@ -1,8 +1,8 @@
-{% test recency(model, field, datepart, interval) %}
-  {{ return(adapter.dispatch('test_recency', 'dbt_utils')(model, field, datepart, interval)) }}
+{% test recency(model, field, datepart, interval, timestamp) %}
+  {{ return(adapter.dispatch('test_recency', 'dbt_utils')(model, field, datepart, interval, timestamp)) }}
 {% endtest %}
 
-{% macro default__test_recency(model, field, datepart, interval) %}
+{% macro default__test_recency(model, field, datepart, interval, timestamp) %}
 
 {% set threshold = dbt_utils.dateadd(datepart, interval * -1, dbt_utils.current_timestamp()) %}
 
@@ -19,6 +19,10 @@ select
     {{ threshold }} as threshold
 
 from recency
-where most_recent < {{ threshold }}
+  {%- if timestamp is true %}
+    where most_recent < timestamp({{ threshold }})
+  {%- else %}
+    where most_recent < {{ threshold }}
+  {%- endif %}
 
 {% endmacro %}


### PR DESCRIPTION
tested in bigquery

This is a:
- [ ] bug fix PR with no breaking changes — please ensure the base branch is `master`
- [x] new functionality — please ensure the base branch is the latest `dev/` branch
- [ ] a breaking change — please ensure the base branch is the latest `dev/` branch

## Description & motivation
recency schema test didn't work for timestamp fields in bigquery,
as bigquery won't cast timestamp/datetime values back and forth
if there is a type mismatch in comparison  

## Checklist
- [ ] I have verified that these changes work locally on the following warehouses (Note: it's okay if you do not have access to all warehouses, this helps us understand what has been covered)
    - [x] BigQuery
    - [ ] Postgres
    - [ ] Redshift
    - [ ] Snowflake
- [ ] I have "dispatched" any new macro(s) so non-core adapters can also use them (e.g. [the `star()` source](https://github.com/fishtown-analytics/dbt-utils/blob/master/macros/sql/star.sql))
- [ ] I have updated the README.md (if applicable)
- [ ] I have added tests & descriptions to my models (and macros if applicable)
- [ ] I have added an entry to CHANGELOG.md
