### PR TITLE
Add SQLServer specific implementation of `deduplicate()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ Before:
 After:
 ```jinja
 {% macro deduplicate(relation, partition_by, order_by) -%}
-...
+...d
 {% endmacro %}
 ```
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ After:
 - Add `where` parameter to `union_relations` macro ([#554](https://github.com/dbt-labs/dbt-utils/pull/554))
 - Add Postgres specific implementation of `deduplicate()` ([#548](https://github.com/dbt-labs/dbt-utils/pull/548))
 - Add Snowflake specific implementation of `deduplicate()` ([#543](https://github.com/dbt-labs/dbt-utils/issues/543), [#548](https://github.com/dbt-labs/dbt-utils/pull/548))
+- Add SQLServer specific implementation of `deduplicate()` ([#550](https://github.com/dbt-labs/dbt-utils/pull/550))
 
 ## Fixes
 - Enable a negative part_number for `split_part()` ([#557](https://github.com/dbt-labs/dbt-utils/issues/557), [#559](https://github.com/dbt-labs/dbt-utils/pull/559))

--- a/macros/sql/deduplicate.sql
+++ b/macros/sql/deduplicate.sql
@@ -120,3 +120,19 @@ The {{ model.package_name }}.{{ model.name }} model triggered this warning.
     )
 
 {%- endmacro -%}
+
+{#
+-- This seems to be the best way to do the deduplication in TSQL without introducing
+-- a new column for the row number.
+#}
+{%- macro sqlserver__deduplicate(relation, partition_by, order_by) -%}
+
+    select top 1 with ties
+        *
+    from {{ relation }}
+    order by row_number() over (
+        partition by {{ partition_by }}
+        order by {{ order_by }}
+    )
+
+{%- endmacro -%}


### PR DESCRIPTION
This is a:
- [ ] bug fix PR with no breaking changes — please ensure the base branch is `main`
- [x] new functionality — please ensure the base branch is the latest `dev/` branch
- [ ] a breaking change — please ensure the base branch is the latest `dev/` branch

## Description & motivation
<!---
Describe your changes, and why you're making them.
-->

This seems like the best way to do this in TSQL without introducing a new column or relying on `dbt_utils.star`.

## Checklist
- [ ] I have verified that these changes work locally on the following warehouses (Note: it's okay if you do not have access to all warehouses, this helps us understand what has been covered)
    - [ ] BigQuery
    - [ ] Postgres
    - [ ] Redshift
    - [ ] Snowflake
- [ ] I followed guidelines to ensure that my changes will work on "non-core" adapters by:
    - [ ] dispatching any new macro(s) so non-core adapters can also use them (e.g. [the `star()` source](https://github.com/fishtown-analytics/dbt-utils/blob/master/macros/sql/star.sql))
    - [ ] using the `limit_zero()` macro in place of the literal string: `limit 0`
    - [ ] using `dbt_utils.type_*` macros instead of explicit datatypes (e.g. `dbt_utils.type_timestamp()` instead of `TIMESTAMP`
- [ ] I have updated the README.md (if applicable)
- [ ] I have added tests & descriptions to my models (and macros if applicable)
- [ ] I have added an entry to CHANGELOG.md
