### PR TITLE
Fixing an issue where the mutually exclusive range test doesn't work …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,31 @@
+# dbt-utils v0.7.3
+
+## Under the hood
+
+- Fix bug introduced in 0.7.2 in dbt_utils.star which could cause the except argument to drop columns that were not explicitly specified ([#418](https://github.com/dbt-labs/dbt-utils/pull/418))
+- Remove deprecated argument from not_null_proportion ([#416](https://github.com/dbt-labs/dbt-utils/pull/416))
+- Change final select statement in not_null_proportion to avoid false positive failures ([#416](https://github.com/dbt-labs/dbt-utils/pull/416))
+
+# dbt-utils v0.7.2
+
+## Features
+
+- Add `not_null_proportion` schema test that allows the user to specify the minimum (`at_least`) tolerated proportion (e.g., `0.95`) of non-null values ([#411](https://github.com/dbt-labs/dbt-utils/pull/411))
+
+
+## Under the hood
+
+
+- Allow user to provide any case type when defining the `exclude` argument in `dbt_utils.star()` ([#403](https://github.com/dbt-labs/dbt-utils/pull/403))
+- Log whole row instead of just column name in 'accepted_range' schema test to allow better visibility into failures ([#413](https://github.com/dbt-labs/dbt-utils/pull/413))
+- Use column name to group in 'get_column_values ' to allow better cross db functionality ([#407](https://github.com/dbt-labs/dbt-utils/pull/407))
+
 # dbt-utils v0.7.1
 
 ## Under the hood
 
 - Declare compatibility with dbt v0.21.0, which has no breaking changes for this package ([#398](https://github.com/fishtown-analytics/dbt-utils/pull/398))
 
-## Features
-
-- Allow user to provide any case type when defining the `exclude` argument in `dbt_utils.star()` ([#403](https://github.com/dbt-labs/dbt-utils/pull/403))
 
 
 # dbt-utils v0.7.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,9 @@
 # dbt-utils v0.8.0
+## 🚨 Breaking changes
+- The partition column in the `mutually_exclusive_ranges` test is now always called `partition_by_col`. This enables compatibility with `--store-failures` when multiple columns are concatenated together. If you have models built on top of the failures table, update them to reflect the new column name. ([#423](https://github.com/dbt-labs/dbt-utils/issues/423), [#430](https://github.com/dbt-labs/dbt-utils/pull/430))
+
+## Contributors:
+- [codigo-ergo-sum](https://github.com/codigo-ergo-sum) (#430)
 
 # dbt-utils v0.7.4b1
 This is a compatibility release in preparation for `dbt-core` v1.0.0 (🎉). When dbt-core 1.0.0 hits release candidate status, we will release the final version of 0.7.4

--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -1,7 +1,7 @@
 name: 'dbt_utils'
 version: '0.7.0'
 
-require-dbt-version: [">=0.20.0", "<=1.0"]
+require-dbt-version: [">=0.20.0", "<=1.0.0"]
 
 config-version: 2
 

--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -1,7 +1,7 @@
 name: 'dbt_utils'
 version: '0.7.0'
 
-require-dbt-version: [">=0.20.0", "<0.22.0"]
+require-dbt-version: [">=0.20.0", "<=1.0"]
 
 config-version: 2
 

--- a/macros/schema_tests/mutually_exclusive_ranges.sql
+++ b/macros/schema_tests/mutually_exclusive_ranges.sql
@@ -35,7 +35,7 @@ with window_functions as (
 
     select
         {% if partition_by %}
-        {{ partition_by }},
+        {{ partition_by }} as partition_by_col,
         {% endif %}
         {{ lower_bound_column }} as lower_bound,
         {{ upper_bound_column }} as upper_bound,

--- a/macros/schema_tests/not_null_proportion.sql
+++ b/macros/schema_tests/not_null_proportion.sql
@@ -1,5 +1,5 @@
 {% macro test_not_null_proportion(model) %}
-  {{ return(adapter.dispatch('test_not_null_proportion', packages = dbt_utils._get_utils_namespaces())(model, **kwargs)) }}
+  {{ return(adapter.dispatch('test_not_null_proportion', 'dbt_utils')(model, **kwargs)) }}
 {% endmacro %}
 
 {% macro default__test_not_null_proportion(model) %}
@@ -9,7 +9,7 @@
 {% set at_most = kwargs.get('at_most', kwargs.get('arg', 1)) %}
 
 with validation as (
-  select 
+  select
     sum(case when {{ column_name }} is null then 0 else 1 end) / cast(count(*) as numeric) as not_null_proportion
   from {{ model }}
 ),
@@ -19,8 +19,8 @@ validation_errors as (
   from validation
   where not_null_proportion < {{ at_least }} or not_null_proportion > {{ at_most }}
 )
-select 
-  count(*)
+select
+  *
 from validation_errors
 
 {% endmacro %}


### PR DESCRIPTION
…with store failures with a multi-column concatenated partition by clause. As per: https://github.com/dbt-labs/dbt-utils/issues/423

This is a:
- [X] bug fix PR with no breaking changes — please ensure the base branch is `master`
- [ ] new functionality — please ensure the base branch is the latest `dev/` branch
- [ ] a breaking change — please ensure the base branch is the latest `dev/` branch

## Description & motivation
<!---
When running a test suite which includes the mutually_exclusive_ranges test and using the --store-failures option, dbt fails when trying to insert rows into the target database, specifically BigQuery. This is due to a column alias being missing in the mutually exclusive ranges test.
-->

## Checklist
- [ ] I have verified that these changes work locally on the following warehouses (Note: it's okay if you do not have access to all warehouses, this helps us understand what has been covered)
    - [ ] BigQuery
    - [ ] Postgres
    - [ ] Redshift
    - [ ] Snowflake
- [ ] I have "dispatched" any new macro(s) so non-core adapters can also use them (e.g. [the `star()` source](https://github.com/fishtown-analytics/dbt-utils/blob/master/macros/sql/star.sql))
- [ ] I have updated the README.md (if applicable)
- [ ] I have added tests & descriptions to my models (and macros if applicable)
- [x] I have added an entry to CHANGELOG.md
