### PR TITLE
Update get_query_results_as_dict example to demonstrate accessing columnar results as dictionary values

### DIFF
--- a/README.md
+++ b/README.md
@@ -1051,7 +1051,7 @@ select
 order_id,
 {%- for payment_method in payment_methods %}
 sum(case when payment_method = '{{ payment_method }}' then amount end)
-  as {{ slugify(payment_method) }}_amount,
+  as {{ dbt_utils.slugify(payment_method) }}_amount,
 
 {% endfor %}
 ...

--- a/README.md
+++ b/README.md
@@ -667,7 +667,7 @@ This macro returns a dictionary from a sql query, so that you don't need to inte
 select
 
     {% for city in places['CITY'] | unique -%}
-      sum(case when city = '{{ city }}' then 1 else 0 end) as users_in_{{ city | replace(' ', '_') }},
+      sum(case when city = '{{ city }}' then 1 else 0 end) as users_in_{{ dbt_utils.slugify(city) }},
     {% endfor %}
 
     {% for state in places['STATE'] | unique -%}

--- a/README.md
+++ b/README.md
@@ -658,17 +658,25 @@ This macro returns a dictionary from a sql query, so that you don't need to inte
 
 **Usage:**
 ```
--- Returns a dictionary of the users table where the state is California
-{% set california_cities = dbt_utils.get_query_results_as_dict("select * from" ~ ref('cities') ~ "where state = 'CA' and city is not null ") %}
-select
-  city,
-{% for city in california_cities %}
-  sum(case when city = {{ city }} then 1 else 0 end) as users_in_{{ city }},
-{% endfor %}
-  count(*) as total
-from {{ ref('users') }}
+{% set sql_statement %}
+    select city, state from {{ ref('users) }}
+{% endset %}
 
-group by 1
+{%- set places = dbt_utils.get_query_results_as_dict(sql_statement) -%}
+
+select
+
+    {% for city in places['CITY'] | unique -%}
+      sum(case when city = '{{ city }}' then 1 else 0 end) as users_in_{{ city | replace(' ', '_') }},
+    {% endfor %}
+
+    {% for state in places['STATE'] | unique -%}
+      sum(case when state = '{{ state }}' then 1 else 0 end) as users_in_{{ state }},
+    {% endfor %}
+
+    count(*) as total_total
+
+from {{ ref('users') }}
 ```
 
 ### SQL generators


### PR DESCRIPTION
This is a:
- [x] bug fix PR with no breaking changes — please ensure the base branch is `master`
- [ ] new functionality — please ensure the base branch is the latest `dev/` branch
- [ ] a breaking change — please ensure the base branch is the latest `dev/` branch

## Description & motivation
<!---
Describe your changes, and why you're making them.
-->
The existing example code snippet for `get_query_results_as_dict` did not demonstrate accessing the result object by dictionary key.


## Checklist
- [x] I have updated the README.md (if applicable)
- [ ] I have added an entry to CHANGELOG.md
