### PR TITLE
date_spine: transform comment to jinja

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 ## 🚨 Breaking changes
 - dbt ONE POINT OH is here! This version of dbt-utils requires _any_ version (minor and patch) of v1, which means far less need for compatibility releases in the future. 
 - The partition column in the `mutually_exclusive_ranges` test is now always called `partition_by_col`. This enables compatibility with `--store-failures` when multiple columns are concatenated together. If you have models built on top of the failures table, update them to reflect the new column name. ([#423](https://github.com/dbt-labs/dbt-utils/issues/423), [#430](https://github.com/dbt-labs/dbt-utils/pull/430))
-
+## Under the hood
+- make date_spine macro compatible with the Athena connector (#462)
 ## Contributors:
 - [codigo-ergo-sum](https://github.com/codigo-ergo-sum) (#430)
 

--- a/macros/sql/date_spine.sql
+++ b/macros/sql/date_spine.sql
@@ -29,16 +29,15 @@
 
 {% macro default__date_spine(datepart, start_date, end_date) %}
 
-/*
-call as follows:
+
+{# call as follows:
 
 date_spine(
     "day",
     "to_date('01/01/2016', 'mm/dd/yyyy')",
     "dateadd(week, 1, current_date)"
-)
+) #}
 
-*/
 
 with rawdata as (
 


### PR DESCRIPTION
This is a:
- [X] bug fix PR with no breaking changes — please ensure the base branch is `master`
- [ ] new functionality — please ensure the base branch is the latest `dev/` branch
- [ ] a breaking change — please ensure the base branch is the latest `dev/` branch

## Description & motivation
The macro date_spine was not compatible with the Athena connector because there was a comment using the syntax `/* ... */`
I replaced it with a Jinja comment block `{#...#}`

## Checklist
- [ ] I have verified that these changes work locally on the following warehouses (Note: it's okay if you do not have access to all warehouses, this helps us understand what has been covered)
    - [ ] BigQuery
    - [ ] Postgres
    - [ ] Redshift
    - [ ] Snowflake
- [ ] I followed guidelines to ensure that my changes will work on "non-core" adapters by:
    - [ ] dispatching any new macro(s) so non-core adapters can also use them (e.g. [the `star()` source](https://github.com/fishtown-analytics/dbt-utils/blob/master/macros/sql/star.sql))
    - [ ] using the `limit_zero()` macro in place of the literal string: `limit 0`
    - [ ] using `dbt_utils.type_*` macros instead of explicit datatypes (e.g. `dbt_utils.type_timestamp()` instead of `TIMESTAMP`
- [ ] I have updated the README.md (if applicable)
- [ ] I have added tests & descriptions to my models (and macros if applicable)
- [X] I have added an entry to CHANGELOG.md
