### PR TITLE
Update get_tables_by_pattern_sql.sql

### DIFF
--- a/macros/sql/get_tables_by_pattern_sql.sql
+++ b/macros/sql/get_tables_by_pattern_sql.sql
@@ -16,6 +16,19 @@
 
 {% endmacro %}
 
+{% macro athena__get_tables_by_pattern_sql(schema_pattern, table_pattern, exclude='', database=target.database) %}
+
+        select distinct
+            table_schema as "table_schema",
+            table_name as "table_name",
+            {{ dbt_utils.get_table_types_sql() }}
+        from {{ database }}.information_schema.tables
+        where lower(table_schema) like lower('{{ schema_pattern }}')
+        and lower(table_name) like lower ('{{ table_pattern }}')
+        and lower(table_name) not like lower ('{{ exclude }}')
+
+{% endmacro %}
+
 
 {% macro bigquery__get_tables_by_pattern_sql(schema_pattern, table_pattern, exclude='', database=target.database) %}
 


### PR DESCRIPTION
Create  specific athena macro because ilike is not a valid function

This is a:
- [x] bug fix with no breaking changes — please ensure the base branch is `next/patch`
- [ ] new functionality — please ensure the base branch is `next/minor`
- [ ] a breaking change — please ensure the base branch is `next/major`

## Description & motivation
When I trying to use dbt codegen to generate source yaml's, I get a query error:

`dbt run-operation generate_source --args '{"schema_name": "ktech_datalake_raw", "table_pattern": "course_course"}'
16:17:53  Running with dbt=1.0.5
Failed to execute query.
Traceback (most recent call last):
  File "/Users/silvio/.pyenv/versions/3.8.6/lib/python3.8/site-packages/pyathena/common.py", line 307, in _execute
    query_id = retry_api_call(
  File "/Users/silvio/.pyenv/versions/3.8.6/lib/python3.8/site-packages/pyathena/util.py", line 84, in retry_api_call
    return retry(func, *args, **kwargs)
  File "/Users/silvio/.pyenv/versions/3.8.6/lib/python3.8/site-packages/tenacity/__init__.py", line 423, in __call__
    do = self.iter(retry_state=retry_state)
  File "/Users/silvio/.pyenv/versions/3.8.6/lib/python3.8/site-packages/tenacity/__init__.py", line 360, in iter
    return fut.result()
  File "/Users/silvio/.pyenv/versions/3.8.6/lib/python3.8/concurrent/futures/_base.py", line 432, in result
    return self.__get_result()
  File "/Users/silvio/.pyenv/versions/3.8.6/lib/python3.8/concurrent/futures/_base.py", line 388, in __get_result
    raise self._exception
  File "/Users/silvio/.pyenv/versions/3.8.6/lib/python3.8/site-packages/tenacity/__init__.py", line 426, in __call__
    result = fn(*args, **kwargs)
  File "/Users/silvio/.pyenv/versions/3.8.6/lib/python3.8/site-packages/botocore/client.py", line 388, in _api_call
    return self._make_api_call(operation_name, kwargs)
  File "/Users/silvio/.pyenv/versions/3.8.6/lib/python3.8/site-packages/botocore/client.py", line 708, in _make_api_call
    raise error_class(parsed_response, operation_name)
botocore.errorfactory.InvalidRequestException: An error occurred (InvalidRequestException) when calling the StartQueryExecution operation: line 18:28: mismatched input 'ilike'. Expecting: '%', '*', '+', '-', '.', '/', 'AT', '[', '||', <expression>
Failed to execute query.`

This errors happens because the macro [get_tables_by_pattern_sql](https://github.com/dbt-labs/dbt-utils/blob/37199d3901a97e813899dc25c1f72601714c2c3c/macros/sql/get_tables_by_pattern_sql.sql) uses like function (not supported on Athena)

## Checklist
- [ ] I have verified that these changes work locally on the following warehouses (Note: it's okay if you do not have access to all warehouses, this helps us understand what has been covered)
    - [ ] BigQuery
    - [ ] Postgres
    - [ ] Redshift
    - [ ] Snowflake
    - [x] Athena
- [ ] I followed guidelines to ensure that my changes will work on "non-core" adapters by:
    - [ ] dispatching any new macro(s) so non-core adapters can also use them (e.g. [the `star()` source](https://github.com/fishtown-analytics/dbt-utils/blob/master/macros/sql/star.sql))
    - [ ] using the `limit_zero()` macro in place of the literal string: `limit 0`
    - [ ] using `dbt_utils.type_*` macros instead of explicit datatypes (e.g. `dbt_utils.type_timestamp()` instead of `TIMESTAMP`
- [ ] I have updated the README.md (if applicable)
- [ ] I have added tests & descriptions to my models (and macros if applicable)
- [ ] I have added an entry to CHANGELOG.md
