### PR TITLE
Have union_relations raise exception when include parameter results in no columns

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,9 @@ This [dbt](https://github.com/dbt-labs/dbt) package contains macros that can be 
 ## Installation Instructions
 Check [dbt Hub](https://hub.getdbt.com/dbt-labs/dbt_utils/latest/) for the latest installation instructions, or [read the docs](https://docs.getdbt.com/docs/package-management) for more information on installing packages.
 
+## Compatibility matrix
+For compatibility details between versions of dbt-core and dbt-utils, [see this spreadsheet](https://docs.google.com/spreadsheets/d/1RoDdC69auAtrwiqmkRsgcFdZ3MdNpeKcJrWkmEpXVIs/edit#gid=0).
+
 ----
 ## Contents
 

--- a/macros/sql/union.sql
+++ b/macros/sql/union.sql
@@ -62,7 +62,18 @@
     {%- set ordered_column_names = column_superset.keys() -%}
 
     {%- if not column_superset.keys() -%}
-        {{ exceptions.raise_compiler_error("No columns to union.") }}
+        {%- set relations_string -%}
+            {%- for relation in relations -%}
+                {{ relation.name }}
+            {%- if not loop.last %}, {% endif -%}
+            {%- endfor -%}
+        {%- endset -%}
+
+        {%- set error_message -%}
+            There were no columns found to union for relations {{ relations_string }}
+        {%- endset -%}
+
+        {{ exceptions.raise_compiler_error(error_message) }}
     {%- endif -%}
 
     {%- for relation in relations %}

--- a/macros/sql/union.sql
+++ b/macros/sql/union.sql
@@ -61,6 +61,10 @@
 
     {%- set ordered_column_names = column_superset.keys() -%}
 
+    {%- if not column_superset.keys() -%}
+        {{ exceptions.raise_compiler_error("No columns to union.") }}
+    {%- endif -%}
+
     {%- for relation in relations %}
 
         (


### PR DESCRIPTION
This is a:
- [ ] bug fix PR with no breaking changes — please ensure the base branch is `master`
- [ ] new functionality — please ensure the base branch is the latest `dev/` branch
- [x] a breaking change — please ensure the base branch is the latest `dev/` branch

## Description & motivation
<!---
Describe your changes, and why you're making them.
-->

Fixes #266. Using the `include` parameter in `union_relations` with columns names that don't exist in the relations will result in invalid SQL being generated. This PR adds logic to raise an exception if there are no columns to union.

There doesn't appear to be a good way to write a unit test to ensure that an exception is raise (https://github.com/dbt-labs/dbt-core/issues/3060), but this worked in my manual testing.

## Checklist
- [x] I have verified that these changes work locally on the following warehouses (Note: it's okay if you do not have access to all warehouses, this helps us understand what has been covered)
    - [ ] BigQuery
    - [ ] Postgres
    - [ ] Redshift
    - [x] Snowflake
- [ ] I followed guidelines to ensure that my changes will work on "non-core" adapters by:
    - [ ] dispatching any new macro(s) so non-core adapters can also use them (e.g. [the `star()` source](https://github.com/fishtown-analytics/dbt-utils/blob/master/macros/sql/star.sql))
    - [ ] using the `limit_zero()` macro in place of the literal string: `limit 0`
    - [ ] using `dbt_utils.type_*` macros instead of explicit datatypes (e.g. `dbt_utils.type_timestamp()` instead of `TIMESTAMP`
- [ ] I have updated the README.md (if applicable)
- [ ] I have added tests & descriptions to my models (and macros if applicable)
- [ ] I have added an entry to CHANGELOG.md
