### PR TITLE
Fix union_relations error when no include/exclude provided

### DIFF
--- a/macros/sql/union.sql
+++ b/macros/sql/union.sql
@@ -61,7 +61,7 @@
 
     {%- set ordered_column_names = column_superset.keys() -%}
 
-    {%- if not column_superset.keys() -%}
+    {% if (include | length > 0 or exclude | length > 0) and not column_superset.keys() %}
         {%- set relations_string -%}
             {%- for relation in relations -%}
                 {{ relation.name }}


### PR DESCRIPTION
This is a:
- [x] bug fix PR with no breaking changes — please ensure the base branch is `main`
- [ ] new functionality — please ensure the base branch is the latest `dev/` branch
- [ ] a breaking change — please ensure the base branch is the latest `dev/` branch

## Description & motivation
(At least partially) Resolves #505 - we still don't know why this happens some times and not others, but at least this protects people who aren't even using include/exclude params. 

## Checklist
- [ ] I have verified that these changes work locally on the following warehouses (Note: it's okay if you do not have access to all warehouses, this helps us understand what has been covered)
    - [ ] BigQuery
    - [ ] Postgres
    - [ ] Redshift
    - [ ] Snowflake
- [ ] I have added an entry to CHANGELOG.md
