### PR TITLE
Delete rows with matching unique key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# dbt-utils v0.9.0
+## Features
+- Add `unique_key` configuration option to `insert_by_period` materialization ([#478](https://github.com/dbt-labs/dbt-utils/pull/478))
+
 # dbt-utils v0.8.0
 ## 🚨 Breaking changes
 - dbt ONE POINT OH is here! This version of dbt-utils requires _any_ version (minor and patch) of v1, which means far less need for compatibility releases in the future. 

--- a/README.md
+++ b/README.md
@@ -1078,7 +1078,8 @@ Progress is logged in the command line for easy monitoring.
     period = "day",
     timestamp_field = "created_at",
     start_date = "2018-01-01",
-    stop_date = "2018-06-01")
+    stop_date = "2018-06-01",
+    unique_key = "id")
 }}
 
 with events as (
@@ -1098,11 +1099,11 @@ with events as (
 * `timestamp_field`: the column name of the timestamp field that will be used to break the model into smaller queries
 * `start_date`: literal date or timestamp - generally choose a date that is earlier than the start of your data
 * `stop_date`: literal date or timestamp (default=current_timestamp)
+* `unique_key`: optional key to use to deduplicate records, this is the same as `unique_key` in [incremental models](https://docs.getdbt.com/docs/building-a-dbt-project/building-models/configuring-incremental-models#defining-a-uniqueness-constraint-optional)
 
 **Caveats:**
 * This materialization is compatible with dbt 0.10.1.
 * This materialization has been written for Redshift.
-* This materialization can only be used for a model where records are not expected to change after they are created.
 * Any model post-hooks that use `{{ this }}` will fail using this materialization. For example:
 ```yaml
 models:

--- a/macros/materializations/insert_by_period_materialization.sql
+++ b/macros/materializations/insert_by_period_materialization.sql
@@ -144,7 +144,7 @@
                                          to_relation=target_relation)}}
     {%- set name = 'main-' ~ i -%}
     {% call statement(name, fetch_result=True) -%}
-      {%- if old_relation is not none and unique_key is not none %}
+      {%- if unique_key is not none %}
       delete from {{ target_relation }}
       where ({{ unique_key }}) in (
         select ({{ unique_key }})

--- a/macros/materializations/insert_by_period_materialization.sql
+++ b/macros/materializations/insert_by_period_materialization.sql
@@ -55,6 +55,7 @@
   {%- set start_date = config.require('start_date') -%}
   {%- set stop_date = config.get('stop_date') or '' -%}}
   {%- set period = config.get('period') or 'week' -%}
+  {%- set unique_key = config.get('unique_key') -%}
 
   {%- if sql.find('__PERIOD_FILTER__') == -1 -%}
     {%- set error_message -%}
@@ -143,6 +144,13 @@
                                          to_relation=target_relation)}}
     {%- set name = 'main-' ~ i -%}
     {% call statement(name, fetch_result=True) -%}
+      {%- if old_relation is not none and unique_key is not none %}
+      delete from {{ target_relation }}
+      where ({{ unique_key }}) in (
+        select ({{ unique_key }})
+        from {{ tmp_relation.include(schema=False) }}
+      );
+      {%- endif %}
       insert into {{target_relation}} ({{target_cols_csv}})
       (
           select


### PR DESCRIPTION
## Description & motivation
This introduces "merge" behaviour for insert by period to match the standard incremental materialisation. This allows insert by period to be used with models where rows change over time.

I simply copied the code from the standard incremental materialisation here: https://github.com/dbt-labs/dbt-core/blob/8442fb66a591c4f5353f8baaaaf62f846c5f5171/core/dbt/include/global_project/macros/materializations/models/incremental/merge.sql#L50.

## Checklist
- [x] I have verified that these changes work locally on the following warehouses (Note: it's okay if you do not have access to all warehouses, this helps us understand what has been covered)
    - [ ] BigQuery
    - [ ] Postgres
    - [x] Redshift
    - [ ] Snowflake
- [x] I followed guidelines to ensure that my changes will work on "non-core" adapters by:
    - [ ] dispatching any new macro(s) so non-core adapters can also use them (e.g. [the `star()` source](https://github.com/fishtown-analytics/dbt-utils/blob/master/macros/sql/star.sql))
    - [ ] using the `limit_zero()` macro in place of the literal string: `limit 0`
    - [ ] using `dbt_utils.type_*` macros instead of explicit datatypes (e.g. `dbt_utils.type_timestamp()` instead of `TIMESTAMP`
- [x] I have updated the README.md (if applicable)
- [ ] I have added tests & descriptions to my models (and macros if applicable)
- [x] I have added an entry to CHANGELOG.md
