### PR TITLE
feat: :sparkles: add order_by macro

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# dbt-utils v0.8.3
+
+## New features
+- A cross-database implementation of `order_by()` ([#524](https://github.com/dbt-labs/dbt-utils/pull/524))
+
 # dbt-utils v0.8.2
 ## Fixes
 - Fix union_relations error from [#473](https://github.com/dbt-labs/dbt-utils/pull/473) when no include/exclude parameters are provided ([#505](https://github.com/dbt-labs/dbt-utils/issues/505), [#509](https://github.com/dbt-labs/dbt-utils/pull/509))

--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ For compatibility details between versions of dbt-core and dbt-utils, [see this 
     - [date_spine](#date_spine-source)
     - [haversine_distance](#haversine_distance-source)
     - [group_by](#group_by-source)
+    - [order_by](#order_by-source)
     - [star](#star-source)
     - [union_relations](#union_relations-source)
     - [generate_series](#generate_series-source)
@@ -745,6 +746,21 @@ Would compile to:
 
 ```sql
 group by 1,2,3
+```
+
+#### order_by ([source](macros/sql/orderby.sql))
+This macro build an order by statement for fields 1...N
+
+**Usage:**
+
+```
+{{ dbt_utils.order_by(n=3) }}
+```
+
+Would compile to:
+
+```sql
+order by 1,2,3
 ```
 
 #### star ([source](macros/sql/star.sql))

--- a/integration_tests/models/sql/schema.yml
+++ b/integration_tests/models/sql/schema.yml
@@ -142,3 +142,11 @@ models:
     tests:
       - dbt_utils.equality:
           compare_model: ref('data_union_events_expected')
+
+  - name: test_orderby
+    columns:
+      - name: column
+        tests:
+          - accepted_values:
+              values:
+                - 'a'

--- a/integration_tests/models/sql/test_orderby.sql
+++ b/integration_tests/models/sql/test_orderby.sql
@@ -1,0 +1,10 @@
+  WITH test_data AS (
+SELECT {{ dbt_utils.safe_cast("'a'", dbt_utils.type_string() )}} AS column
+ UNION ALL    
+SELECT {{ dbt_utils.safe_cast("'b'", dbt_utils.type_string() )}} AS column
+       )
+
+SELECT *
+  FROM test_data
+       {{ dbt_utils.order_by(1) }}
+ LIMIT 1

--- a/macros/sql/orderby.sql
+++ b/macros/sql/orderby.sql
@@ -1,0 +1,11 @@
+{%- macro order_by(n) -%}
+    {{ return(adapter.dispatch('order_by', 'dbt_utils')(n)) }}
+{% endmacro %}
+
+{%- macro default__order_by(n) -%}
+
+  order by {% for i in range(1, n + 1) -%}
+      {{ i }}{{ ',' if not loop.last }}   
+   {%- endfor -%}
+
+{%- endmacro -%}


### PR DESCRIPTION
This is a:
- [ ] bug fix PR with no breaking changes — please ensure the base branch is `main`
- [X] new functionality — please ensure the base branch is the latest `dev/` branch
- [ ] a breaking change — please ensure the base branch is the latest `dev/` branch

## Description & motivation
An order_by macro because all dbt_utils users who uses `group_by` should be also be allowed to use `order_by`.

## Checklist
- [X] I have verified that these changes work locally on the following warehouses (Note: it's okay if you do not have access to all warehouses, this helps us understand what has been covered)
    - [ ] BigQuery
    - [X] Postgres
    - [ ] Redshift
    - [X] Snowflake
- [X] I followed guidelines to ensure that my changes will work on "non-core" adapters by:
    - [X] dispatching any new macro(s) so non-core adapters can also use them (e.g. [the `star()` source](https://github.com/fishtown-analytics/dbt-utils/blob/master/macros/sql/star.sql))
    - [X] using the `limit_zero()` macro in place of the literal string: `limit 0`
    - [X] using `dbt_utils.type_*` macros instead of explicit datatypes (e.g. `dbt_utils.type_timestamp()` instead of `TIMESTAMP`
- [X] I have updated the README.md (if applicable)
- [X] I have added tests & descriptions to my models (and macros if applicable)
- [X] I have added an entry to CHANGELOG.md
