### PR TITLE
Change casting for bigquery

### DIFF
--- a/macros/cross_db_utils/dateadd.sql
+++ b/macros/cross_db_utils/dateadd.sql
@@ -17,7 +17,7 @@
 {% macro bigquery__dateadd(datepart, interval, from_date_or_timestamp) %}
 
         datetime_add(
-            cast( {{ from_date_or_timestamp }} as datetime),
+            cast( {{ from_date_or_timestamp }} as timestamp),
         interval {{ interval }} {{ datepart }}
         )
 


### PR DESCRIPTION
Bigquery lets you cast a string in the format of timestamp or datetime to timestamp, but not casting a string in the format of timestamp to datetime.
When trying to use the util on a string in a timestamp format, it fails:

`datetime_add(cast( '2022-03-11 00:00:00' as datetime, interval -2 day)` - works
`datetime_add(cast( '2022-03-11 00:00:00+00:00' as datetime, interval -2 day)` - fails

`datetime_add(cast( '2022-03-11 00:00:00' as timestamp, interval -2 day)` - works
`datetime_add(cast( '2022-03-11 00:00:00+00:00' as timestamp, interval -2 day)` - works

My proposed change fixes that.

This is a:
- [X] bug fix PR with no breaking changes — please ensure the base branch is `main`

## Description & motivation
<!---
Describe your changes, and why you're making them.
-->

## Checklist
- [X] I have verified that these changes work locally on the following warehouses (Note: it's okay if you do not have access to all warehouses, this helps us understand what has been covered)
    - [X] BigQuery
    - [ ] Postgres
    - [ ] Redshift
    - [ ] Snowflake
- [ ] I followed guidelines to ensure that my changes will work on "non-core" adapters by:
    - [ ] dispatching any new macro(s) so non-core adapters can also use them (e.g. [the `star()` source](https://github.com/fishtown-analytics/dbt-utils/blob/master/macros/sql/star.sql))
    - [ ] using the `limit_zero()` macro in place of the literal string: `limit 0`
    - [ ] using `dbt_utils.type_*` macros instead of explicit datatypes (e.g. `dbt_utils.type_timestamp()` instead of `TIMESTAMP`
- [ ] I have updated the README.md (if applicable)
- [ ] I have added tests & descriptions to my models (and macros if applicable)
- [ ] I have added an entry to CHANGELOG.md
