### PR TITLE
Update: add table quoting for get_relations_by_pattern

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# dbt-utils v0.8.1
+## Fixes
+- `get_relations_by_pattern()` now allows you to specify table quoting if needed ([#489](https://github.com/dbt-labs/dbt-utils/issues/489))
+## Contributors:
+- [aescay](https://github.com/aescay)
 # dbt-utils v0.8.0
 ## 🚨 Breaking changes
 - dbt ONE POINT OH is here! This version of dbt-utils requires _any_ version (minor and patch) of v1, which means far less need for compatibility releases in the future. 

--- a/README.md
+++ b/README.md
@@ -607,6 +607,7 @@ This macro is particularly handy when paired with `union_relations`.
 * `exclude` (optional): Exclude any relations that match this table pattern.
 * `database` (optional, default = `target.database`): The database to inspect
 for relations.
+* `quote_table` (optional): Wrap the table name in quotes.
 
 **Examples:**
 Generate drop statements for all Relations that match a naming pattern:

--- a/macros/sql/get_relations_by_pattern.sql
+++ b/macros/sql/get_relations_by_pattern.sql
@@ -1,8 +1,8 @@
-{% macro get_relations_by_pattern(schema_pattern, table_pattern, exclude='', database=target.database) %}
-    {{ return(adapter.dispatch('get_relations_by_pattern', 'dbt_utils')(schema_pattern, table_pattern, exclude, database)) }}
+{% macro get_relations_by_pattern(schema_pattern, table_pattern, exclude='', database=target.database, quote_table=False) %}
+    {{ return(adapter.dispatch('get_relations_by_pattern', 'dbt_utils')(schema_pattern, table_pattern, exclude, database, quote_table)) }}
 {% endmacro %}
 
-{% macro default__get_relations_by_pattern(schema_pattern, table_pattern, exclude='', database=target.database) %}
+{% macro default__get_relations_by_pattern(schema_pattern, table_pattern, exclude='', database=target.database, quote_table=False) %}
 
     {%- call statement('get_tables', fetch_result=True) %}
 
@@ -15,10 +15,15 @@
     {%- if table_list and table_list['table'] -%}
         {%- set tbl_relations = [] -%}
         {%- for row in table_list['table'] -%}
+            {% if quote_table %}
+            {% set table_name = '"' ~ row.table_name ~ '"' %}
+            {% else %}
+            {% set table_name = row.table_name %}
+            {% endif %}
             {%- set tbl_relation = api.Relation.create(
                 database=database,
                 schema=row.table_schema,
-                identifier=row.table_name,
+                identifier=table_name,
                 type=row.table_type
             ) -%}
             {%- do tbl_relations.append(tbl_relation) -%}


### PR DESCRIPTION
This is a:
- [ ] bug fix PR with no breaking changes — please ensure the base branch is `master`
- [x] new functionality — please ensure the base branch is the latest `dev/` branch
- [ ] a breaking change — please ensure the base branch is the latest `dev/` branch

## Description & motivation
<!---
Describe your changes, and why you're making them.
-->
Adding an option to allow quoting table names. This makes it possible to run this macro on table names that are considered protected words (ex. table names that are the same as function names).

## Checklist
- [x] I have verified that these changes work locally on the following warehouses (Note: it's okay if you do not have access to all warehouses, this helps us understand what has been covered)
    - [ ] BigQuery
    - [ ] Postgres
    - [ ] Redshift
    - [x] Snowflake
- [x] I followed guidelines to ensure that my changes will work on "non-core" adapters by:
    - [ ] dispatching any new macro(s) so non-core adapters can also use them (e.g. [the `star()` source](https://github.com/fishtown-analytics/dbt-utils/blob/master/macros/sql/star.sql))
    - [ ] using the `limit_zero()` macro in place of the literal string: `limit 0`
    - [ ] using `dbt_utils.type_*` macros instead of explicit datatypes (e.g. `dbt_utils.type_timestamp()` instead of `TIMESTAMP`
- [x] I have updated the README.md (if applicable)
- [x] I have added tests & descriptions to my models (and macros if applicable)
- [ ] I have added an entry to CHANGELOG.md
