### PR TITLE
Add handling for `android-app://` in `get_url_host()` macro

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,10 +9,12 @@ This is a compatibility release in preparation for `dbt-core` v1.0.0 (🎉). Whe
 - Bump `require-dbt-version` to have an upper bound of `'<=1.0.0'`.
 - Url link fixes within the README for `not_constant`, `dateadd`, `datediff` and updated the header `Logger` to `Jinja Helpers`. ([#431](https://github.com/dbt-labs/dbt-utils/pull/431))
 - Fully qualified a `cte_name.*` in the `equality` test to avoid an Exasol error ([#420](https://github.com/dbt-labs/dbt-utils/pull/420))
+- `get_url_host()` macro now correctly handles URLs beginning with `android-app://` ([#426](https://github.com/dbt-labs/dbt-utils/pull/426))
 
 ## Contributors:
 - [joemarkiewicz](https://github.com/fivetran-joemarkiewicz)
 - [TimoKruth](https://github.com/TimoKruth)
+- [foundinblank](https://github.com/foundinblank)
 
 # dbt-utils v0.7.3
 

--- a/integration_tests/data/web/data_url_host.csv
+++ b/integration_tests/data/web/data_url_host.csv
@@ -2,6 +2,6 @@ original_url,parsed_url
 www.google.co.uk?utm_source=google&utm_medium=cpc&utm_campaign=spring-summer,www.google.co.uk
 http://witanddelight.com/2018/01/tips-tricks-how-run-half-marathon-first-time/,witanddelight.com
 https://www.nytimes.com/2018/01/01/blog,www.nytimes.com
-android-app://m.facebook.com/,m.facebook.com,
-docs.nytimes.com/2021/01/01/index.js?utm_source=google,docs.nytimes.com,
+android-app://m.facebook.com/,m.facebook.com
+docs.nytimes.com/2021/01/01/index.js?utm_source=google,docs.nytimes.com
 https://m.facebook.com/,m.facebook.com

--- a/integration_tests/data/web/data_url_host.csv
+++ b/integration_tests/data/web/data_url_host.csv
@@ -2,3 +2,6 @@ original_url,parsed_url
 www.google.co.uk?utm_source=google&utm_medium=cpc&utm_campaign=spring-summer,www.google.co.uk
 http://witanddelight.com/2018/01/tips-tricks-how-run-half-marathon-first-time/,witanddelight.com
 https://www.nytimes.com/2018/01/01/blog,www.nytimes.com
+android-app://m.facebook.com/,m.facebook.com,
+docs.nytimes.com/2021/01/01/index.js?utm_source=google,docs.nytimes.com,
+https://m.facebook.com/,m.facebook.com

--- a/macros/web/get_url_host.sql
+++ b/macros/web/get_url_host.sql
@@ -4,10 +4,6 @@
 
 {% macro default__get_url_host(field) -%}
 
-{% set parsed = split_part(split_part(replaced)) %}
-
-{{ dbt_utils.safe_cast() }} --as it currently is
-
 {% set replace_schema = regexp_replace(field, '^[-A-Za-z]+:\/\/', "''") %}
 
 {%- set parsed =

--- a/macros/web/get_url_host.sql
+++ b/macros/web/get_url_host.sql
@@ -1,7 +1,9 @@
 {% macro get_url_host(field) -%}
     {{ return(adapter.dispatch('get_url_host', 'dbt_utils')(field)) }}
 {% endmacro %}
+
 {% macro default__get_url_host(field) -%}
+
 {%- set parsed =
     dbt_utils.split_part(
         dbt_utils.split_part(
@@ -16,9 +18,11 @@
 
 -%}
 
+
     {{ dbt_utils.safe_cast(
         parsed,
         dbt_utils.type_string()
         )}}
+
 
 {%- endmacro %}

--- a/macros/web/get_url_host.sql
+++ b/macros/web/get_url_host.sql
@@ -4,12 +4,30 @@
 
 {% macro default__get_url_host(field) -%}
 
-{% set replace_schema = regexp_replace(field, '^[-A-Za-z]+:\/\/', "''") | safe %}
+{% set replace_schema = regexp_replace(field, '^[-A-Za-z]+:\/\/', "''") %}
+
+{% set payment_methods_query %}
+{{ dbt_utils.safe_cast(
+    replace_schema,
+    dbt_utils.type_string()
+    )}}
+{% endset %}
+
+{% set results = run_query(payment_methods_query) %}
+
+{% if execute %}
+{# Return the first column #}
+{% set results_list = results.columns[0].values()[0] %}
+{% else %}
+{% set results_list = [] %}
+{% endif %}
+
+{{ return(results_list) }}
 
 {%- set parsed =
     dbt_utils.split_part(
         dbt_utils.split_part(
-            replace_schema, "'/'", 1
+            results_list, "'/'", 1
             ), "'?'", 1
         )
 -%}

--- a/macros/web/get_url_host.sql
+++ b/macros/web/get_url_host.sql
@@ -4,13 +4,13 @@
 
 {% macro default__get_url_host(field) -%}
 
-{% set replace_schema = regexp_replace(field, '^[-A-Za-z]+:\/\/', "''") %}
+{% set replace_schema = regexp_replace(field, '^[-A-Za-z]+:\/\/', "''") | safe %}
 
 {%- set parsed =
     dbt_utils.split_part(
         dbt_utils.split_part(
             replace_schema, "'/'", 1
-          ), "'?'", 1
+            ), "'?'", 1
         )
 -%}
 

--- a/macros/web/get_url_host.sql
+++ b/macros/web/get_url_host.sql
@@ -1,42 +1,24 @@
 {% macro get_url_host(field) -%}
     {{ return(adapter.dispatch('get_url_host', 'dbt_utils')(field)) }}
 {% endmacro %}
-
 {% macro default__get_url_host(field) -%}
-
-{% set replace_schema = regexp_replace(field, '^[-A-Za-z]+:\/\/', "''") %}
-
-{% set payment_methods_query %}
-{{ dbt_utils.safe_cast(
-    replace_schema,
-    dbt_utils.type_string()
-    )}}
-{% endset %}
-
-{% set results = run_query(payment_methods_query) %}
-
-{% if execute %}
-{# Return the first column #}
-{% set results_list = results.columns[0].values()[0] %}
-{% else %}
-{% set results_list = [] %}
-{% endif %}
-
-{{ return(results_list) }}
-
 {%- set parsed =
     dbt_utils.split_part(
         dbt_utils.split_part(
-            results_list, "'/'", 1
-            ), "'?'", 1
-        )
--%}
+            dbt_utils.replace(
+                dbt_utils.replace(
+                    dbt_utils.replace(field, "'android-app://'", "''"
+                    ), "'http://'", "''"
+                ), "'https://'", "''"
+            ), "'/'", 1
+        ), "'?'", 1
+    )
 
+-%}
 
     {{ dbt_utils.safe_cast(
         parsed,
         dbt_utils.type_string()
         )}}
-
 
 {%- endmacro %}

--- a/macros/web/get_url_host.sql
+++ b/macros/web/get_url_host.sql
@@ -7,7 +7,7 @@
 {%- set parsed =
     dbt_utils.split_part(
         dbt_utils.split_part(
-            regexp_replace(field, '^[-A-Za-z]+:\/\/', "''"
+            'regexp_replace'(field, '^[-A-Za-z]+:\/\/', "''"
             ), "'/'", 1
         ), "'?'", 1
     )

--- a/macros/web/get_url_host.sql
+++ b/macros/web/get_url_host.sql
@@ -7,7 +7,7 @@
 {%- set parsed =
     dbt_utils.split_part(
         dbt_utils.split_part(
-            regexp_replace(field '^[-A-Za-z]+:\/\/', "''"
+            regexp_replace(field, '^[-A-Za-z]+:\/\/', "''"
             ), "'/'", 1
         ), "'?'", 1
     )

--- a/macros/web/get_url_host.sql
+++ b/macros/web/get_url_host.sql
@@ -4,14 +4,18 @@
 
 {% macro default__get_url_host(field) -%}
 
+{% set parsed = split_part(split_part(replaced)) %}
+
+{{ dbt_utils.safe_cast() }} --as it currently is
+
+{% set replace_schema = regexp_replace(field, '^[-A-Za-z]+:\/\/', "''") %}
+
 {%- set parsed =
     dbt_utils.split_part(
         dbt_utils.split_part(
-            regexp_replace(field, '^[-A-Za-z]+:\/\/', "''"
-            ), "'/'", 1
-        ), "'?'", 1
-    )
-
+            replace_schema, "'/'", 1
+          ), "'?'", 1
+        )
 -%}
 
 

--- a/macros/web/get_url_host.sql
+++ b/macros/web/get_url_host.sql
@@ -24,5 +24,4 @@
         dbt_utils.type_string()
         )}}
 
-
 {%- endmacro %}

--- a/macros/web/get_url_host.sql
+++ b/macros/web/get_url_host.sql
@@ -4,25 +4,21 @@
 
 {% macro default__get_url_host(field) -%}
 
-{%- set parsed = 
+{%- set parsed =
     dbt_utils.split_part(
         dbt_utils.split_part(
-            dbt_utils.replace(
-                dbt_utils.replace(
-                    dbt_utils.replace(field, "'android-app://'", "''"
-                    ), "'http://'", "''"
-                ), "'https://'", "''"
+            regexp_replace(field '^[-A-Za-z]+:\/\/', "''"
             ), "'/'", 1
         ), "'?'", 1
     )
-    
+
 -%}
 
-     
+
     {{ dbt_utils.safe_cast(
         parsed,
         dbt_utils.type_string()
         )}}
-        
+
 
 {%- endmacro %}

--- a/macros/web/get_url_host.sql
+++ b/macros/web/get_url_host.sql
@@ -8,7 +8,9 @@
     dbt_utils.split_part(
         dbt_utils.split_part(
             dbt_utils.replace(
-                dbt_utils.replace(field, "'http://'", "''"
+                dbt_utils.replace(
+                    dbt_utils.replace(field, "'android-app://'", "''"
+                    ), "'http://'", "''"
                 ), "'https://'", "''"
             ), "'/'", 1
         ), "'?'", 1

--- a/macros/web/get_url_host.sql
+++ b/macros/web/get_url_host.sql
@@ -7,7 +7,7 @@
 {%- set parsed =
     dbt_utils.split_part(
         dbt_utils.split_part(
-            'regexp_replace'(field, '^[-A-Za-z]+:\/\/', "''"
+            regexp_replace(field, '^[-A-Za-z]+:\/\/', "''"
             ), "'/'", 1
         ), "'?'", 1
     )


### PR DESCRIPTION
This is a:
- [x] bug fix PR with no breaking changes — please ensure the base branch is `master`
- [ ] new functionality — please ensure the base branch is the latest `dev/` branch
- [ ] a breaking change — please ensure the base branch is the latest `dev/` branch

## Description & motivation
In my Segment page view data, we see `referrer` values such as `android-app://m.facebook.com/`. These seem to be specific for Android apps and take the place of `http://`. The current `get_url_host()` macro will return an `android-app://` value instead of the hostname for those referrer URLs. Be great if the `get_url_host()` macro handled those too!

## Checklist
- [x] I have verified that these changes work locally on the following warehouses (Note: it's okay if you do not have access to all warehouses, this helps us understand what has been covered)
    - [ ] BigQuery
    - [ ] Postgres
    - [ ] Redshift
    - [x] Snowflake
- [ ] I have "dispatched" any new macro(s) so non-core adapters can also use them (e.g. [the `star()` source](https://github.com/fishtown-analytics/dbt-utils/blob/master/macros/sql/star.sql))
- [ ] I have updated the README.md (if applicable)
- [ ] I have added tests & descriptions to my models (and macros if applicable)
- [ ] I have added an entry to CHANGELOG.md
