### PR TITLE
Quote the column name properly in unpivot macro

### DIFF
--- a/macros/sql/unpivot.sql
+++ b/macros/sql/unpivot.sql
@@ -65,7 +65,7 @@ Arguments:
       cast(  {% if col.data_type == 'boolean' %}
            {{ dbt_utils.cast_bool_to_text(col.column) }}
              {% else %}
-           {{ col.column }}
+           '{{ col.column }}'
              {% endif %}
            as {{ cast_to }}) as {{ value_name }}
 


### PR DESCRIPTION
This is a:
- [x] bug fix PR with no breaking changes — please ensure the base branch is `master`
- [ ] new functionality — please ensure the base branch is the latest `dev/` branch
- [ ] a breaking change — please ensure the base branch is the latest `dev/` branch

## Description & motivation

Column name should be quote properly for preventing keyword collision.

## Checklist
- [x] I have verified that these changes work locally on the following warehouses (Note: it's okay if you do not have access to all warehouses, this helps us understand what has been covered)
    - [ ] BigQuery
    - [ ] Postgres
    - [x] Redshift
    - [ ] Snowflake
- [ ] I followed guidelines to ensure that my changes will work on "non-core" adapters by:
    - [ ] dispatching any new macro(s) so non-core adapters can also use them (e.g. [the `star()` source](https://github.com/fishtown-analytics/dbt-utils/blob/master/macros/sql/star.sql))
    - [ ] using the `limit_zero()` macro in place of the literal string: `limit 0`
    - [ ] using `dbt_utils.type_*` macros instead of explicit datatypes (e.g. `dbt_utils.type_timestamp()` instead of `TIMESTAMP`
- [ ] I have updated the README.md (if applicable)
- [ ] I have added tests & descriptions to my models (and macros if applicable)
- [ ] I have added an entry to CHANGELOG.md
