### PR TITLE
use `limit_zero` macro instead of `limit 0`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,19 @@
+# dbt-utils v0.7.4b1
+This is a compatibility release in preparation for `dbt-core` v1.0.0 (🎉). When dbt-core 1.0.0 hits release candidate status, we will release the final version of 0.7.4
+
+🚨 Projects using utils 0.7.4 with Core 1.0.0 can expect to see a deprecation warning. This will be resolved in 0.8.0 of dbt_utils alongside the final version of 1.0.0.
+
+:rotating_light:🚨 We have renamed the `master` branch to `main`. If you have a local version of `dbt-utils`, you will need to update to the new branch. See the [GitHub docs](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-branches-in-your-repository/renaming-a-branch#updating-a-local-clone-after-a-branch-name-changes) for more details.
+
+## Under the hood
+- Bump `require-dbt-version` to have an upper bound of `'<=1.0.0'`.
+- Url link fixes within the README for `not_constant`, `dateadd`, `datediff` and updated the header `Logger` to `Jinja Helpers`. ([#431](https://github.com/dbt-labs/dbt-utils/pull/431))
+- Fully qualified a `cte_name.*` in the `equality` test to avoid an Exasol error ([#420](https://github.com/dbt-labs/dbt-utils/pull/420))
+
+## Contributors:
+- [joemarkiewicz](https://github.com/fivetran-joemarkiewicz)
+- [TimoKruth](https://github.com/TimoKruth)
+
 # dbt-utils v0.7.3
 
 ## Under the hood
@@ -14,8 +30,6 @@
 
 
 ## Under the hood
-
-
 - Allow user to provide any case type when defining the `exclude` argument in `dbt_utils.star()` ([#403](https://github.com/dbt-labs/dbt-utils/pull/403))
 - Log whole row instead of just column name in 'accepted_range' schema test to allow better visibility into failures ([#413](https://github.com/dbt-labs/dbt-utils/pull/413))
 - Use column name to group in 'get_column_values ' to allow better cross db functionality ([#407](https://github.com/dbt-labs/dbt-utils/pull/407))
@@ -25,7 +39,6 @@
 ## Under the hood
 
 - Declare compatibility with dbt v0.21.0, which has no breaking changes for this package ([#398](https://github.com/fishtown-analytics/dbt-utils/pull/398))
-
 
 
 # dbt-utils v0.7.0

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Check [dbt Hub](https://hub.getdbt.com/dbt-labs/dbt_utils/latest/) for the lates
   - [expression_is_true](#expression_is_true-source)
   - [recency](#recency-source)
   - [at_least_one](#at_least_one-source)
-  - [not_constant](#not_constant)
+  - [not_constant](#not_constant-source)
   - [cardinality_equality](#cardinality_equality-source)
   - [unique_where](#unique_where-source)
   - [not_null_where](#not_null_where-source)
@@ -48,13 +48,13 @@ Check [dbt Hub](https://hub.getdbt.com/dbt-labs/dbt_utils/latest/) for the lates
 
 - [Cross-database macros](#cross-database-macros):
     - [current_timestamp](#current_timestamp-source)
-    - [dateadd](#date_add-source)
-    - [datediff](#datadiff-source)
+    - [dateadd](#dateadd-source)
+    - [datediff](#datediff-source)
     - [split_part](#split_part-source)
     - [last_day](#last_day-source)
     - [width_bucket](#width_bucket-source)
 
-- [Logger](#logger)
+- [Jinja Helpers](#jinja-helpers)
     - [pretty_time](#pretty_time-source)
     - [pretty_log_format](#pretty_log_format-source)
     - [log_info](#log_info-source)

--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -1,7 +1,7 @@
 name: 'dbt_utils'
 version: '0.7.0'
 
-require-dbt-version: [">=0.20.0", "<0.22.0"]
+require-dbt-version: [">=0.20.0", "<=1.0.0"]
 
 config-version: 2
 

--- a/integration_tests/tests/jinja_helpers/test_slugify.sql
+++ b/integration_tests/tests/jinja_helpers/test_slugify.sql
@@ -1,6 +1,6 @@
 {% if dbt_utils.slugify('!Hell0 world-hi') == 'hell0_world_hi' %}
     {# Return 0 rows for the test to pass #}
-    select 1 as col_name {{ limit_zero }}
+    select 1 as col_name {{ limit_zero() }}
 {% else %}
     {# Return >0 rows for the test to fail #}
     select 1

--- a/integration_tests/tests/jinja_helpers/test_slugify.sql
+++ b/integration_tests/tests/jinja_helpers/test_slugify.sql
@@ -1,6 +1,6 @@
 {% if dbt_utils.slugify('!Hell0 world-hi') == 'hell0_world_hi' %}
     {# Return 0 rows for the test to pass #}
-    select 1 {{ limit_zero }}
+    select 1 as col_name {{ limit_zero }}
 {% else %}
     {# Return >0 rows for the test to fail #}
     select 1

--- a/integration_tests/tests/jinja_helpers/test_slugify.sql
+++ b/integration_tests/tests/jinja_helpers/test_slugify.sql
@@ -1,6 +1,6 @@
 {% if dbt_utils.slugify('!Hell0 world-hi') == 'hell0_world_hi' %}
     {# Return 0 rows for the test to pass #}
-    select 1 limit 0
+    select 1 {{ limit_zero }}
 {% else %}
     {# Return >0 rows for the test to fail #}
     select 1

--- a/macros/schema_tests/equality.sql
+++ b/macros/schema_tests/equality.sql
@@ -64,9 +64,9 @@ b_minus_a as (
 
 unioned as (
 
-    select 'a_minus_b' as which_diff, * from a_minus_b
+    select 'a_minus_b' as which_diff, a_minus_b.* from a_minus_b
     union all
-    select 'b_minus_a' as which_diff, * from b_minus_a
+    select 'b_minus_a' as which_diff, b_minus_a.* from b_minus_a
 
 )
 


### PR DESCRIPTION
This is a:
- [x] bug fix PR with no breaking changes — please ensure the base branch is `master`
- [ ] new functionality — please ensure the base branch is the latest `dev/` branch
- [ ] a breaking change — please ensure the base branch is the latest `dev/` branch

## Description & motivation
<!---
Describe your changes, and why you're making them.
-->

This test cannot be used by databases that don't support `limit zero`

## Checklist
- [ ] I have verified that these changes work locally on the following warehouses (Note: it's okay if you do not have access to all warehouses, this helps us understand what has been covered)
    - [ ] BigQuery
    - [ ] Postgres
    - [ ] Redshift
    - [ ] Snowflake
- [x] I have "dispatched" any new macro(s) so non-core adapters can also use them (e.g. [the `star()` source](https://github.com/fishtown-analytics/dbt-utils/blob/master/macros/sql/star.sql))
- [x] I have updated the README.md (if applicable)
- [ ] I have added tests & descriptions to my models (and macros if applicable)
- [ ] I have added an entry to CHANGELOG.md
