### PR TITLE
Add backtick to avoid bigquery error

### DIFF
--- a/macros/sql/surrogate_key.sql
+++ b/macros/sql/surrogate_key.sql
@@ -37,7 +37,7 @@ deprecated in a future release of dbt-utils. The {}.{} model triggered this warn
 {%- for field in field_list_xf -%}
 
     {%- set _ = fields.append(
-        "coalesce(cast(" ~ field ~ " as " ~ dbt_utils.type_string() ~ "), '')"
+        "coalesce(cast(`" ~ field ~ "` as " ~ dbt_utils.type_string() ~ "), '')"
     ) -%}
 
     {%- if not loop.last %}


### PR DESCRIPTION
Some columns are named like bigquery keywords "group" "order" "date"... This solution can this kind of issue

This is a:
- [x] bug fix PR with no breaking changes — please ensure the base branch is `master`
- [ ] new functionality — please ensure the base branch is the latest `dev/` branch
- [ ] a breaking change — please ensure the base branch is the latest `dev/` branch

## Description & motivation
<!---
Describe your changes, and why you're making them.
-->

## Checklist
- [x] I have verified that these changes work locally on the following warehouses (Note: it's okay if you do not have access to all warehouses, this helps us understand what has been covered)
    - [x] BigQuery
    - [ ] Postgres
    - [ ] Redshift
    - [ ] Snowflake
- [ ] I followed guidelines to ensure that my changes will work on "non-core" adapters by:
    - [ ] dispatching any new macro(s) so non-core adapters can also use them (e.g. [the `star()` source](https://github.com/fishtown-analytics/dbt-utils/blob/master/macros/sql/star.sql))
    - [ ] using the `limit_zero()` macro in place of the literal string: `limit 0`
    - [ ] using `dbt_utils.type_*` macros instead of explicit datatypes (e.g. `dbt_utils.type_timestamp()` instead of `TIMESTAMP`
- [ ] I have updated the README.md (if applicable)
- [ ] I have added tests & descriptions to my models (and macros if applicable)
- [ ] I have added an entry to CHANGELOG.md
