### PR TITLE
Fix deduplicate test

### DIFF
--- a/integration_tests/models/sql/schema.yml
+++ b/integration_tests/models/sql/schema.yml
@@ -153,7 +153,7 @@ models:
       - dbt_utils.equality:
           compare_model: ref('data_union_events_expected')
 
-  - name: test_dedupe
+  - name: test_deduplicate
     tests:
       - dbt_utils.equality:
           compare_model: ref('data_deduplicate_expected')


### PR DESCRIPTION
resolves #579

This is a:
- [ ] documentation update
- [x] bug fix with no breaking changes
- [ ] new functionality
- [ ] a breaking change

All pull requests from community contributors should target the `main` branch (default).

## Description & motivation
The integration test for the `deduplicate` macro will run now:
```
02:01:33  47 of 88 PASS dbt_utils_equality_test_deduplicate_ref_data_deduplicate_expected_  [PASS in 3.26s]
```

## Checklist
- [X] I have verified that these changes work locally on the following warehouses (Note: it's okay if you do not have access to all warehouses, this helps us understand what has been covered)
    - [ ] BigQuery
    - [ ] Postgres
    - [ ] Redshift
    - [X] Snowflake