### PR TITLE
fix pivot : in pivoted column value, single quote must be escaped (on…

### DIFF
--- a/integration_tests/data/sql/data_pivot.csv
+++ b/integration_tests/data/sql/data_pivot.csv
@@ -1,4 +1,5 @@
 size,color
 S,red
 S,blue
+S,blue's
 M,red

--- a/integration_tests/data/sql/data_pivot_expected.csv
+++ b/integration_tests/data/sql/data_pivot_expected.csv
@@ -1,3 +1,3 @@
 size,red,blue,blue's
-S,1,0,0
-M,1,1,1
+S,1,1,1
+M,1,0,0

--- a/integration_tests/data/sql/data_pivot_expected.csv
+++ b/integration_tests/data/sql/data_pivot_expected.csv
@@ -1,3 +1,3 @@
-size,red,blue
-S,1,1
-M,1,0
+size,red,blue,blue's
+S,1,0,0
+M,1,1,1

--- a/integration_tests/dbt_project.yml
+++ b/integration_tests/dbt_project.yml
@@ -59,6 +59,9 @@ seeds:
       data_get_column_values_dropped:
         # this.incorporate() to hardcode the node's type as otherwise dbt doesn't know it yet
         +post-hook: "{% do adapter.drop_relation(this.incorporate(type='table')) %}"
+      
+      data_pivot_expected:
+        quote_columns: true
 
 
     schema_tests:

--- a/integration_tests/models/sql/test_pivot.sql
+++ b/integration_tests/models/sql/test_pivot.sql
@@ -2,10 +2,10 @@
 -- TODO: How do we make this work nicely on Snowflake too?
 
 {% if target.type == 'snowflake' %}
-    {% set column_values = ['RED', 'BLUE'] %}
+    {% set column_values = ['RED', 'BLUE', "BLUE'S"] %}
     {% set cmp = 'ilike' %}
 {% else %}
-    {% set column_values = ['red', 'blue'] %}
+    {% set column_values = ['red', 'blue', "blue's"] %}
     {% set cmp = '=' %}
 {% endif %}
 

--- a/macros/cross_db_utils/escape_single_quotes.sql
+++ b/macros/cross_db_utils/escape_single_quotes.sql
@@ -1,0 +1,9 @@
+{% macro escape_single_quotes(expression) %}
+      {{ return(adapter.dispatch('escape_single_quotes', 'dbt_utils') (expression)) }}
+{% endmacro %}
+
+{% macro default__escape_single_quotes(expression) %}{{ expression | replace("'","''") }}{% endmacro %}
+
+{% macro snowflake__escape_single_quotes(expression) %}{{ expression | replace("'", "\'") }}{% endmacro %}
+
+{% macro bigquery__escape_single_quotes(expression) %}{{ expression | replace("'", "\'") }}{% endmacro %}

--- a/macros/sql/pivot.sql
+++ b/macros/sql/pivot.sql
@@ -69,7 +69,7 @@ Arguments:
     {{ agg }}(
       {% if distinct %} distinct {% endif %}
       case
-      when {{ column }} {{ cmp }} '{{ v }}'
+      when {{ column }} {{ cmp }} '{{ v | replace("'","''") }}' {# escape quote in value (in postgresql) #}
         then {{ then_value }}
       else {{ else_value }}
       end

--- a/macros/sql/pivot.sql
+++ b/macros/sql/pivot.sql
@@ -69,7 +69,7 @@ Arguments:
     {{ agg }}(
       {% if distinct %} distinct {% endif %}
       case
-      when {{ column }} {{ cmp }} '{{ v | replace("'","''") }}' {# escape quote in value (in postgresql) #}
+      when {{ column }} {{ cmp }} '{{ dbt_utils.escape_single_quotes(v) }}' {# escape else ex. syntax error near : when color = 'blue's' #}
         then {{ then_value }}
       else {{ else_value }}
       end


### PR DESCRIPTION
… postgresql)

else ex. syntax error near : when color = 'blue's'

This is a:
- [x ] bug fix PR with no breaking changes — please ensure the base branch is `master`
- [ ] new functionality — please ensure the base branch is the latest `dev/` branch
- [ ] a breaking change — please ensure the base branch is the latest `dev/` branch

## Description & motivation
pivot script gets a syntax error when working with pivoted column values that contain quotes, because it quotes them but did not escape them. This fix quotes them.

## Checklist
- [ x] I have verified that these changes work locally on the following warehouses (Note: it's okay if you do not have access to all warehouses, this helps us understand what has been covered)
    - [ ] BigQuery
    - [ x] Postgres
    - [ ] Redshift
    - [ ] Snowflake
- [ ] I followed guidelines to ensure that my changes will work on "non-core" adapters by:
    - [ ] dispatching any new macro(s) so non-core adapters can also use them (e.g. [the `star()` source](https://github.com/fishtown-analytics/dbt-utils/blob/master/macros/sql/star.sql))
    - [ ] using the `limit_zero()` macro in place of the literal string: `limit 0`
    - [ ] using `dbt_utils.type_*` macros instead of explicit datatypes (e.g. `dbt_utils.type_timestamp()` instead of `TIMESTAMP`
- [ ] I have updated the README.md (if applicable)
- [ x] I have added tests & descriptions to my models (and macros if applicable)
- [ ] I have added an entry to CHANGELOG.md
