### PR TITLE
Added case for handling postgres foreign tables...

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,12 @@
 - dbt ONE POINT OH is here! This version of dbt-utils requires _any_ version (minor and patch) of v1, which means far less need for compatibility releases in the future. 
 - The partition column in the `mutually_exclusive_ranges` test is now always called `partition_by_col`. This enables compatibility with `--store-failures` when multiple columns are concatenated together. If you have models built on top of the failures table, update them to reflect the new column name. ([#423](https://github.com/dbt-labs/dbt-utils/issues/423), [#430](https://github.com/dbt-labs/dbt-utils/pull/430))
 
+## Fixes
+- `get_relations_by_pattern()` now uses additional sub macros `get_table_types_sql()` to determine table types for different database engines. ([#357](https://github.com/dbt-labs/dbt-utils/issues/357), [#476](https://github.com/dbt-labs/dbt-utils/pull/476))
+
 ## Contributors:
 - [codigo-ergo-sum](https://github.com/codigo-ergo-sum) (#430)
+- [Aesthet](https://github.com/Aesthet) (#476)
 
 # dbt-utils 0.7.5
 🚨 This is a compatibility release in preparation for `dbt-core` v1.0.0 (🎉). Projects using dbt-utils 0.7.4 with dbt-core v1.0.0 can expect to see a deprecation warning. This will be resolved in dbt_utils v0.8.0.

--- a/README.md
+++ b/README.md
@@ -11,7 +11,6 @@ For compatibility details between versions of dbt-core and dbt-utils, [see this 
 
 **[Schema tests](#schema-tests)**
   - [equal_rowcount](#equal_rowcount-source)
-  - [fewer_rows_than](#fewer_rows_than-source)
   - [equality](#equality-source)
   - [expression_is_true](#expression_is_true-source)
   - [recency](#recency-source)

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ For compatibility details between versions of dbt-core and dbt-utils, [see this 
 
 **[Schema tests](#schema-tests)**
   - [equal_rowcount](#equal_rowcount-source)
+  - [fewer_rows_than](#fewer_rows_than-source)
   - [equality](#equality-source)
   - [expression_is_true](#expression_is_true-source)
   - [recency](#recency-source)

--- a/macros/sql/get_table_types_sql.sql
+++ b/macros/sql/get_table_types_sql.sql
@@ -1,0 +1,22 @@
+{%- macro get_table_types_sql() -%}
+  {{ return(adapter.dispatch('get_table_types_sql', 'dbt_utils')()) }}
+{%- endmacro -%}
+
+{% macro default__get_table_types_sql() %}
+            case table_type
+                when 'BASE TABLE' then 'table'
+                when 'EXTERNAL TABLE' then 'external'
+                when 'MATERIALIZED VIEW' then 'materializedview'
+                else lower(table_type)
+            end as "table_type"
+{% endmacro %}
+
+
+{% macro postgres__get_table_types_sql() %}
+            case table_type
+                when 'BASE TABLE' then 'table'
+                when 'FOREIGN' then 'external'
+                when 'MATERIALIZED VIEW' then 'materializedview'
+                else lower(table_type)
+            end as "table_type"
+{% endmacro %}

--- a/macros/sql/get_tables_by_pattern_sql.sql
+++ b/macros/sql/get_tables_by_pattern_sql.sql
@@ -11,6 +11,7 @@
             case table_type
                 when 'BASE TABLE' then 'table'
                 when 'EXTERNAL TABLE' then 'external'
+                when 'FOREIGN' then 'external'
                 when 'MATERIALIZED VIEW' then 'materializedview'
                 else lower(table_type)
             end as "table_type"

--- a/macros/sql/get_tables_by_pattern_sql.sql
+++ b/macros/sql/get_tables_by_pattern_sql.sql
@@ -8,13 +8,7 @@
         select distinct
             table_schema as "table_schema",
             table_name as "table_name",
-            case table_type
-                when 'BASE TABLE' then 'table'
-                when 'EXTERNAL TABLE' then 'external'
-                when 'FOREIGN' then 'external'
-                when 'MATERIALIZED VIEW' then 'materializedview'
-                else lower(table_type)
-            end as "table_type"
+            {{ dbt_utils.get_table_types_sql() }}
         from {{ database }}.information_schema.tables
         where table_schema ilike '{{ schema_pattern }}'
         and table_name ilike '{{ table_pattern }}'


### PR DESCRIPTION
(tables which are external to current database and are imported into current database from remote data stores by using Foreign Data Wrappers functionality).

This is a:
- [x] bug fix PR with no breaking changes — please ensure the base branch is `master`
- [ ] new functionality — please ensure the base branch is the latest `dev/` branch
- [ ] a breaking change — please ensure the base branch is the latest `dev/` branch

## Description & motivation
As described in [this issue](https://github.com/dbt-labs/dbt-utils/issues/357) we are facing errors when we are using Postgres Foreign Data Wrappers functionality - in particular tables which are imported as part of IMPORT FOREIGN SCHEMA command. Those tables are external to database in which they are imported and they have type FOREIGN, which is causing errors during execution of get_relations_by_pattern macros which is getting values from get_tables_by_pattern_sql macros.

## Checklist
- [ ] I have verified that these changes work locally on the following warehouses (Note: it's okay if you do not have access to all warehouses, this helps us understand what has been covered)
    - [ ] BigQuery
    - [x] Postgres
    - [ ] Redshift
    - [x] Snowflake
- [ ] I followed guidelines to ensure that my changes will work on "non-core" adapters by:
    - [ ] dispatching any new macro(s) so non-core adapters can also use them (e.g. [the `star()` source](https://github.com/fishtown-analytics/dbt-utils/blob/master/macros/sql/star.sql))
    - [ ] using the `limit_zero()` macro in place of the literal string: `limit 0`
    - [ ] using `dbt_utils.type_*` macros instead of explicit datatypes (e.g. `dbt_utils.type_timestamp()` instead of `TIMESTAMP`
- [ ] I have updated the README.md (if applicable)
- [ ] I have added tests & descriptions to my models (and macros if applicable)
- [ ] I have added an entry to CHANGELOG.md
