### PR TITLE
star macro: conditional check to see if cols contains columns, if not replace with *

### DIFF
--- a/macros/sql/star.sql
+++ b/macros/sql/star.sql
@@ -11,10 +11,14 @@
         {{ return('*') }}
     {% endif %}
 
-    {%- for col in dbt_utils.get_filtered_columns_in_relation(from, except) %}
+    {% set cols = dbt_utils.get_filtered_columns_in_relation(from, except) %}
 
-        {%- if relation_alias %}{{ relation_alias }}.{% else %}{%- endif -%}{{ adapter.quote(col)|trim }} {%- if prefix!='' or suffix!='' %} as {{ adapter.quote(prefix ~ col ~ suffix)|trim }} {%- endif -%}
-        {%- if not loop.last %},{{ '\n  ' }}{% endif %}
-
-    {%- endfor -%}
+    {%- if cols|length <= 0 -%}
+      {{- return('*') -}}
+    {%- else -%}
+        {%- for col in cols %}
+            {%- if relation_alias %}{{ relation_alias }}.{% else %}{%- endif -%}{{ adapter.quote(col)|trim }} {%- if prefix!='' or suffix!='' %} as {{ adapter.quote(prefix ~ col ~ suffix)|trim }} {%- endif -%}
+            {%- if not loop.last %},{{ '\n  ' }}{% endif %}
+        {%- endfor -%}
+    {% endif %}
 {%- endmacro %}


### PR DESCRIPTION
Fixes #605

This is a:
- [x] bug fix with no breaking changes — please ensure the base branch is `next/patch`
- [ ] new functionality — please ensure the base branch is `next/minor`
- [ ] a breaking change — please ensure the base branch is `next/major`

## Description & motivation
I have been using sqlfluff to lint my dbt sql code. Sqlfluff relies on the dbt compiled code to lint. When dbt_util.star is called with a reference that does not yet exist (parsing mode) without running `dbt run` it does not know how to handle `get_filtered_columns_in_relation` being empty. This PR should add the case where if `get_filtered_columns_in_relation` is empty it will replace the entire dbt_utils query with a star. This allows the compiled version to be properly linted without a parsing error. 
Previously:
```SQL
SELECT
FROM "Table.Name"
```
Now:
```SQL
SELECT *
FROM "Table.Name"
```

I'm not sure if the submitted ["fix"](https://github.com/dbt-labs/dbt-utils/pull/532/files) for this in Release 0.8.3 works as intended, but should be reviewed by someone more familiar with the codebase. 

The method I used for testing was running `dbt compile --select path/to/file` on a file like the following:
```SQL
WITH table1asCTE AS(
    SELECT {{ dbt_utils.star(from=ref('table1'),
        except=["Column1"
        ,"Column2"
    ]) }}
    FROM {{ref ('table1')}}
),

SELECT *
FROM table1asCTE
```
A prerequisite for the above is the referenced table cannot exist in the database.

## Checklist
- [ ] I have verified that these changes work locally on the following warehouses (Note: it's okay if you do not have access to all warehouses, this helps us understand what has been covered)
    - [ ] BigQuery
    - [ ] Postgres
    - [ ] Redshift
    - [ ] Snowflake
- [ ] I followed guidelines to ensure that my changes will work on "non-core" adapters by:
    - [ ] dispatching any new macro(s) so non-core adapters can also use them (e.g. [the `star()` source](https://github.com/fishtown-analytics/dbt-utils/blob/master/macros/sql/star.sql))
    - [ ] using the `limit_zero()` macro in place of the literal string: `limit 0`
    - [ ] using `dbt_utils.type_*` macros instead of explicit datatypes (e.g. `dbt_utils.type_timestamp()` instead of `TIMESTAMP`
- [ ] I have updated the README.md (if applicable)
- [ ] I have added tests & descriptions to my models (and macros if applicable)
- [ ] I have added an entry to CHANGELOG.md
