### PR TITLE
fix / added documentation about listagg macro to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1081,6 +1081,21 @@ When an expression falls outside the range, the function returns:
 {{ dbt_utils.width_bucket(expr, min_value, max_value, num_buckets) }}
 ```
 
+#### listagg ([source](macros/cross_db_utils/listagg.sql))
+This macro returns the concatenated input values from a group of rows separated by a specified deliminator. 
+
+**Args**:
+- `measure` (required): The expression (typically a column name) that determines the values to be concatenated. To only include distinct values add keyword DISTINCT to beginning of expression (example: 'DISTINCT column_to_agg').
+- `delimiter_text` (required): Text representing the delimiter to separate concatenated values by.
+- `order_by_clause` (optional): An expression (typically a column name) that determines the order of the concatenated values.
+- `limit_num` (optional): Specifies the maximum number of values to be concatenated.
+
+Note: If there are instances of `delimiter_text` within your `measure`, you cannot include a `limit_num`.
+
+**Usage:**
+```
+{{ dbt_utils.listagg(measure='column_to_agg', delimiter_text="','", order_by_clause="order by order_by_column", limit_num=10) }}
+```
 
 ---
 ### Jinja Helpers


### PR DESCRIPTION
Closes #544

This is a:
- [X] bug fix PR with no breaking changes — please ensure the base branch is `main`
- [ ] new functionality — please ensure the base branch is the latest `dev/` branch
- [ ] a breaking change — please ensure the base branch is the latest `dev/` branch

## Description & motivation
<!---
Describe your changes, and why you're making them.
-->
This PR adds documentation about the `listagg` cross-db macro to the README as requested by issue #544 

## Checklist
- [ ] I have verified that these changes work locally on the following warehouses (Note: it's okay if you do not have access to all warehouses, this helps us understand what has been covered)
    - [ ] BigQuery
    - [ ] Postgres
    - [ ] Redshift
    - [ ] Snowflake
- [ ] I followed guidelines to ensure that my changes will work on "non-core" adapters by:
    - [ ] dispatching any new macro(s) so non-core adapters can also use them (e.g. [the `star()` source](https://github.com/fishtown-analytics/dbt-utils/blob/master/macros/sql/star.sql))
    - [ ] using the `limit_zero()` macro in place of the literal string: `limit 0`
    - [ ] using `dbt_utils.type_*` macros instead of explicit datatypes (e.g. `dbt_utils.type_timestamp()` instead of `TIMESTAMP`
- [X] I have updated the README.md (if applicable)
- [ ] I have added tests & descriptions to my models (and macros if applicable)
- [ ] I have added an entry to CHANGELOG.md
