### PR TITLE
Remove column name in generated column

### DIFF
--- a/macros/schema_tests/sequential_values.sql
+++ b/macros/schema_tests/sequential_values.sql
@@ -12,7 +12,7 @@ with windowed as (
         {{ column_name }},
         lag({{ column_name }}) over (
             order by {{ column_name }}
-        ) as previous_{{ column_name }}
+        ) as _previous
     from {{ model }}
 ),
 
@@ -21,9 +21,9 @@ validation_errors as (
         *
     from windowed
     {% if datepart %}
-    where not(cast({{ column_name }} as {{ dbt_utils.type_timestamp() }})= cast({{ dbt_utils.dateadd(datepart, interval, 'previous_' + column_name) }} as {{ dbt_utils.type_timestamp() }}))
+    where not(cast({{ column_name }} as {{ dbt_utils.type_timestamp() }})= cast({{ dbt_utils.dateadd(datepart, interval, '_previous') }} as {{ dbt_utils.type_timestamp() }}))
     {% else %}
-    where not({{ column_name }} = previous_{{ column_name }} + {{ interval }})
+    where not({{ column_name }} = _previous + {{ interval }})
     {% endif %}
 )
 


### PR DESCRIPTION
This is a:
- [X] bug fix PR with no breaking changes — please ensure the base branch is `master`
- [ ] new functionality — please ensure the base branch is the latest `dev/` branch
- [ ] a breaking change — please ensure the base branch is the latest `dev/` branch

## Description & motivation
The sequential_values test internally generates a column name to keep track of the previous value. Generating this name causes errors when using the [quote property](https://docs.getdbt.com/reference/resource-properties/quote/).

This PR simplifies the column name that tracks the previous value. I've prefixed the name with an underscore "_" to reduce the risk of conflicts.

I'm not sure if this is a breaking change. Do users parse the `previous_{{ column_name }}` name when examining the test errors?

## Checklist
- [X] I have verified that these changes work locally on the following warehouses (Note: it's okay if you do not have access to all warehouses, this helps us understand what has been covered)
    - [ ] BigQuery
    - [ ] Postgres
    - [X] Redshift
    - [ ] Snowflake
- [ ] I followed guidelines to ensure that my changes will work on "non-core" adapters by:
    - [ ] dispatching any new macro(s) so non-core adapters can also use them (e.g. [the `star()` source](https://github.com/fishtown-analytics/dbt-utils/blob/master/macros/sql/star.sql))
    - [ ] using the `limit_zero()` macro in place of the literal string: `limit 0`
    - [ ] using `dbt_utils.type_*` macros instead of explicit datatypes (e.g. `dbt_utils.type_timestamp()` instead of `TIMESTAMP`
- [ ] I have updated the README.md (if applicable)
- [ ] I have added tests & descriptions to my models (and macros if applicable)
- [ ] I have added an entry to CHANGELOG.md
