### PR TITLE
Fail integration tests appropriately

### DIFF
--- a/run_test.sh
+++ b/run_test.sh
@@ -22,10 +22,10 @@ _seeds="--full-refresh"
 if [[ ! -z $2 ]]; then _models="--models $2"; fi
 if [[ ! -z $3 ]]; then _seeds="--select $3 --full-refresh"; fi
 
-dbt deps --target $1
-dbt seed --target $1 $_seeds
+dbt deps --target $1 || exit 1
+dbt seed --target $1 $_seeds || exit 1
 if [ $1 == 'redshift' ]; then
-    dbt run -x -m test_insert_by_period --full-refresh --target redshift
+    dbt run -x -m test_insert_by_period --full-refresh --target redshift || exit 1
 fi
-dbt run -x --target $1 $_models
-dbt test -x --target $1 $_models
+dbt run -x --target $1 $_models || exit 1
+dbt test -x --target $1 $_models || exit 1


### PR DESCRIPTION
Closes #540

This is a:
- [X] bug fix PR with no breaking changes

## Description & motivation
The integration tests passed in CircleCI even though one of the dbt steps failed. This is because the shell script only returns the final exit code -- intermediate exit codes are ignored by default. 

Several options to solve this issue are discussed [here](https://github.com/dbt-labs/dbt-utils/issues/540#issuecomment-1096720063).

Chosen option: `command || exit 1` because it is minimally invasive, low risk, and preserves our optionality in the future.

### Positive Consequences

- solves the immediate problem
- low risk
- minimally invasive and straight-forward
    - only requires adding the ` || exit 1` suffix to 5 lines of code
- preserves our optionality in the future
    - completely reversible
    - doesn't prevent us from pursuing the other ideas like dbt build, etc as the next logical steps to take
- inspiration to learn more how bash behaves

### Negative Consequences

* raises question if this solution should be advocated for every other project that uses something like a `run_test.sh` script
* harder to read for those of us not expert in bash

## Checklist
- [X] I have verified that these changes work locally on the following warehouses (Note: it's okay if you do not have access to all warehouses, this helps us understand what has been covered)
    - [ ] BigQuery
    - [ ] Postgres
    - [ ] Redshift
    - [X] Snowflake
- [ ] I followed guidelines to ensure that my changes will work on "non-core" adapters by:
    - [ ] dispatching any new macro(s) so non-core adapters can also use them (e.g. [the `star()` source](https://github.com/fishtown-analytics/dbt-utils/blob/master/macros/sql/star.sql))
    - [ ] using the `limit_zero()` macro in place of the literal string: `limit 0`
    - [ ] using `dbt_utils.type_*` macros instead of explicit datatypes (e.g. `dbt_utils.type_timestamp()` instead of `TIMESTAMP`
- [X] I have updated the README.md (if applicable)
- [X] I have added tests & descriptions to my models (and macros if applicable)
- [ ] I have added an entry to CHANGELOG.md
