### PR TITLE
Regression: Correctly handle missing relations in get_column_values

### DIFF
--- a/integration_tests/data/sql/data_get_column_values_dropped.csv
+++ b/integration_tests/data/sql/data_get_column_values_dropped.csv
@@ -1,0 +1,12 @@
+field
+a
+b
+c
+d
+e
+f
+g
+g
+g
+g
+g

--- a/integration_tests/dbt_project.yml
+++ b/integration_tests/dbt_project.yml
@@ -56,7 +56,9 @@ seeds:
         +schema: events
       
       data_get_column_values_dropped:
-        +post-hook: "{% do adapter.drop_relation(this) %}"
+        # TODO: Ideally this would use the adapter, but it gives a "Tried to drop relation, but its type is null" error.
+        #+post-hook: "{% do adapter.drop_relation(this) %}"
+        +post-hook: "drop table {{ this }}"
 
 
     schema_tests:

--- a/integration_tests/dbt_project.yml
+++ b/integration_tests/dbt_project.yml
@@ -54,6 +54,10 @@ seeds:
     sql:
       data_events_20180103:
         +schema: events
+      
+      data_get_column_values_dropped:
+        +post-hook: "{% do adapter.drop_relation(this) %}"
+
 
     schema_tests:
       data_test_sequential_timestamps:

--- a/integration_tests/tests/sql/test_get_column_values_use_default.sql
+++ b/integration_tests/tests/sql/test_get_column_values_use_default.sql
@@ -1,0 +1,25 @@
+
+{% set column_values = dbt_utils.get_column_values(ref('data_get_column_values_dropped'), 'field', default=['y', 'z'], order_by="field") %}
+
+with expected as (
+    select { dbt_utils.safe_cast('y', dbt_utils.type_string()) }} as expected union all
+    select { dbt_utils.safe_cast('z', dbt_utils.type_string()) }} as expected 
+),
+
+actual as (
+    select 
+        {% for val in column_values %}
+            {{ dbt_utils.safe_cast(val, dbt_utils.type_string()) }} as 'actual'
+            {% if not loop.last %}
+                union all
+            {% endif %}
+        {% endfor %}
+),
+
+failures as (
+    select * from actual
+    except 
+    select * from expected
+)
+
+select * from failures

--- a/macros/sql/get_column_values.sql
+++ b/macros/sql/get_column_values.sql
@@ -13,15 +13,18 @@
     {# TODO: Change the method signature in a future 0.x.0 release #}
     {%- set target_relation = table -%}
 
+    {# adapter.load_relation is a convenience wrapper to avoid building a Relation when we already have one #}
+    {% set relation_exists = (load_relation(target_relation)) is not none %}
+
     {%- call statement('get_column_values', fetch_result=true) %}
 
-        {%- if not target_relation and default is none -%}
+        {%- if not relation_exists and default is none -%}
 
-          {{ exceptions.raise_compiler_error("In get_column_values(): relation " ~ table ~ " does not exist and no default value was provided.") }}
+          {{ exceptions.raise_compiler_error("In get_column_values(): relation " ~ target_relation ~ " does not exist and no default value was provided.") }}
 
-        {%- elif not target_relation and default is not none -%}
+        {%- elif not relation_exists and default is not none -%}
 
-          {{ log("Relation " ~ table ~ " does not exist. Returning the default value: " ~ default) }}
+          {{ log("Relation " ~ target_relation ~ " does not exist. Returning the default value: " ~ default) }}
 
           {{ return(default) }}
 


### PR DESCRIPTION
Resolves #444 

This is a:
- [x] bug fix PR with no breaking changes — please ensure the base branch is `master`
- [ ] new functionality — please ensure the base branch is the latest `dev/` branch
- [ ] a breaking change — please ensure the base branch is the latest `dev/` branch

## Description & motivation
The change I made in #440 to solve #424, in turn broke the fix introduced in #152/#119 to have a default when a model doesn't exist.

This:
- adds a test to validate behaviour when a model doesn't exist, to prevent future regressions. 
- goes back to the old approach of explicitly trying to load the relation (but using the convenience method) to check existence, instead of taking the not-None-ness of the input object at face value. 

Concerns: 
- I don't know why the integration tests aren't running, and I want them to! 
- The convenience method `load_relation` doesn't do anything differently to the old behaviour. I _think_ this means that anyone who has both #424 and #119 problems will still be stuck. But I haven't run into any of them yet, so we'll burn that bridge when we get to it. 

## Checklist
- [ ] I have verified that these changes work locally on the following warehouses (Note: it's okay if you do not have access to all warehouses, this helps us understand what has been covered)
    - [ ] BigQuery
    - [ ] Postgres
    - [ ] Redshift
    - [x] Snowflake
- [x] I followed guidelines to ensure that my changes will work on "non-core" adapters by:
    - [x] dispatching any new macro(s) so non-core adapters can also use them (e.g. [the `star()` source](https://github.com/fishtown-analytics/dbt-utils/blob/master/macros/sql/star.sql))
    - [x] using the `limit_zero()` macro in place of the literal string: `limit 0`
    - [x] using `dbt_utils.type_*` macros instead of explicit datatypes (e.g. `dbt_utils.type_timestamp()` instead of `TIMESTAMP`
- [x] I have updated the README.md (if applicable)
- [x] I have added tests & descriptions to my models (and macros if applicable)
- [ ] I have added an entry to CHANGELOG.md
