### PR TITLE
Use the relation object passed into get_column_values, instead of making our own

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 🚨 This is a compatibility release in preparation for `dbt-core` v1.0.0 (🎉). Projects using dbt-utils 0.7.4 with dbt-core v1.0.0 can expect to see a deprecation warning. This will be resolved in dbt_utils v0.8.0.
 
 ## Fixes
-- `get_column_values()` now works correctly with mixed-quoting styles on Snowflake ([#424](https://github.com/dbt-labs/dbt-utils/issues/424), [PR tk])
+- `get_column_values()` now works correctly with mixed-quoting styles on Snowflake ([#424](https://github.com/dbt-labs/dbt-utils/issues/424), [#440](https://github.com/dbt-labs/dbt-utils/pull/440))
 
 # dbt-utils v0.7.4b1
 This is a compatibility release in preparation for `dbt-core` v1.0.0 (🎉). When dbt-core 1.0.0 hits release candidate status, we will release the final version of 0.7.4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# dbt-utils v0.7.4
+🚨 This is a compatibility release in preparation for `dbt-core` v1.0.0 (🎉). Projects using dbt-utils 0.7.4 with dbt-core v1.0.0 can expect to see a deprecation warning. This will be resolved in dbt_utils v0.8.0.
+
+## Fixes
+- `get_column_values()` now works correctly with mixed-quoting styles on Snowflake ([#424](https://github.com/dbt-labs/dbt-utils/issues/424), [PR tk])
+
 # dbt-utils v0.7.4b1
 This is a compatibility release in preparation for `dbt-core` v1.0.0 (🎉). When dbt-core 1.0.0 hits release candidate status, we will release the final version of 0.7.4
 

--- a/integration_tests/models/sql/test_get_column_values.sql
+++ b/integration_tests/models/sql/test_get_column_values.sql
@@ -1,13 +1,13 @@
 
-{% set columns = dbt_utils.get_column_values(ref('data_get_column_values'), 'field', default=[], order_by="field") %}
+{% set column_values = dbt_utils.get_column_values(ref('data_get_column_values'), 'field', default=[], order_by="field") %}
 
 
 {% if target.type == 'snowflake' %}
 
 select
-    {% for column in columns -%}
+    {% for val in column_values -%}
 
-        sum(case when field = '{{ column }}' then 1 else 0 end) as count_{{ column }}
+        sum(case when field = '{{ val }}' then 1 else 0 end) as count_{{ val }}
         {%- if not loop.last %},{% endif -%}
 
     {%- endfor %}
@@ -17,9 +17,9 @@ from {{ ref('data_get_column_values') }}
 {% else %}
 
 select
-    {% for column in columns -%}
+    {% for val in column_values -%}
 
-        {{dbt_utils.safe_cast("sum(case when field = '" ~ column ~ "' then 1 else 0 end)", dbt_utils.type_string()) }} as count_{{ column }}
+        {{dbt_utils.safe_cast("sum(case when field = '" ~ val ~ "' then 1 else 0 end)", dbt_utils.type_string()) }} as count_{{ val }}
         {%- if not loop.last %},{% endif -%}
 
     {%- endfor %}

--- a/macros/sql/get_column_values.sql
+++ b/macros/sql/get_column_values.sql
@@ -9,9 +9,9 @@
         {{ return('') }}
     {% endif %}
 
-    {%- set target_relation = adapter.get_relation(database=table.database,
-                                          schema=table.schema,
-                                         identifier=table.identifier) -%}
+    {# Not all relations are tables. Renaming for internal clarity without breaking functionality for anyone using named arguments #}
+    {# TODO: Change the method signature in a future 0.x.0 release #}
+    {%- set target_relation = table -%}
 
     {%- call statement('get_column_values', fetch_result=true) %}
 


### PR DESCRIPTION
Resolves #424 - Mixed-quoting styles on Snowflake created an invalid `Relation` using the adapter

This is a:
- [x] bug fix PR with no breaking changes — please ensure the base branch is `master`

## Checklist
- [ ] I have verified that these changes work locally on the following warehouses (Note: it's okay if you do not have access to all warehouses, this helps us understand what has been covered)
    - [ ] BigQuery
    - [ ] Postgres
    - [ ] Redshift
    - [ ] Snowflake
- [ ] I followed guidelines to ensure that my changes will work on "non-core" adapters by:
    - [ ] dispatching any new macro(s) so non-core adapters can also use them (e.g. [the `star()` source](https://github.com/fishtown-analytics/dbt-utils/blob/master/macros/sql/star.sql))
    - [ ] using the `limit_zero()` macro in place of the literal string: `limit 0`
    - [ ] using `dbt_utils.type_*` macros instead of explicit datatypes (e.g. `dbt_utils.type_timestamp()` instead of `TIMESTAMP`
- [ ] I have updated the README.md (if applicable)
- [x] I have added tests & descriptions to my models (and macros if applicable)
- [x] I have added an entry to CHANGELOG.md
