### PR TITLE
add casting

### DIFF
--- a/macros/cross_db_utils/datediff.sql
+++ b/macros/cross_db_utils/datediff.sql
@@ -61,6 +61,10 @@
 {# redshift should use default instead of postgres #}
 {% macro redshift__datediff(first_date, second_date, datepart) %}
 
-    {{ return(dbt_utils.default__datediff(first_date, second_date, datepart)) }}
+    datediff(
+        {{ datepart }},
+        {{ first_date }}::{{ dbt_utils.type_timestamp()}},
+        {{ second_date }}::{{ dbt_utils.type_timestamp()}}
+        )
 
 {% endmacro %}


### PR DESCRIPTION
This is a:
- [x] bug fix PR with no breaking changes — please ensure the base branch is `master`
- [ ] new functionality — please ensure the base branch is the latest `dev/` branch
- [ ] a breaking change — please ensure the base branch is the latest `dev/` branch

## Description & motivation
Redshift's `datediff` function does not support the difference between two `timestamptz` (for example, see https://github.com/dbt-labs/dbt-utils/issues/482). In order to handle that case, I would like to add casting to `timestamp`. 

## Checklist
- [ ] I have verified that these changes work locally on the following warehouses (Note: it's okay if you do not have access to all warehouses, this helps us understand what has been covered)
    - [ ] BigQuery
    - [ ] Postgres
    - [x] Redshift
    - [ ] Snowflake
- [ ] I followed guidelines to ensure that my changes will work on "non-core" adapters by:
    - [ ] dispatching any new macro(s) so non-core adapters can also use them (e.g. [the `star()` source](https://github.com/fishtown-analytics/dbt-utils/blob/master/macros/sql/star.sql))
    - [ ] using the `limit_zero()` macro in place of the literal string: `limit 0`
    - [x] using `dbt_utils.type_*` macros instead of explicit datatypes (e.g. `dbt_utils.type_timestamp()` instead of `TIMESTAMP`
- [ ] I have updated the README.md (if applicable)
- [ ] I have added tests & descriptions to my models (and macros if applicable)
- [ ] I have added an entry to CHANGELOG.md
