### PR TITLE
Typed materialized views as views

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# dbt-utils v0.8.2
+## Fixes
+- Fix union_relations error from [#473](https://github.com/dbt-labs/dbt-utils/pull/473) when no include/exclude parameters are provided ([#505](https://github.com/dbt-labs/dbt-utils/issues/505), [#509](https://github.com/dbt-labs/dbt-utils/pull/509))
+
 # dbt-utils v0.8.1
 
 ## New features

--- a/README.md
+++ b/README.md
@@ -310,6 +310,7 @@ models:
               to: ref('other_model_name')
               field: client_id
               from_condition: id <> '4ca448b8-24bf-4b88-96c6-b1609499c38b'
+              to_condition: created_date >= '2020-01-01'
 ```
 
 #### mutually_exclusive_ranges ([source](macros/schema_tests/mutually_exclusive_ranges.sql))

--- a/README.md
+++ b/README.md
@@ -772,7 +772,7 @@ from {{ ref('my_model') }}
 This macro unions together an array of [Relations](https://docs.getdbt.com/docs/writing-code-in-dbt/class-reference/#relation),
 even when columns have differing orders in each Relation, and/or some columns are
 missing from some relations. Any columns exclusive to a subset of these
-relations will be filled with `null` where not present. An new column
+relations will be filled with `null` where not present. A new column
 (`_dbt_source_relation`) is also added to indicate the source for each record.
 
 **Usage:**

--- a/README.md
+++ b/README.md
@@ -377,53 +377,58 @@ models:
         partition_by: customer_id
         gaps: allowed
 ```
+<details>
+<summary>Additional `gaps` and `zero_length_range_allowed` examples</summary>
 
-**Understanding the `gaps` argument:**
-Here are a number of examples for each allowed `gaps` argument.
-* `gaps: not_allowed`: The upper bound of one record must be the lower bound of
-the next record.
+  **Understanding the `gaps` argument:**
 
-| lower_bound | upper_bound |
-|-------------|-------------|
-| 0           | 1           |
-| 1           | 2           |
-| 2           | 3           |
+  Here are a number of examples for each allowed `gaps` argument.
+  * `gaps: not_allowed`: The upper bound of one record must be the lower bound of
+  the next record.
 
-* `gaps: allowed` (default): There may be a gap between the upper bound of one
-record and the lower bound of the next record.
+  | lower_bound | upper_bound |
+  |-------------|-------------|
+  | 0           | 1           |
+  | 1           | 2           |
+  | 2           | 3           |
 
-| lower_bound | upper_bound |
-|-------------|-------------|
-| 0           | 1           |
-| 2           | 3           |
-| 3           | 4           |
+  * `gaps: allowed` (default): There may be a gap between the upper bound of one
+  record and the lower bound of the next record.
 
-* `gaps: required`: There must be a gap between the upper bound of one record and
-the lower bound of the next record (common for date ranges).
+  | lower_bound | upper_bound |
+  |-------------|-------------|
+  | 0           | 1           |
+  | 2           | 3           |
+  | 3           | 4           |
 
-| lower_bound | upper_bound |
-|-------------|-------------|
-| 0           | 1           |
-| 2           | 3           |
-| 4           | 5           |
+  * `gaps: required`: There must be a gap between the upper bound of one record and
+  the lower bound of the next record (common for date ranges).
 
-**Understanding the `zero_length_range_allowed` argument:**
-Here are a number of examples for each allowed `zero_length_range_allowed` argument.
-* `zero_length_range_allowed: false`: (default) The upper bound of each record must be greater than its lower bound.
+  | lower_bound | upper_bound |
+  |-------------|-------------|
+  | 0           | 1           |
+  | 2           | 3           |
+  | 4           | 5           |
 
-| lower_bound | upper_bound |
-|-------------|-------------|
-| 0           | 1           |
-| 1           | 2           |
-| 2           | 3           |
+  **Understanding the `zero_length_range_allowed` argument:**
+  Here are a number of examples for each allowed `zero_length_range_allowed` argument.
+  * `zero_length_range_allowed: false`: (default) The upper bound of each record must be greater than its lower bound.
 
-* `zero_length_range_allowed: true`: The upper bound of each record can be greater than or equal to its lower bound.
+  | lower_bound | upper_bound |
+  |-------------|-------------|
+  | 0           | 1           |
+  | 1           | 2           |
+  | 2           | 3           |
 
-| lower_bound | upper_bound |
-|-------------|-------------|
-| 0           | 1           |
-| 2           | 2           |
-| 3           | 4           |
+  * `zero_length_range_allowed: true`: The upper bound of each record can be greater than or equal to its lower bound.
+
+  | lower_bound | upper_bound |
+  |-------------|-------------|
+  | 0           | 1           |
+  | 2           | 2           |
+  | 3           | 4           |
+
+</details>
 
 #### sequential_values ([source](macros/schema_tests/sequential_values.sql))
 This test confirms that a column contains sequential values. It can be used

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ For compatibility details between versions of dbt-core and dbt-utils, [see this 
 [Materializations](#materializations):
 - [insert_by_period](#insert_by_period-source)
 
----
+----
 ### Schema Tests
 #### equal_rowcount ([source](macros/schema_tests/equal_rowcount.sql))
 This schema test asserts the that two relations have the same number of rows.

--- a/macros/sql/get_relations_by_pattern.sql
+++ b/macros/sql/get_relations_by_pattern.sql
@@ -19,7 +19,7 @@
                 database=database,
                 schema=row.table_schema,
                 identifier=row.table_name,
-                type = row.table_type if row.table_type != ‘materialized view’  else ‘view’
+                type = row.table_type if row.table_type != 'materialized view'  else 'materializedview'
             ) -%}
             {%- do tbl_relations.append(tbl_relation) -%}
         {%- endfor -%}

--- a/macros/sql/get_relations_by_pattern.sql
+++ b/macros/sql/get_relations_by_pattern.sql
@@ -19,7 +19,7 @@
                 database=database,
                 schema=row.table_schema,
                 identifier=row.table_name,
-                type=row.table_type
+                type = row.table_type if row.table_type != ‘materialized view’  else ‘view’
             ) -%}
             {%- do tbl_relations.append(tbl_relation) -%}
         {%- endfor -%}

--- a/macros/sql/get_relations_by_pattern.sql
+++ b/macros/sql/get_relations_by_pattern.sql
@@ -19,7 +19,7 @@
                 database=database,
                 schema=row.table_schema,
                 identifier=row.table_name,
-                type = row.table_type if row.table_type != 'materialized view'  else 'materializedview'
+                type = row.table_type
             ) -%}
             {%- do tbl_relations.append(tbl_relation) -%}
         {%- endfor -%}

--- a/macros/sql/get_table_types_sql.sql
+++ b/macros/sql/get_table_types_sql.sql
@@ -8,7 +8,7 @@
                 when 'EXTERNAL TABLE' then 'external'
                 when 'MATERIALIZED VIEW' then 'materializedview'
                 else lower(table_type)
-            end as "table_type"
+            end as table_type
 {% endmacro %}
 
 

--- a/macros/sql/get_tables_by_pattern_sql.sql
+++ b/macros/sql/get_tables_by_pattern_sql.sql
@@ -30,10 +30,7 @@
             select distinct
                 table_schema,
                 table_name,
-                case table_type
-                    when 'BASE TABLE' then 'table'
-                    else lower(table_type)
-                end as table_type
+                {{ dbt_utils.get_table_types_sql() }}
 
             from {{ adapter.quote(database) }}.{{ schema }}.INFORMATION_SCHEMA.TABLES
             where lower(table_name) like lower ('{{ table_pattern }}')

--- a/macros/sql/union.sql
+++ b/macros/sql/union.sql
@@ -61,7 +61,7 @@
 
     {%- set ordered_column_names = column_superset.keys() -%}
 
-    {%- if not column_superset.keys() -%}
+    {% if (include | length > 0 or exclude | length > 0) and not column_superset.keys() %}
         {%- set relations_string -%}
             {%- for relation in relations -%}
                 {{ relation.name }}


### PR DESCRIPTION
This is a:
- [X ] bug fix PR with no breaking changes — please ensure the base branch is `main`
- [ ] new functionality — please ensure the base branch is the latest `dev/` branch
- [ ] a breaking change — please ensure the base branch is the latest `dev/` branch

## Description & motivation
<!---
I ran into an issue with the dbt codegen package where we could not generate yaml for sources due to some existing as materialized views.
-->

## Checklist
- [ X] I have verified that these changes work locally on the following warehouses (Note: it's okay if you do not have access to all warehouses, this helps us understand what has been covered)
    - [ X] BigQuery
    - [ ] Postgres
    - [ ] Redshift
    - [ ] Snowflake
- [ ] I followed guidelines to ensure that my changes will work on "non-core" adapters by:
    - [ X] dispatching any new macro(s) so non-core adapters can also use them (e.g. [the `star()` source](https://github.com/fishtown-analytics/dbt-utils/blob/master/macros/sql/star.sql))
    - [ X] using the `limit_zero()` macro in place of the literal string: `limit 0`
    - [ X] using `dbt_utils.type_*` macros instead of explicit datatypes (e.g. `dbt_utils.type_timestamp()` instead of `TIMESTAMP`
- [ X] I have updated the README.md (if applicable)
- [ X] I have added tests & descriptions to my models (and macros if applicable)
- [ X] I have added an entry to CHANGELOG.md
