### PR TITLE
Athena / Presto support for some aspects of dbt utils

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+# dbt-utils v0.8.next
+
+## Fixes
+- `get_tables_by_pattern_sql()` support of Athena / Presto adapters ([#546](https://github.com/dbt-labs/dbt-utils/issues/546))
+
+## Contributors:
+- [@SOVALINUX](https://github.com/SOVALINUX) (#546)
+
 # dbt-utils v0.8.3
 ## New features
 - A macro for deduplicating data, `deduplicate()` ([#335](https://github.com/dbt-labs/dbt-utils/issues/335), [#512](https://github.com/dbt-labs/dbt-utils/pull/512))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,11 @@
 
 ## Fixes
 - `get_tables_by_pattern_sql()` support of Athena / Presto adapters ([#546](https://github.com/dbt-labs/dbt-utils/issues/546))
+- `not_null_proportion` and `datatype numeric` support of Athena / Presto adapters ([#553] ( https://github.com/dbt-labs/dbt-utils/issues/553))
 
 ## Contributors:
-- [@SOVALINUX](https://github.com/SOVALINUX) (#546)
+- [@SOVALINUX](https://github.com/SOVALINUX) (#546, #553)
+
 
 # dbt-utils v0.8.3
 ## New features

--- a/macros/cross_db_utils/current_timestamp.sql
+++ b/macros/cross_db_utils/current_timestamp.sql
@@ -14,6 +14,14 @@
     current_timestamp
 {% endmacro %}
 
+{% macro athena__current_timestamp() %}
+    now()
+{% endmacro %}
+
+{% macro presto__current_timestamp() %}
+    now()
+{% endmacro %}
+
 
 
 {% macro current_timestamp_in_utc() -%}

--- a/macros/cross_db_utils/datatypes.sql
+++ b/macros/cross_db_utils/datatypes.sql
@@ -69,6 +69,14 @@
     numeric
 {% endmacro %}
 
+{% macro athena__type_numeric() %}
+    double
+{% endmacro %}
+
+{% macro presto__type_numeric() %}
+    double
+{% endmacro %}
+
 
 {# bigint  -------------------------------------------------     #}
 

--- a/macros/cross_db_utils/dateadd.sql
+++ b/macros/cross_db_utils/dateadd.sql
@@ -35,3 +35,23 @@
     {{ return(dbt_utils.default__dateadd(datepart, interval, from_date_or_timestamp)) }}
 
 {% endmacro %}
+
+{% macro athena__dateadd(datepart, interval, from_date_or_timestamp) %}
+
+    date_add(
+        '{{ datepart | replace("'", "") }}',
+        {{ interval }},
+        {{ from_date_or_timestamp }}
+        )
+
+{% endmacro %}
+
+{% macro presto__dateadd(datepart, interval, from_date_or_timestamp) %}
+
+    date_add(
+        '{{ datepart | replace("'", "") }}',
+        {{ interval }},
+        {{ from_date_or_timestamp }}
+        )
+
+{% endmacro %}

--- a/macros/generic_tests/not_null_proportion.sql
+++ b/macros/generic_tests/not_null_proportion.sql
@@ -24,3 +24,50 @@ select
 from validation_errors
 
 {% endmacro %}
+
+{% macro athena__test_not_null_proportion(model) %}
+
+{% set column_name = kwargs.get('column_name', kwargs.get('arg')) %}
+{% set at_least = kwargs.get('at_least', kwargs.get('arg')) %}
+{% set at_most = kwargs.get('at_most', kwargs.get('arg', 1)) %}
+
+with validation as (
+  select
+    sum(case when {{ column_name }} is null then 0 else 1 end) / cast(count(*) as double) as not_null_proportion
+  from {{ model }}
+),
+validation_errors as (
+  select
+    not_null_proportion
+  from validation
+  where not_null_proportion < {{ at_least }} or not_null_proportion > {{ at_most }}
+)
+select
+  *
+from validation_errors
+
+{% endmacro %}
+
+{% macro presto__test_not_null_proportion(model) %}
+
+{% set column_name = kwargs.get('column_name', kwargs.get('arg')) %}
+{% set at_least = kwargs.get('at_least', kwargs.get('arg')) %}
+{% set at_most = kwargs.get('at_most', kwargs.get('arg', 1)) %}
+
+with validation as (
+  select
+    sum(case when {{ column_name }} is null then 0 else 1 end) / cast(count(*) as double) as not_null_proportion
+  from {{ model }}
+),
+validation_errors as (
+  select
+    not_null_proportion
+  from validation
+  where not_null_proportion < {{ at_least }} or not_null_proportion > {{ at_most }}
+)
+select
+  *
+from validation_errors
+
+{% endmacro %}
+

--- a/macros/generic_tests/not_null_proportion.sql
+++ b/macros/generic_tests/not_null_proportion.sql
@@ -10,53 +10,7 @@
 
 with validation as (
   select
-    sum(case when {{ column_name }} is null then 0 else 1 end) / cast(count(*) as numeric) as not_null_proportion
-  from {{ model }}
-),
-validation_errors as (
-  select
-    not_null_proportion
-  from validation
-  where not_null_proportion < {{ at_least }} or not_null_proportion > {{ at_most }}
-)
-select
-  *
-from validation_errors
-
-{% endmacro %}
-
-{% macro athena__test_not_null_proportion(model) %}
-
-{% set column_name = kwargs.get('column_name', kwargs.get('arg')) %}
-{% set at_least = kwargs.get('at_least', kwargs.get('arg')) %}
-{% set at_most = kwargs.get('at_most', kwargs.get('arg', 1)) %}
-
-with validation as (
-  select
-    sum(case when {{ column_name }} is null then 0 else 1 end) / cast(count(*) as double) as not_null_proportion
-  from {{ model }}
-),
-validation_errors as (
-  select
-    not_null_proportion
-  from validation
-  where not_null_proportion < {{ at_least }} or not_null_proportion > {{ at_most }}
-)
-select
-  *
-from validation_errors
-
-{% endmacro %}
-
-{% macro presto__test_not_null_proportion(model) %}
-
-{% set column_name = kwargs.get('column_name', kwargs.get('arg')) %}
-{% set at_least = kwargs.get('at_least', kwargs.get('arg')) %}
-{% set at_most = kwargs.get('at_most', kwargs.get('arg', 1)) %}
-
-with validation as (
-  select
-    sum(case when {{ column_name }} is null then 0 else 1 end) / cast(count(*) as double) as not_null_proportion
+    sum(case when {{ column_name }} is null then 0 else 1 end) / {{ dbt_utils.safe_cast('count(*)', dbt_utils.type_numeric() ) }} as not_null_proportion
   from {{ model }}
 ),
 validation_errors as (

--- a/macros/sql/get_tables_by_pattern_sql.sql
+++ b/macros/sql/get_tables_by_pattern_sql.sql
@@ -16,6 +16,39 @@
 
 {% endmacro %}
 
+{% macro athena__get_tables_by_pattern_sql(schema_pattern, table_pattern, exclude='', database=target.database) %}
+
+{% set table_schema_like_str = "regexp_like({}, '(?i)\\A{}\\Z')".format("table_schema", schema_pattern) %}
+{% set table_name_like_str = "regexp_like({}, '(?i)\\A{}\\Z')".format("table_name", table_pattern) %}
+{% set table_name_not_like_str = "not regexp_like({}, '(?i)\\A{}\\Z')".format("table_name", exclude) %}
+
+        select distinct
+            table_schema as "table_schema",
+            table_name as "table_name",
+            {{ dbt_utils.get_table_types_sql() }}
+        from {{ database }}.information_schema.tables
+        where {{ table_schema_like_str }}
+        and {{ table_name_like_str }}
+        and {{ table_name_not_like_str }}
+
+{% endmacro %}
+
+{% macro presto__get_tables_by_pattern_sql(schema_pattern, table_pattern, exclude='', database=target.database) %}
+
+{% set table_schema_like_str = "regexp_like({}, '(?i)\\A{}\\Z')".format("table_schema", schema_pattern) %}
+{% set table_name_like_str = "regexp_like({}, '(?i)\\A{}\\Z')".format("table_name", table_pattern) %}
+{% set table_name_not_like_str = "not regexp_like({}, '(?i)\\A{}\\Z')".format("table_name", exclude) %}
+
+        select distinct
+            table_schema as "table_schema",
+            table_name as "table_name",
+            {{ dbt_utils.get_table_types_sql() }}
+        from {{ database }}.information_schema.tables
+        where {{ table_schema_like_str }}
+        and {{ table_name_like_str }}
+        and {{ table_name_not_like_str }}
+
+{% endmacro %}
 
 {% macro bigquery__get_tables_by_pattern_sql(schema_pattern, table_pattern, exclude='', database=target.database) %}
 


### PR DESCRIPTION
This is a:
- [x] bug fix PR with no breaking changes

## Description & motivation
Currently I'm using `dbt-unit-testing` package to run unit tests and this package uses dbt-utils
My connector is Athena (Presto-based) and Athena/Presto doesn't support `ilike` operator - it has to be changed to more explicit regexp
Another issue is in `not_null_proportion` generic test due to type `numeric` what is not supported in Athena / Presto

## Checklist
- [x] I have verified that these changes work locally on the following warehouses (Note: it's okay if you do not have access to all warehouses, this helps us understand what has been covered)
    - [ ] BigQuery
    - [ ] Postgres
    - [ ] Redshift
    - [ ] Snowflake
    - [x] Athena
- [ ] I followed guidelines to ensure that my changes will work on "non-core" adapters by:
    - [x] dispatching any new macro(s) so non-core adapters can also use them (e.g. [the `star()` source](https://github.com/fishtown-analytics/dbt-utils/blob/master/macros/sql/star.sql))
- [ ] I have updated the README.md (if applicable)
- [ ] I have added tests & descriptions to my models (and macros if applicable)
- [x] I have added an entry to CHANGELOG.md
