### PR TITLE
Add `where` parameter to `union_relations`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+## New features
+- Add `where` parameter to `union_relations` macro ([#554](https://github.com/dbt-labs/dbt-utils/pull/554))
 ## Quality of life
 - Documentation about listagg macro ([#544](https://github.com/dbt-labs/dbt-utils/issues/544), [#560](https://github.com/dbt-labs/dbt-utils/pull/560))
 - Fix links to macro section in table of contents ([#555](https://github.com/dbt-labs/dbt-utils/pull/555))

--- a/README.md
+++ b/README.md
@@ -853,6 +853,7 @@ final query. Note the `include` and `exclude` arguments are mutually exclusive.
 e.g. `{"some_field": "varchar(100)"}`.``
 * `source_column_name` (optional, `default="_dbt_source_relation"`): The name of
 the column that records the source of this row.
+* `where` (optional): Filter conditions to include in the `where` clause.
 
 #### generate_series ([source](macros/sql/generate_series.sql))
 This macro implements a cross-database mechanism to generate an arbitrarily long list of numbers. Specify the maximum number you'd like in your list and it will create a 1-indexed SQL result set.

--- a/integration_tests/models/sql/schema.yml
+++ b/integration_tests/models/sql/schema.yml
@@ -148,6 +148,16 @@ models:
       - dbt_utils.equality:
           compare_model: ref('data_union_expected')
 
+  - name: test_union_where
+    columns:
+      - name: id
+        tests:
+          - dbt_utils.expression_is_true:
+              expression: "= 1"
+      - name: favorite_number
+        tests:
+          - dbt_utils.not_constant
+
   - name: test_get_relations_by_pattern
     tests:
       - dbt_utils.equality:

--- a/integration_tests/models/sql/test_union_where.sql
+++ b/integration_tests/models/sql/test_union_where.sql
@@ -1,0 +1,5 @@
+select 
+    id, 
+    favorite_number
+from 
+    {{ ref('test_union_where_base') }}

--- a/integration_tests/models/sql/test_union_where_base.sql
+++ b/integration_tests/models/sql/test_union_where_base.sql
@@ -1,0 +1,4 @@
+{{ dbt_utils.union_relations(
+    [ref('data_union_table_1'), ref('data_union_table_2')],
+    where="id = 1"
+) }}

--- a/macros/sql/union.sql
+++ b/macros/sql/union.sql
@@ -1,8 +1,8 @@
-{%- macro union_relations(relations, column_override=none, include=[], exclude=[], source_column_name='_dbt_source_relation') -%}
-    {{ return(adapter.dispatch('union_relations', 'dbt_utils')(relations, column_override, include, exclude, source_column_name)) }}
+{%- macro union_relations(relations, column_override=none, include=[], exclude=[], source_column_name='_dbt_source_relation', where=none) -%}
+    {{ return(adapter.dispatch('union_relations', 'dbt_utils')(relations, column_override, include, exclude, source_column_name, where)) }}
 {% endmacro %}
 
-{%- macro default__union_relations(relations, column_override=none, include=[], exclude=[], source_column_name='_dbt_source_relation') -%}
+{%- macro default__union_relations(relations, column_override=none, include=[], exclude=[], source_column_name='_dbt_source_relation', where=none) -%}
 
     {%- if exclude and include -%}
         {{ exceptions.raise_compiler_error("Both an exclude and include list were provided to the `union` macro. Only one is allowed") }}
@@ -92,6 +92,10 @@
                 {%- endfor %}
 
             from {{ relation }}
+
+            {% if where -%}
+            where {{ where }}
+            {%- endif %}
         )
 
         {% if not loop.last -%}


### PR DESCRIPTION
Resolves #464, resolves #382

This is a:
- [ ] bug fix PR with no breaking changes — please ensure the base branch is `main`
- [x] new functionality — please ensure the base branch is the latest `dev/` branch
- [ ] a breaking change — please ensure the base branch is the latest `dev/` branch

## Description & motivation
I often want to add basic filters when using `union_relations`, such as excluding obsolete records or low-quality data. Currently, I have to create two models to do so: one to union the data then another to filter it. This PR adds a `where` parameter to `union_relations` so models are filtered _before_ being unioned.

More context & discussion can be found in #464 and #382.

## Checklist
- [x] I have verified that these changes work locally on the following warehouses (Note: it's okay if you do not have access to all warehouses, this helps us understand what has been covered)
    - [ ] BigQuery
    - [ ] Postgres
    - [ ] Redshift
    - [x] Snowflake
- [x] I have updated the README.md (if applicable)
- [x] I have added tests & descriptions to my models (and macros if applicable)
- [x] I have added an entry to CHANGELOG.md
