### PR TITLE
add prefix and suffix arguments to star macro

### DIFF
--- a/README.md
+++ b/README.md
@@ -725,7 +725,7 @@ group by 1,2,3
 ```
 
 #### star ([source](macros/sql/star.sql))
-This macro generates a list of all fields that exist in the `from` relation, excluding any fields listed in the `except` argument. The construction is identical to `select * from {{ref('my_model')}}`, replacing star (`*`) with the star macro. This macro also has an optional `relation_alias` argument that will prefix all generated fields with an alias.
+This macro generates a list of all fields that exist in the `from` relation, excluding any fields listed in the `except` argument. The construction is identical to `select * from {{ref('my_model')}}`, replacing star (`*`) with the star macro. This macro also has an optional `relation_alias` argument that will prefix all generated fields with an alias (`relation_alias`.`field_name`). The macro also has optional `prefix` and `suffix` arguments, which will be appropriately concatenated to each field name in the output (`prefix` ~ `field_name` ~ `suffix`).
 
 **Usage:**
 ```sql

--- a/integration_tests/data/sql/data_star_prefix_suffix_expected.csv
+++ b/integration_tests/data/sql/data_star_prefix_suffix_expected.csv
@@ -1,0 +1,4 @@
+prefix_field_1_suffix,prefix_field_2_suffix,prefix_field_3_suffix
+a,b,c
+d,e,f
+g,h,i

--- a/integration_tests/models/sql/schema.yml
+++ b/integration_tests/models/sql/schema.yml
@@ -106,6 +106,11 @@ models:
       - dbt_utils.equality:
           compare_model: ref('data_star_expected')
 
+  - name: test_star_prefix_suffix
+    tests:
+      - dbt_utils.equality:
+          compare_model: ref('data_star_prefix_suffix_expected')
+
   - name: test_surrogate_key
     tests:
       - assert_equal:

--- a/integration_tests/models/sql/test_star_prefix_suffix.sql
+++ b/integration_tests/models/sql/test_star_prefix_suffix.sql
@@ -1,5 +1,5 @@
-{% set prefix_with = 'prefix_' %}
-{% set suffix_with = '_suffix' %}
+{% set prefix_with = 'prefix_' if target.type != 'snowflake' else 'PREFIX_' %}
+{% set suffix_with = '_suffix' if target.type != 'snowflake' else '_SUFFIX' %}
 
 with data as (
 

--- a/integration_tests/models/sql/test_star_prefix_suffix.sql
+++ b/integration_tests/models/sql/test_star_prefix_suffix.sql
@@ -1,0 +1,13 @@
+{% set prefix_with = 'prefix_' %}
+{% set suffix_with = '_suffix' %}
+
+with data as (
+
+    select
+        {{ dbt_utils.star(from=ref('data_star'), prefix=prefix_with, suffix=suffix_with) }}
+
+    from {{ ref('data_star') }}
+
+)
+
+select * from data

--- a/macros/sql/star.sql
+++ b/macros/sql/star.sql
@@ -1,8 +1,8 @@
-{% macro star(from, relation_alias=False, except=[]) -%}
-    {{ return(adapter.dispatch('star', 'dbt_utils')(from, relation_alias, except)) }}
+{% macro star(from, relation_alias=False, except=[], prefix='', suffix='') -%}
+    {{ return(adapter.dispatch('star', 'dbt_utils')(from, relation_alias, except, prefix, suffix)) }}
 {% endmacro %}
 
-{% macro default__star(from, relation_alias=False, except=[]) -%}
+{% macro default__star(from, relation_alias=False, except=[], prefix='', suffix='') -%}
     {%- do dbt_utils._is_relation(from, 'star') -%}
     {%- do dbt_utils._is_ephemeral(from, 'star') -%}
 
@@ -24,7 +24,7 @@
 
     {%- for col in include_cols %}
 
-        {%- if relation_alias %}{{ relation_alias }}.{% else %}{%- endif -%}{{ adapter.quote(col)|trim }}
+        {%- if relation_alias %}{{ relation_alias }}.{% else %}{%- endif -%}{{ adapter.quote(col)|trim }} as {{ adapter.quote(prefix ~ col ~ suffix)|trim }}
         {%- if not loop.last %},{{ '\n  ' }}{% endif %}
 
     {%- endfor -%}


### PR DESCRIPTION
This is a:
- [ ] bug fix PR with no breaking changes — please ensure the base branch is `master`
- [x] new functionality — please ensure the base branch is the latest `dev/` branch
- [ ] a breaking change — please ensure the base branch is the latest `dev/` branch

## Description & motivation
<!---
Describe your changes, and why you're making them.
-->

Just added optional `prefix` and `suffix` arguments to the star macro, so that the output fields will all be renamed as prefix ~ name ~ suffix (very similar to the `pivot` macro). 

This is helpful to me in that I can more easily know where columns came from. Morewover, I have a particular case where I am using `star` twice in the same CTE, and the columns included in each source relation that I'm joining/selecting from can have custom names. If there's any overlap between the two sources, we'll see an `ambiguous column` error without any prefix or suffix to distinguish them

## Checklist
- [x] I have verified that these changes work locally on the following warehouses (Note: it's okay if you do not have access to all warehouses, this helps us understand what has been covered)
    - [x] BigQuery
    - [ ] Postgres
    - [ ] Redshift
    - [ ] Snowflake
- [ ] I have "dispatched" any new macro(s) so non-core adapters can also use them (e.g. [the `star()` source](https://github.com/fishtown-analytics/dbt-utils/blob/master/macros/sql/star.sql)) **is this just adding the arguments to the dispatch line?**
- [x] I have updated the README.md (if applicable)
- [ ] I have added tests & descriptions to my models (and macros if applicable)
- [ ] I have added an entry to CHANGELOG.md
