### PR TITLE
Remove extra semicolon in `insert_by_period` materialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,10 +9,12 @@ This is a compatibility release in preparation for `dbt-core` v1.0.0 (🎉). Whe
 - Bump `require-dbt-version` to have an upper bound of `'<=1.0.0'`.
 - Url link fixes within the README for `not_constant`, `dateadd`, `datediff` and updated the header `Logger` to `Jinja Helpers`. ([#431](https://github.com/dbt-labs/dbt-utils/pull/431))
 - Fully qualified a `cte_name.*` in the `equality` test to avoid an Exasol error ([#420](https://github.com/dbt-labs/dbt-utils/pull/420))
+- Remove extra semicolon in `insert_by_period` materialization that was causing errors ([#439](https://github.com/dbt-labs/dbt-utils/pull/439))
 
 ## Contributors:
 - [joemarkiewicz](https://github.com/fivetran-joemarkiewicz)
 - [TimoKruth](https://github.com/TimoKruth)
+- [sean-rose](https://github.com/sean-rose)
 
 # dbt-utils v0.7.3
 

--- a/macros/materializations/insert_by_period_materialization.sql
+++ b/macros/materializations/insert_by_period_materialization.sql
@@ -102,7 +102,7 @@
     {# Create an empty target table -#}
     {% call statement('main') -%}
       {%- set empty_sql = sql | replace("__PERIOD_FILTER__", 'false') -%}
-      {{create_table_as(False, target_relation, empty_sql)}};
+      {{create_table_as(False, target_relation, empty_sql)}}
     {%- endcall %}
   {%- endif %}
 


### PR DESCRIPTION
This is a:
- [x] bug fix PR with no breaking changes — please ensure the base branch is `master`
- [ ] new functionality — please ensure the base branch is the latest `dev/` branch
- [ ] a breaking change — please ensure the base branch is the latest `dev/` branch

## Description & motivation
This removes an extra semicolon in the `insert_by_period` materialization that causes the initial materialization (or rematerialized due to a full refresh) to fail immediately after creating the empty table when running in Snowflake with a "_cannot unpack non-iterable NoneType object_" error.

## Checklist
- [x] I have verified that these changes work locally on the following warehouses (Note: it's okay if you do not have access to all warehouses, this helps us understand what has been covered)
    - [ ] BigQuery
    - [ ] Postgres
    - [ ] Redshift
    - [x] Snowflake
- [ ] I have "dispatched" any new macro(s) so non-core adapters can also use them (e.g. [the `star()` source](https://github.com/fishtown-analytics/dbt-utils/blob/master/macros/sql/star.sql))
- [ ] I have updated the README.md (if applicable)
- [ ] I have added tests & descriptions to my models (and macros if applicable)
- [x] I have added an entry to CHANGELOG.md
