### PR TITLE
Enhance usability of star macro by only generating column aliases when prefix and/or suffix is specified

### DIFF
--- a/README.md
+++ b/README.md
@@ -729,9 +729,9 @@ group by 1,2,3
 ```
 
 #### star ([source](macros/sql/star.sql))
-This macro generates a list of all fields that exist in the `from` relation, excluding any fields listed in the `except` argument. The construction is identical to `select * from {{ref('my_model')}}`, replacing star (`*`) with the star macro. This macro also has an optional `relation_alias` argument that will prefix all generated fields with an alias (`relation_alias`.`field_name`). 
+This macro generates a comma-separated list of all fields that exist in the `from` relation, excluding any fields listed in the `except` argument. The construction is identical to `select * from {{ref('my_model')}}`, replacing star (`*`) with the star macro. This macro also has an optional `relation_alias` argument that will prefix all generated fields with an alias (`relation_alias`.`field_name`). 
 
-The macro also has optional `prefix` and `suffix` arguments, which will be appropriately concatenated to each field name in the output (`prefix` ~ `field_name` ~ `suffix`).  A column alias will only be generated if a prefix and/or a suffix is specified. This makes the star macro useful for returning a CSV list of column names that can also be used in other situations such as `select ... from {ref('my_model')}} where (*) not in (select ...`, replacing star (`*`) with the star macro.  
+The macro also has optional `prefix` and `suffix` arguments. When one or both are provided, they will be concatenated onto each field's alias in the output (`prefix` ~ `field_name` ~ `suffix`). NB: This prevents the output from being used in any context other than a select statement.
 
 **Usage:**
 ```sql

--- a/README.md
+++ b/README.md
@@ -729,7 +729,9 @@ group by 1,2,3
 ```
 
 #### star ([source](macros/sql/star.sql))
-This macro generates a list of all fields that exist in the `from` relation, excluding any fields listed in the `except` argument. The construction is identical to `select * from {{ref('my_model')}}`, replacing star (`*`) with the star macro. This macro also has an optional `relation_alias` argument that will prefix all generated fields with an alias (`relation_alias`.`field_name`). The macro also has optional `prefix` and `suffix` arguments, which will be appropriately concatenated to each field name in the output (`prefix` ~ `field_name` ~ `suffix`).
+This macro generates a list of all fields that exist in the `from` relation, excluding any fields listed in the `except` argument. The construction is identical to `select * from {{ref('my_model')}}`, replacing star (`*`) with the star macro. This macro also has an optional `relation_alias` argument that will prefix all generated fields with an alias (`relation_alias`.`field_name`). 
+
+The macro also has optional `prefix` and `suffix` arguments, which will be appropriately concatenated to each field name in the output (`prefix` ~ `field_name` ~ `suffix`).  A column alias will only be generated if either a prefix or a suffix is specified. This makes the star macro useful for returning a CSV list of column names that can also be used in other situations such as `select ... from {ref('my_model')}} where (*) not in (select ...`, replacing star (`*`) with the star macro.  
 
 **Usage:**
 ```sql

--- a/README.md
+++ b/README.md
@@ -731,7 +731,7 @@ group by 1,2,3
 #### star ([source](macros/sql/star.sql))
 This macro generates a list of all fields that exist in the `from` relation, excluding any fields listed in the `except` argument. The construction is identical to `select * from {{ref('my_model')}}`, replacing star (`*`) with the star macro. This macro also has an optional `relation_alias` argument that will prefix all generated fields with an alias (`relation_alias`.`field_name`). 
 
-The macro also has optional `prefix` and `suffix` arguments, which will be appropriately concatenated to each field name in the output (`prefix` ~ `field_name` ~ `suffix`).  A column alias will only be generated if either a prefix or a suffix is specified. This makes the star macro useful for returning a CSV list of column names that can also be used in other situations such as `select ... from {ref('my_model')}} where (*) not in (select ...`, replacing star (`*`) with the star macro.  
+The macro also has optional `prefix` and `suffix` arguments, which will be appropriately concatenated to each field name in the output (`prefix` ~ `field_name` ~ `suffix`).  A column alias will only be generated if a prefix and/or a suffix is specified. This makes the star macro useful for returning a CSV list of column names that can also be used in other situations such as `select ... from {ref('my_model')}} where (*) not in (select ...`, replacing star (`*`) with the star macro.  
 
 **Usage:**
 ```sql

--- a/integration_tests/data/sql/data_star_aggregate.csv
+++ b/integration_tests/data/sql/data_star_aggregate.csv
@@ -1,0 +1,5 @@
+group_field_1,group_field_2,value_field
+a,b,1
+a,b,2
+c,d,3
+c,e,4

--- a/integration_tests/data/sql/data_star_aggregate_expected.csv
+++ b/integration_tests/data/sql/data_star_aggregate_expected.csv
@@ -1,4 +1,4 @@
-group_1,group_2,value_field_sum
+group_field_1,group_field_2,value_field_sum
 a,b,3
 c,d,3
 c,e,4

--- a/integration_tests/data/sql/data_star_aggregate_expected.csv
+++ b/integration_tests/data/sql/data_star_aggregate_expected.csv
@@ -1,0 +1,4 @@
+group_1,group_2,value_field_sum
+a,b,3
+c,d,3
+c,e,4

--- a/integration_tests/models/sql/schema.yml
+++ b/integration_tests/models/sql/schema.yml
@@ -111,6 +111,11 @@ models:
       - dbt_utils.equality:
           compare_model: ref('data_star_prefix_suffix_expected')
 
+  - name: test_star_aggregate
+    tests:
+      - dbt_utils.equality:
+          compare_model: ref('data_star_aggregate_expected')
+
   - name: test_surrogate_key
     tests:
       - assert_equal:

--- a/integration_tests/models/sql/test_star_aggregate.sql
+++ b/integration_tests/models/sql/test_star_aggregate.sql
@@ -8,7 +8,7 @@ with data as (
         {{ selected_columns }},
         sum(value_field) as value_field_sum
 
-    from {{ ref('data_star') }}
+    from {{ ref('data_star_aggregate') }}
     group by {{ selected_columns }}
 
 )

--- a/integration_tests/models/sql/test_star_aggregate.sql
+++ b/integration_tests/models/sql/test_star_aggregate.sql
@@ -1,4 +1,4 @@
-{#-/*This test checks that column aliases aren't applied unless there's a prefix/suffix necessary, to ensure that GROUP BYs keep working*/#-}
+{#-/*This test checks that column aliases aren't applied unless there's a prefix/suffix necessary, to ensure that GROUP BYs keep working*/-#}
 
 {% set selected_columns = dbt_utils.star(from=ref('data_star_aggregate'), except=['value_field']) %}
 

--- a/integration_tests/models/sql/test_star_aggregate.sql
+++ b/integration_tests/models/sql/test_star_aggregate.sql
@@ -1,0 +1,16 @@
+{#-/*This test checks that column aliases aren't applied unless there's a prefix/suffix necessary, to ensure that GROUP BYs keep working*/#-}
+
+{% set selected_columns = dbt_utils.star(from=ref('data_star_aggregate'), except=['value_field']) %}
+
+with data as (
+
+    select
+        {{ selected_columns }},
+        sum(value_field) as value_field_sum
+
+    from {{ ref('data_star') }}
+    group by {{ selected_columns }}
+
+)
+
+select * from data

--- a/macros/sql/star.sql
+++ b/macros/sql/star.sql
@@ -24,7 +24,7 @@
 
     {%- for col in include_cols %}
 
-        {%- if relation_alias %}{{ relation_alias }}.{% else %}{%- endif -%}{{ adapter.quote(col)|trim }} as {{ adapter.quote(prefix ~ col ~ suffix)|trim }}
+        {%- if relation_alias %}{{ relation_alias }}.{% else %}{%- endif -%}{{ adapter.quote(col)|trim }} {%- if prefix!='' or suffix!='' -%} as {{ adapter.quote(prefix ~ col ~ suffix)|trim }} {%- endif -%}
         {%- if not loop.last %},{{ '\n  ' }}{% endif %}
 
     {%- endfor -%}


### PR DESCRIPTION
This is a:
- [ ] bug fix PR with no breaking changes — please ensure the base branch is `master`
- [X] new functionality — please ensure the base branch is the latest `dev/` branch
- [ ] a breaking change — please ensure the base branch is the latest `dev/` branch

## Description & motivation
<!---

-->
The current implementation of the star macro always generates column aliases.  This limits its usage to the specified situation `select * from {{ref('my_model')}}`, replacing star (`*`) with the star macro. 

With the simple addition of a condition, I have modified the star macro so that a column alias will only be added if there is a prefix and/or a suffix specified.  This makes the star macro useful in other situations such as in WHERE or GROUP BY predicates such as: `select ... from {ref('my_model')}} where (*) not in (select ...`, replacing star (`*`) with the star macro.  

This should also be a non-breaking change, as if neither a prefix and/or suffix is specified, then the column name alias is the same as the actual column name.  
## Checklist
- [ ] I have verified that these changes work locally on the following warehouses (Note: it's okay if you do not have access to all warehouses, this helps us understand what has been covered)
    - [ ] BigQuery
    - [ ] Postgres
    - [ ] Redshift
    - [X] Snowflake
- [X] I followed guidelines to ensure that my changes will work on "non-core" adapters by:
    - [ ] dispatching any new macro(s) so non-core adapters can also use them (e.g. [the `star()` source](https://github.com/fishtown-analytics/dbt-utils/blob/master/macros/sql/star.sql))
    - [X] using the `limit_zero()` macro in place of the literal string: `limit 0`
    - [X] using `dbt_utils.type_*` macros instead of explicit datatypes (e.g. `dbt_utils.type_timestamp()` instead of `TIMESTAMP`
- [X] I have updated the README.md (if applicable)
- [ ] I have added tests & descriptions to my models (and macros if applicable)
- [ ] I have added an entry to CHANGELOG.md
