### PR TITLE
Place the seed node specifications under the seeds key

### DIFF
--- a/integration_tests/models/generic_tests/schema.yml
+++ b/integration_tests/models/generic_tests/schema.yml
@@ -1,6 +1,6 @@
 version: 2
 
-models:
+seeds:
   - name: data_test_not_constant
     columns:
       - name: field
@@ -30,27 +30,6 @@ models:
           - dbt_utils.expression_is_true:
               expression: = 0.5
               condition: col_a = 0.5
-
-  - name: test_recency
-    tests:
-      - dbt_utils.recency:
-          datepart: day
-          field: today
-          interval: 1
-
-  - name: test_equal_rowcount
-    tests:
-      - dbt_utils.equal_rowcount:
-          compare_model: ref('test_equal_rowcount')
-
-  - name: test_equal_column_subset
-    tests:
-      - dbt_utils.equality:
-          compare_model: ref('data_people')
-          compare_columns:
-            - first_name
-            - last_name
-            - email
 
   - name: data_people
     columns:
@@ -136,7 +115,6 @@ models:
           - dbt_utils.cardinality_equality:
               to: ref('data_cardinality_equality_b')
               field: different_name
-          
 
   - name: data_test_accepted_range
     columns:
@@ -168,3 +146,25 @@ models:
         tests:
           - dbt_utils.not_null_proportion:
               at_least: 0.9
+
+models:
+  - name: test_recency
+    tests:
+      - dbt_utils.recency:
+          datepart: day
+          field: today
+          interval: 1
+
+  - name: test_equal_rowcount
+    tests:
+      - dbt_utils.equal_rowcount:
+          compare_model: ref('test_equal_rowcount')
+
+  - name: test_equal_column_subset
+    tests:
+      - dbt_utils.equality:
+          compare_model: ref('data_people')
+          compare_columns:
+            - first_name
+            - last_name
+            - email


### PR DESCRIPTION
resolves #558

This is a:
- [ ] documentation update
- [X] bug fix with no breaking changes
- [ ] new functionality
- [ ] a breaking change

All pull requests from community contributors should target the `main` branch (default).

## Description & motivation
For our integration tests, we had our seeds under the `models` key in our YAML configuration. dbt will emit a warning for each case. The solution is very simple: just move it under the `seeds` key instead!

Note: this will leave any deprecation warnings in place when running integration tests. Those warning will remain until we fully remove that functionality within a major release that contains breaking changes.

## Checklist
- [x] I have verified that these changes work in CI for all the main warehouses
- [x] I have updated the README.md (if applicable)
- [x] I have added tests & descriptions to my models (and macros if applicable)
- [ ] I have added an entry to CHANGELOG.md
