### PR TITLE
Fix/557 split part negative part number

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+- Enable a negative part_number for `split_part()` ([#557](https://github.com/dbt-labs/dbt-utils/issues/557), [#559](https://github.com/dbt-labs/dbt-utils/pull/559))
+
 # dbt-utils v0.8.3
 ## New features
 - A macro for deduplicating data, `deduplicate()` ([#335](https://github.com/dbt-labs/dbt-utils/issues/335), [#512](https://github.com/dbt-labs/dbt-utils/pull/512))

--- a/integration_tests/models/cross_db_utils/test_split_part.sql
+++ b/integration_tests/models/cross_db_utils/test_split_part.sql
@@ -26,3 +26,11 @@ select
     result_3 as expected
 
 from data
+
+union all
+
+select
+    {{ dbt_utils.split_part('parts', 'split_on', -1) }} as actual,
+    result_3 as expected
+
+from data

--- a/macros/cross_db_utils/split_part.sql
+++ b/macros/cross_db_utils/split_part.sql
@@ -14,11 +14,59 @@
 {% endmacro %}
 
 
+{% macro _split_part_negative(string_text, delimiter_text, part_number) %}
+
+    split_part(
+        {{ string_text }},
+        {{ delimiter_text }},
+          length({{ string_text }}) 
+          - length(
+              replace({{ string_text }},  {{ delimiter_text }}, '')
+          ) + 2 {{ part_number }}
+        )
+
+{% endmacro %}
+
+
+{% macro postgres__split_part(string_text, delimiter_text, part_number) %}
+
+  {% if part_number > 0 %}
+    {{ dbt_utils.default__split_part(string_text, delimiter_text, part_number) }}
+  {% else %}
+    {{ dbt_utils._split_part_negative(string_text, delimiter_text, part_number) }}
+  {% endif %}
+
+{% endmacro %}
+
+
+{% macro redshift__split_part(string_text, delimiter_text, part_number) %}
+
+  {% if part_number > 0 %}
+    {{ dbt_utils.default__split_part(string_text, delimiter_text, part_number) }}
+  {% else %}
+    {{ dbt_utils._split_part_negative(string_text, delimiter_text, part_number) }}
+  {% endif %}
+
+{% endmacro %}
+
+
 {% macro bigquery__split_part(string_text, delimiter_text, part_number) %}
 
+  {% if part_number > 0 %}
     split(
         {{ string_text }},
         {{ delimiter_text }}
         )[safe_offset({{ part_number - 1 }})]
+  {% else %}
+    split(
+        {{ string_text }},
+        {{ delimiter_text }}
+        )[safe_offset(
+          length({{ string_text }}) 
+          - length(
+              replace({{ string_text }},  {{ delimiter_text }}, '')
+          ) + 1
+        )]
+  {% endif %}
 
 {% endmacro %}

--- a/macros/cross_db_utils/split_part.sql
+++ b/macros/cross_db_utils/split_part.sql
@@ -30,7 +30,7 @@
 
 {% macro postgres__split_part(string_text, delimiter_text, part_number) %}
 
-  {% if part_number > 0 %}
+  {% if part_number >= 0 %}
     {{ dbt_utils.default__split_part(string_text, delimiter_text, part_number) }}
   {% else %}
     {{ dbt_utils._split_part_negative(string_text, delimiter_text, part_number) }}
@@ -41,7 +41,7 @@
 
 {% macro redshift__split_part(string_text, delimiter_text, part_number) %}
 
-  {% if part_number > 0 %}
+  {% if part_number >= 0 %}
     {{ dbt_utils.default__split_part(string_text, delimiter_text, part_number) }}
   {% else %}
     {{ dbt_utils._split_part_negative(string_text, delimiter_text, part_number) }}
@@ -52,7 +52,7 @@
 
 {% macro bigquery__split_part(string_text, delimiter_text, part_number) %}
 
-  {% if part_number > 0 %}
+  {% if part_number >= 0 %}
     split(
         {{ string_text }},
         {{ delimiter_text }}


### PR DESCRIPTION
This is a:
- [x] bug fix PR with no breaking changes — please ensure the base branch is `main`
- [ ] new functionality — please ensure the base branch is the latest `dev/` branch
- [ ] a breaking change — please ensure the base branch is the latest `dev/` branch

## Description & motivation
Fixes #557 
I have not added any entry to the CHANGELOG, please let me know if it is required for a bug fix.

## Checklist
- [x] I have verified that these changes work locally on the following warehouses (Note: it's okay if you do not have access to all warehouses, this helps us understand what has been covered)
    - [x] BigQuery
    - [x] Postgres
    - [ ] Redshift
    - [ ] Snowflake
- [x] I followed guidelines to ensure that my changes will work on "non-core" adapters by:
    - [ ] dispatching any new macro(s) so non-core adapters can also use them (e.g. [the `star()` source](https://github.com/fishtown-analytics/dbt-utils/blob/master/macros/sql/star.sql))
    - [ ] using the `limit_zero()` macro in place of the literal string: `limit 0`
    - [ ] using `dbt_utils.type_*` macros instead of explicit datatypes (e.g. `dbt_utils.type_timestamp()` instead of `TIMESTAMP`
- [ ] I have updated the README.md (if applicable)
- [x] I have added tests & descriptions to my models (and macros if applicable)
- [ ] I have added an entry to CHANGELOG.md
