### PR TITLE
Refactor `deduplicate()` arguments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,32 @@
 # Unreleased
+
+## 🚨 deduplicate ([#542](https://github.com/dbt-labs/dbt-utils/pull/542), [#548](https://github.com/dbt-labs/dbt-utils/pull/548))
+
+The call signature of `deduplicate` has changed. The previous call signature is marked as deprecated and will be removed in the next minor version.
+
+- The `group_by` argument is now deprecated and replaced by `partition_by`.
+- The `order_by` argument is now required.
+- The `relation_alias` argument has been removed as the macro now supports `relation` as a string directly. If you were using `relation_alias` to point to a CTE previously then you can now pass the alias directly to `relation`.
+
+Before:
+```jinja
+{% macro deduplicate(relation, group_by, order_by=none, relation_alias=none) -%}
+...
+{% endmacro %}
+```
+
+After:
+```jinja
+{% macro deduplicate(relation, partition_by, order_by) -%}
+...
+{% endmacro %}
+```
+
 ## New features
-- Add an optional `where` clause parameter to `get_column_values()` to filter values returned ([#511](https://github.com/dbt-labs/dbt-utils/issues/511), [#583](https://github.com/dbt-labs/dbt-utils/pull/583)) 
+- Add an optional `where` clause parameter to `get_column_values()` to filter values returned ([#511](https://github.com/dbt-labs/dbt-utils/issues/511), [#583](https://github.com/dbt-labs/dbt-utils/pull/583))
 - Add `where` parameter to `union_relations` macro ([#554](https://github.com/dbt-labs/dbt-utils/pull/554))
+- Add Postgres specific implementation of `deduplicate()` ([#548](https://github.com/dbt-labs/dbt-utils/pull/548))
+- Add Snowflake specific implementation of `deduplicate()` ([#543](https://github.com/dbt-labs/dbt-utils/issues/543), [#548](https://github.com/dbt-labs/dbt-utils/pull/548))
 
 ## Fixes
 - Enable a negative part_number for `split_part()` ([#557](https://github.com/dbt-labs/dbt-utils/issues/557), [#559](https://github.com/dbt-labs/dbt-utils/pull/559))
@@ -10,6 +35,7 @@
 - Documentation about listagg macro ([#544](https://github.com/dbt-labs/dbt-utils/issues/544), [#560](https://github.com/dbt-labs/dbt-utils/pull/560))
 - Fix links to macro section in table of contents ([#555](https://github.com/dbt-labs/dbt-utils/pull/555))
 - Contributing guide ([#574](https://github.com/dbt-labs/dbt-utils/pull/574))
+- Add better documentation for `deduplicate()` ([#542](https://github.com/dbt-labs/dbt-utils/pull/542), [#548](https://github.com/dbt-labs/dbt-utils/pull/548))
 
 ## Under the hood
 - Fail integration tests appropriately ([#540](https://github.com/dbt-labs/dbt-utils/issues/540), [#545](https://github.com/dbt-labs/dbt-utils/pull/545))
@@ -34,7 +60,7 @@
 
 ## Fixes
 - `get_column_values()` once more raises an error when the model doesn't exist and there is no default provided ([#531](https://github.com/dbt-labs/dbt-utils/issues/531), [#533](https://github.com/dbt-labs/dbt-utils/pull/533))
-- `get_column_values()` raises an error when used with an ephemeral model, instead of getting stuck in a compilation loop ([#358](https://github.com/dbt-labs/dbt-utils/issues/358), [#518](https://github.com/dbt-labs/dbt-utils/pull/518)) 
+- `get_column_values()` raises an error when used with an ephemeral model, instead of getting stuck in a compilation loop ([#358](https://github.com/dbt-labs/dbt-utils/issues/358), [#518](https://github.com/dbt-labs/dbt-utils/pull/518))
 - BigQuery materialized views work correctly with `get_relations_by_pattern()` ([#525](https://github.com/dbt-labs/dbt-utils/pull/525))
 
 ## Quality of life

--- a/README.md
+++ b/README.md
@@ -740,7 +740,7 @@ This macro returns the sql required to remove duplicate rows from a model, sourc
 
 **Args:**
  - `relation` (required): a [Relation](https://docs.getdbt.com/reference/dbt-classes#relation) (a `ref` or `source`) or string which identifies the model to deduplicate.
- - `group_by` (required): column names (or expressions) to use to identify a set/window of rows out of which to select one as the deduplicated row.
+ - `partition_by` (required): column names (or expressions) to use to identify a set/window of rows out of which to select one as the deduplicated row.
  - `order_by` (required): column names (or expressions) that determine the priority order of which row should be chosen if there are duplicates (comma-separated string).
 
 **Usage:**

--- a/README.md
+++ b/README.md
@@ -736,13 +736,12 @@ This macro returns the sql required to build a date spine. The spine will includ
 ```
 
 #### deduplicate ([source](macros/sql/deduplicate.sql))
-This macro returns the sql required to remove duplicate rows from a model or source.
+This macro returns the sql required to remove duplicate rows from a model, source, or CTE.
 
 **Args:**
  - `relation` (required): a [Relation](https://docs.getdbt.com/reference/dbt-classes#relation) (a `ref` or `source`) or string which identifies the model to deduplicate.
  - `group_by` (required): column names (or expressions) to use to identify a set/window of rows out of which to select one as the deduplicated row.
- - `order_by` (optional, default=none): column names (or expressions) that determine the priority order of which row should be chosen if there are duplicates (comma-separated string).
- - `relation_alias` (optional, default=none): DEPRECATED - string to select from which references a `ref`, `source` or CTE which contains the same columns as `relation`.
+ - `order_by` (required): column names (or expressions) that determine the priority order of which row should be chosen if there are duplicates (comma-separated string).
 
 **Usage:**
 
@@ -751,7 +750,6 @@ This macro returns the sql required to remove duplicate rows from a model or sou
     relation=source('my_source', 'my_table'),
     group_by="user_id, cast(timestamp as day)",
     order_by="timestamp desc",
-    relation_alias="my_cte"
    )
 }}
 ```

--- a/README.md
+++ b/README.md
@@ -738,6 +738,12 @@ This macro returns the sql required to build a date spine. The spine will includ
 #### deduplicate ([source](macros/sql/deduplicate.sql))
 This macro returns the sql required to remove duplicate rows from a model or source.
 
+**Args:**
+ - `relation` (required): a [Relation](https://docs.getdbt.com/reference/dbt-classes#relation) (a `ref` or `source`) or string which identifies the model to deduplicate.
+ - `group_by` (required): column names (or expressions) to use to identify a set/window of rows out of which to select one as the deduplicated row.
+ - `order_by` (optional, default=none): column names (or expressions) that determine the priority order of which row should be chosen if there are duplicates (comma-separated string).
+ - `relation_alias` (optional, default=none): DEPRECATED - string to select from which references a `ref`, `source` or CTE which contains the same columns as `relation`.
+
 **Usage:**
 
 ```
@@ -746,6 +752,21 @@ This macro returns the sql required to remove duplicate rows from a model or sou
     group_by="user_id, cast(timestamp as day)",
     order_by="timestamp desc",
     relation_alias="my_cte"
+   )
+}}
+```
+
+```
+with my_cte as (
+    select *
+    from {{ source('my_source', 'my_table') }}
+    where user_id = 1
+)
+
+{{ dbt_utils.deduplicate(
+    relation='my_cte',
+    group_by="user_id, cast(timestamp as day)",
+    order_by="timestamp desc",
    )
 }}
 ```

--- a/README.md
+++ b/README.md
@@ -748,8 +748,17 @@ This macro returns the sql required to remove duplicate rows from a model, sourc
 ```
 {{ dbt_utils.deduplicate(
     relation=source('my_source', 'my_table'),
-    group_by="user_id, cast(timestamp as day)",
+    partition_by='user_id, cast(timestamp as day)',
     order_by="timestamp desc",
+   )
+}}
+```
+
+```
+{{ dbt_utils.deduplicate(
+    relation=ref('my_model'),
+    partition_by='user_id',
+    order_by='effective_date desc, effective_sequence desc',
    )
 }}
 ```
@@ -763,8 +772,8 @@ with my_cte as (
 
 {{ dbt_utils.deduplicate(
     relation='my_cte',
-    group_by="user_id, cast(timestamp as day)",
-    order_by="timestamp desc",
+    partition_by='user_id, cast(timestamp as day)',
+    order_by='timestamp desc',
    )
 }}
 ```

--- a/README.md
+++ b/README.md
@@ -741,7 +741,7 @@ This macro returns the sql required to remove duplicate rows from a model, sourc
 **Args:**
  - `relation` (required): a [Relation](https://docs.getdbt.com/reference/dbt-classes#relation) (a `ref` or `source`) or string which identifies the model to deduplicate.
  - `partition_by` (required): column names (or expressions) to use to identify a set/window of rows out of which to select one as the deduplicated row.
- - `order_by` (required): column names (or expressions) that determine the priority order of which row should be chosen if there are duplicates (comma-separated string).
+ - `order_by` (required): column names (or expressions) that determine the priority order of which row should be chosen if there are duplicates (comma-separated string). *NB.* if this order by clause results in ties then which row is returned may be nondeterministic across runs.
 
 **Usage:**
 

--- a/integration_tests/models/sql/schema.yml
+++ b/integration_tests/models/sql/schema.yml
@@ -172,3 +172,8 @@ models:
     tests:
       - dbt_utils.equality:
           compare_model: ref('data_deduplicate_expected')
+
+  - name: test_deduplicate_deprecated
+    tests:
+      - dbt_utils.equality:
+          compare_model: ref('data_deduplicate_expected')

--- a/integration_tests/models/sql/test_deduplicate.sql
+++ b/integration_tests/models/sql/test_deduplicate.sql
@@ -11,7 +11,7 @@ deduped as (
     {{
         dbt_utils.deduplicate(
             'source',
-            group_by='user_id',
+            partition_by='user_id',
             order_by='version desc',
         ) | indent
     }}

--- a/integration_tests/models/sql/test_deduplicate.sql
+++ b/integration_tests/models/sql/test_deduplicate.sql
@@ -10,10 +10,9 @@ deduped as (
 
     {{
         dbt_utils.deduplicate(
-            ref('data_deduplicate'),
+            'source',
             group_by='user_id',
             order_by='version desc',
-            relation_alias="source"
         ) | indent
     }}
 

--- a/integration_tests/models/sql/test_deduplicate_deprecated.sql
+++ b/integration_tests/models/sql/test_deduplicate_deprecated.sql
@@ -1,0 +1,22 @@
+with
+
+source as (
+    select *
+    from {{ ref('data_deduplicate') }}
+    where user_id = 1
+),
+
+deduped as (
+
+    {{
+        dbt_utils.deduplicate(
+            ref('data_deduplicate'),
+            group_by='user_id',
+            order_by='version desc',
+            relation_alias='source',
+        ) | indent
+    }}
+
+)
+
+select * from deduped

--- a/macros/sql/deduplicate.sql
+++ b/macros/sql/deduplicate.sql
@@ -1,19 +1,17 @@
-{%- macro deduplicate(relation, group_by, order_by=none, relation_alias=none) -%}
-    {{ return(adapter.dispatch('deduplicate', 'dbt_utils')(relation, group_by, order_by=order_by, relation_alias=relation_alias)) }}
+{%- macro deduplicate(relation, group_by, order_by) -%}
+    {{ return(adapter.dispatch('deduplicate', 'dbt_utils')(relation, group_by, order_by=order_by)) }}
 {% endmacro %}
 
-{%- macro default__deduplicate(relation, group_by, order_by=none, relation_alias=none) -%}
+{%- macro default__deduplicate(relation, group_by, order_by) -%}
 
     with row_numbered as (
         select
             _inner.*,
             row_number() over (
                 partition by {{ group_by }}
-                {% if order_by is not none -%}
                 order by {{ order_by }}
-                {%- endif %}
             ) as rn
-        from {{ relation if relation_alias is none else relation_alias }} as _inner
+        from {{ relation }} as _inner
     )
 
     select
@@ -32,9 +30,9 @@
 {%- endmacro -%}
 
 {# Redshift should use default instead of Postgres #}
-{% macro redshift__deduplicate(relation, group_by, order_by=none, relation_alias=none) -%}
+{% macro redshift__deduplicate(relation, group_by, order_by) -%}
 
-    {{ return(dbt_utils.default__deduplicate(relation, group_by, order_by=order_by, relation_alias=relation_alias)) }}
+    {{ return(dbt_utils.default__deduplicate(relation, group_by, order_by=order_by)) }}
 
 {% endmacro %}
 
@@ -42,12 +40,12 @@
 -- Postgres has the `DISTINCT ON` syntax:
 -- https://www.postgresql.org/docs/current/sql-select.html#SQL-DISTINCT
 #}
-{%- macro postgres__deduplicate(relation, group_by, order_by=none, relation_alias=none) -%}
+{%- macro postgres__deduplicate(relation, group_by, order_by) -%}
 
     select
         distinct on ({{ group_by }}) *
-    from {{ relation if relation_alias is none else relation_alias }}
-    order by {{ group_by }}{{ ',' ~ order_by if order_by is not none else '' }}
+    from {{ relation }}
+    order by {{ group_by }}{{ ',' ~ order_by }}
 
 {%- endmacro -%}
 
@@ -55,16 +53,14 @@
 -- Snowflake has the `QUALIFY` syntax:
 -- https://docs.snowflake.com/en/sql-reference/constructs/qualify.html
 #}
-{%- macro snowflake__deduplicate(relation, group_by, order_by=none, relation_alias=none) -%}
+{%- macro snowflake__deduplicate(relation, group_by, order_by) -%}
 
     select *
-    from {{ relation if relation_alias is none else relation_alias }}
+    from {{ relation }}
     qualify
         row_number() over (
             partition by {{ group_by }}
-            {% if order_by is not none -%}
             order by {{ order_by }}
-            {%- endif %}
         ) = 1
 
 {%- endmacro -%}
@@ -74,17 +70,15 @@
 --  clause in BigQuery:
 --  https://github.com/dbt-labs/dbt-utils/issues/335#issuecomment-788157572
 #}
-{%- macro bigquery__deduplicate(relation, group_by, order_by=none, relation_alias=none) -%}
+{%- macro bigquery__deduplicate(relation, group_by, order_by) -%}
 
     select
         array_agg (
             original
-            {% if order_by is not none -%}
             order by {{ order_by }}
-            {%- endif %}
             limit 1
         )[offset(0)].*
-    from {{ relation if relation_alias is none else relation_alias }} as original
+    from {{ relation }} as original
     group by {{ group_by }}
 
 {%- endmacro -%}

--- a/macros/sql/deduplicate.sql
+++ b/macros/sql/deduplicate.sql
@@ -17,18 +17,16 @@
     )
 
     select
-        data.*
+        distinct data.*
     from {{ relation }} as data
-    join row_numbered using (
-        {{ group_by }}
-        {% for expression in order_by.split(',') %}
-        {% if expression.lower().endswith(' asc') or expression.lower().endswith(' desc') %}
-            {{ ',' ~ expression.rsplit(' ', 1)[0] }}
-        {% else %}
-            {{ ',' ~ expression }}
-        {% endif %}
-        {% endfor %}
-    )
+    {#
+    -- Not all DBs will support natural joins but the ones that do include:
+    -- Oracle, MySQL, SQLite, Redshift, Teradata, Materialize, Databricks
+    -- Apache Spark, SingleStore, Vertica
+    -- Those that do not appear to support natural joins include:
+    -- SQLServer, Trino, Presto, Rockset, Athena
+    #}
+    natural join row_numbered
     where row_numbered.rn = 1
 
 {%- endmacro -%}

--- a/macros/sql/deduplicate.sql
+++ b/macros/sql/deduplicate.sql
@@ -35,6 +35,24 @@
 {%- endmacro -%}
 
 {#
+-- Snowflake has the `QUALIFY` syntax:
+-- https://docs.snowflake.com/en/sql-reference/constructs/qualify.html
+#}
+{%- macro snowflake__deduplicate(relation, group_by, order_by=none, relation_alias=none) -%}
+
+    select *
+    from {{ relation if relation_alias is none else relation_alias }}
+    qualify
+        row_number() over (
+            partition by {{ group_by }}
+            {% if order_by is not none -%}
+            order by {{ order_by }}
+            {%- endif %}
+        ) = 1
+
+{%- endmacro -%}
+
+{#
 --  It is more performant to deduplicate using `array_agg` with a limit
 --  clause in BigQuery:
 --  https://github.com/dbt-labs/dbt-utils/issues/335#issuecomment-788157572

--- a/macros/sql/deduplicate.sql
+++ b/macros/sql/deduplicate.sql
@@ -107,13 +107,16 @@ The {{ model.package_name }}.{{ model.name }} model triggered this warning.
 #}
 {%- macro bigquery__deduplicate(relation, partition_by, order_by) -%}
 
-    select
-        array_agg (
-            original
-            order by {{ order_by }}
-            limit 1
-        )[offset(0)].*
-    from {{ relation }} as original
-    group by {{ partition_by }}
+    select unique.*
+    from (
+        select
+            array_agg (
+                original
+                order by {{ order_by }}
+                limit 1
+            )[offset(0)] unique
+        from {{ relation }} original
+        group by {{ partition_by }}
+    )
 
 {%- endmacro -%}

--- a/macros/sql/deduplicate.sql
+++ b/macros/sql/deduplicate.sql
@@ -1,5 +1,40 @@
-{%- macro deduplicate(relation, partition_by, order_by) -%}
-    {{ return(adapter.dispatch('deduplicate', 'dbt_utils')(relation, partition_by, order_by=order_by)) }}
+{%- macro deduplicate(relation, partition_by, order_by=none, relation_alias=none) -%}
+
+    {%- set error_message_group_by -%}
+Warning: the `group_by` parameter of the `deduplicate` macro is no longer supported and will be deprecated in a future release of dbt-utils.
+Use `partition_by` instead.
+The {{ model.package_name }}.{{ model.name }} model triggered this warning.
+    {%- endset -%}
+
+    {% if kwargs.get('group_by') %}
+    {%- do exceptions.warn(error_message_group_by) -%}
+    {%- endif -%}
+
+    {%- set error_message_order_by -%}
+Warning: `order_by` as an optional parameter of the `deduplicate` macro is no longer supported and will be deprecated in a future release of dbt-utils.
+Supply a non-null value for `order_by` instead.
+The {{ model.package_name }}.{{ model.name }} model triggered this warning.
+    {%- endset -%}
+
+    {% if not order_by %}
+    {%- do exceptions.warn(error_message_order_by) -%}
+    {%- endif -%}
+
+    {%- set error_message_alias -%}
+Warning: the `relation_alias` parameter of the `deduplicate` macro is no longer supported and will be deprecated in a future release of dbt-utils.
+If you were using `relation_alias` to point to a CTE previously then you can now pass the alias directly to `relation` instead.
+The {{ model.package_name }}.{{ model.name }} model triggered this warning.
+    {%- endset -%}
+
+    {% if relation_alias %}
+    {%- do exceptions.warn(error_message_alias) -%}
+    {%- endif -%}
+
+    {% set partition_by = partition_by or kwargs.get('group_by') %}
+    {% set relation = relation_alias or relation %}
+    {% set order_by = order_by or "'1'" %}
+
+    {{ return(adapter.dispatch('deduplicate', 'dbt_utils')(relation, partition_by, order_by)) }}
 {% endmacro %}
 
 {%- macro default__deduplicate(relation, partition_by, order_by) -%}

--- a/macros/sql/deduplicate.sql
+++ b/macros/sql/deduplicate.sql
@@ -22,6 +22,19 @@
 {%- endmacro -%}
 
 {#
+-- Postgres has the `DISTINCT ON` syntax:
+-- https://www.postgresql.org/docs/current/sql-select.html#SQL-DISTINCT
+#}
+{%- macro postgres__deduplicate(relation, group_by, order_by=none, relation_alias=none) -%}
+
+    select
+        distinct on ({{ group_by }}) *
+    from {{ relation if relation_alias is none else relation_alias }}
+    order by {{ group_by }}{{ ',' ~ order_by if order_by is not none else '' }}
+
+{%- endmacro -%}
+
+{#
 --  It is more performant to deduplicate using `array_agg` with a limit
 --  clause in BigQuery:
 --  https://github.com/dbt-labs/dbt-utils/issues/335#issuecomment-788157572

--- a/macros/sql/deduplicate.sql
+++ b/macros/sql/deduplicate.sql
@@ -33,6 +33,13 @@
 
 {%- endmacro -%}
 
+{# Redshift should use default instead of Postgres #}
+{% macro redshift__deduplicate(relation, group_by, order_by=none, relation_alias=none) -%}
+
+    {{ return(dbt_utils.default__deduplicate(relation, group_by, order_by=order_by, relation_alias=relation_alias)) }}
+
+{% endmacro %}
+
 {#
 -- Postgres has the `DISTINCT ON` syntax:
 -- https://www.postgresql.org/docs/current/sql-select.html#SQL-DISTINCT

--- a/macros/sql/deduplicate.sql
+++ b/macros/sql/deduplicate.sql
@@ -60,18 +60,14 @@
 {%- macro bigquery__deduplicate(relation, group_by, order_by=none, relation_alias=none) -%}
 
     select
-        {{ dbt_utils.star(relation, relation_alias='deduped') | indent }}
-    from (
-        select
-            array_agg (
-                original
-                {% if order_by is not none -%}
-                order by {{ order_by }}
-                {%- endif %}
-                limit 1
-            )[offset(0)] as deduped
-        from {{ relation if relation_alias is none else relation_alias }} as original
-        group by {{ group_by }}
-    )
+        array_agg (
+            original
+            {% if order_by is not none -%}
+            order by {{ order_by }}
+            {%- endif %}
+            limit 1
+        )[offset(0)].*
+    from {{ relation if relation_alias is none else relation_alias }} as original
+    group by {{ group_by }}
 
 {%- endmacro -%}


### PR DESCRIPTION
This is a:
- [ ] bug fix PR with no breaking changes — please ensure the base branch is `main`
- [ ] new functionality — please ensure the base branch is the latest `dev/` branch
- [ ] a breaking change — please ensure the base branch is the latest `dev/` branch

## Description & motivation
<!---
Describe your changes, and why you're making them.
-->
This Pull Request aims to improve the `deduplicate` macro based on community feedback from its first release. It is stacked on top of #549 and introduces breaking changes.

- #542 discusses argument naming as well as how to improve the documentation.
- #542 also raises the issue that the usage of `relation_alias` to reference CTEs is confusing. This prompted me to investigate whether this is really needed - it was only needed due to the use of `dbt_utils.star` which can be avoided by using a `natural join` which is supported by most SQL syntaxes.

## Checklist
- [x] I have verified that these changes work locally on the following warehouses (Note: it's okay if you do not have access to all warehouses, this helps us understand what has been covered)
    - [x] BigQuery
    - [x] Postgres
    - [x] Redshift
    - [x] Snowflake
- [x] I followed guidelines to ensure that my changes will work on "non-core" adapters by:
    - [x] dispatching any new macro(s) so non-core adapters can also use them (e.g. [the `star()` source](https://github.com/fishtown-analytics/dbt-utils/blob/master/macros/sql/star.sql))
    - [x] using the `limit_zero()` macro in place of the literal string: `limit 0`
    - [x] using `dbt_utils.type_*` macros instead of explicit datatypes (e.g. `dbt_utils.type_timestamp()` instead of `TIMESTAMP`
- [x] I have updated the README.md (if applicable)
- [x] I have added tests & descriptions to my models (and macros if applicable)
- [x] I have added an entry to CHANGELOG.md
