### PR TITLE
Add `alias` argument to `deduplicate` macro

### DIFF
--- a/README.md
+++ b/README.md
@@ -717,7 +717,7 @@ This macro returns the sql required to remove duplicate rows from a model or sou
     relation=source('my_source', 'my_table'),
     group_by="user_id, cast(timestamp as day)",
     order_by="timestamp desc",
-    alias="my_cte"
+    relation_alias="my_cte"
    )
 }}
 ```

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ For compatibility details between versions of dbt-core and dbt-utils, [see this 
 
 - [SQL generators](#sql-generators)
     - [date_spine](#date_spine-source)
-    - [dedupe](#dedupe-source)
+    - [deduplicate](#deduplicate)
     - [haversine_distance](#haversine_distance-source)
     - [group_by](#group_by-source)
     - [star](#star-source)
@@ -716,7 +716,8 @@ This macro returns the sql required to remove duplicate rows from a model or sou
 {{ dbt_utils.deduplicate(
     relation=source('my_source', 'my_table'),
     group_by="user_id, cast(timestamp as day)",
-    order_by="timestamp desc"
+    order_by="timestamp desc",
+    alias="my_cte"
    )
 }}
 ```

--- a/integration_tests/data/sql/data_deduplicate.csv
+++ b/integration_tests/data/sql/data_deduplicate.csv
@@ -1,3 +1,4 @@
 user_id,event,version
 1,play,1
 1,play,2
+2,pause,1

--- a/integration_tests/models/sql/test_deduplicate.sql
+++ b/integration_tests/models/sql/test_deduplicate.sql
@@ -13,7 +13,7 @@ deduped as (
             ref('data_deduplicate'),
             group_by='user_id',
             order_by='version desc',
-            alias="source"
+            relation_alias="source"
         ) | indent
     }}
 

--- a/integration_tests/models/sql/test_deduplicate.sql
+++ b/integration_tests/models/sql/test_deduplicate.sql
@@ -1,6 +1,21 @@
-with deduped as (
+with
 
-    {{ dbt_utils.deduplicate(ref('data_deduplicate'), group_by='user_id', order_by='version desc') | indent }}
+source as (
+    select *
+    from {{ ref('data_deduplicate') }}
+    where user_id = 1
+),
+
+deduped as (
+
+    {{
+        dbt_utils.deduplicate(
+            ref('data_deduplicate'),
+            group_by='user_id',
+            order_by='version desc',
+            alias="source"
+        ) | indent
+    }}
 
 )
 

--- a/macros/sql/deduplicate.sql
+++ b/macros/sql/deduplicate.sql
@@ -1,8 +1,8 @@
-{%- macro deduplicate(relation, group_by, order_by=none) -%}
-    {{ return(adapter.dispatch('deduplicate', 'dbt_utils')(relation, group_by, order_by=order_by)) }}
+{%- macro deduplicate(relation, group_by, order_by=none, alias=none) -%}
+    {{ return(adapter.dispatch('deduplicate', 'dbt_utils')(relation, group_by, order_by=order_by, alias=alias)) }}
 {% endmacro %}
 
-{%- macro default__deduplicate(relation, group_by, order_by=none) -%}
+{%- macro default__deduplicate(relation, group_by, order_by=none, alias=none) -%}
 
     select
         {{ dbt_utils.star(relation, relation_alias='deduped') | indent }}
@@ -15,7 +15,7 @@
                 order by {{ order_by }}
                 {%- endif %}
             ) as rn
-        from {{ relation }} as _inner
+        from {{ relation if alias is none else alias }} as _inner
     ) as deduped
     where deduped.rn = 1
 
@@ -26,7 +26,7 @@
 --  clause in BigQuery:
 --  https://github.com/dbt-labs/dbt-utils/issues/335#issuecomment-788157572
 #}
-{%- macro bigquery__deduplicate(relation, group_by, order_by=none) -%}
+{%- macro bigquery__deduplicate(relation, group_by, order_by=none, alias=none) -%}
 
     select
         {{ dbt_utils.star(relation, relation_alias='deduped') | indent }}
@@ -39,7 +39,7 @@
                 {%- endif %}
                 limit 1
             )[offset(0)] as deduped
-        from {{ relation }} as original
+        from {{ relation if alias is none else alias }} as original
         group by {{ group_by }}
     )
 

--- a/macros/sql/deduplicate.sql
+++ b/macros/sql/deduplicate.sql
@@ -1,8 +1,8 @@
-{%- macro deduplicate(relation, group_by, order_by=none, alias=none) -%}
-    {{ return(adapter.dispatch('deduplicate', 'dbt_utils')(relation, group_by, order_by=order_by, alias=alias)) }}
+{%- macro deduplicate(relation, group_by, order_by=none, relation_alias=none) -%}
+    {{ return(adapter.dispatch('deduplicate', 'dbt_utils')(relation, group_by, order_by=order_by, relation_alias=relation_alias)) }}
 {% endmacro %}
 
-{%- macro default__deduplicate(relation, group_by, order_by=none, alias=none) -%}
+{%- macro default__deduplicate(relation, group_by, order_by=none, relation_alias=none) -%}
 
     select
         {{ dbt_utils.star(relation, relation_alias='deduped') | indent }}
@@ -15,7 +15,7 @@
                 order by {{ order_by }}
                 {%- endif %}
             ) as rn
-        from {{ relation if alias is none else alias }} as _inner
+        from {{ relation if relation_alias is none else relation_alias }} as _inner
     ) as deduped
     where deduped.rn = 1
 
@@ -26,7 +26,7 @@
 --  clause in BigQuery:
 --  https://github.com/dbt-labs/dbt-utils/issues/335#issuecomment-788157572
 #}
-{%- macro bigquery__deduplicate(relation, group_by, order_by=none, alias=none) -%}
+{%- macro bigquery__deduplicate(relation, group_by, order_by=none, relation_alias=none) -%}
 
     select
         {{ dbt_utils.star(relation, relation_alias='deduped') | indent }}
@@ -39,7 +39,7 @@
                 {%- endif %}
                 limit 1
             )[offset(0)] as deduped
-        from {{ relation if alias is none else alias }} as original
+        from {{ relation if relation_alias is none else relation_alias }} as original
         group by {{ group_by }}
     )
 


### PR DESCRIPTION
This is a:
- [ ] bug fix PR with no breaking changes — please ensure the base branch is `main`
- [x] new functionality — please ensure the base branch is the latest `dev/` branch
- [ ] a breaking change — please ensure the base branch is the latest `dev/` branch

## Description & motivation

It occurred to me that quite often one might want to first filter a model and then deduplicate it. The requirement for `deduplicate` to take a relation (in order to be able to return the correct columns) makes this difficult. By adding an `alias` argument we allow the macro to find the columns from a relation but to select from a CTE.

## Checklist
- [ ] I have verified that these changes work locally on the following warehouses (Note: it's okay if you do not have access to all warehouses, this helps us understand what has been covered)
    - [ ] BigQuery
    - [ ] Postgres
    - [ ] Redshift
    - [ ] Snowflake
- [x] I followed guidelines to ensure that my changes will work on "non-core" adapters by:
    - [x] dispatching any new macro(s) so non-core adapters can also use them (e.g. [the `star()` source](https://github.com/fishtown-analytics/dbt-utils/blob/master/macros/sql/star.sql))
    - [x] using the `limit_zero()` macro in place of the literal string: `limit 0`
    - [x] using `dbt_utils.type_*` macros instead of explicit datatypes (e.g. `dbt_utils.type_timestamp()` instead of `TIMESTAMP`
- [x] I have updated the README.md (if applicable)
- [x] I have added tests & descriptions to my models (and macros if applicable)
- [ ] I have added an entry to CHANGELOG.md
