### PR TITLE
Add optional where clause to get_column_values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@
 - A macro for deduplicating data, `deduplicate()` ([#335](https://github.com/dbt-labs/dbt-utils/issues/335), [#512](https://github.com/dbt-labs/dbt-utils/pull/512))
 - A cross-database implementation of `listagg()` ([#530](https://github.com/dbt-labs/dbt-utils/pull/530))
 - A new macro to get the columns in a relation as a list, `get_filtered_columns_in_relation()`. This is similar to the `star()` macro, but creates a Jinja list instead of a comma-separated string. ([#516](https://github.com/dbt-labs/dbt-utils/pull/516))
-- Add an optional `where` clause parameter to `get_column_values()` to filter vaklues returned ([#511](https://github.com/dbt-labs/dbt-utils/issues/511), [#583](https://github.com/dbt-labs/dbt-utils/pull/583)) 
+- Add an optional `where` clause parameter to `get_column_values()` to filter values returned ([#511](https://github.com/dbt-labs/dbt-utils/issues/511), [#583](https://github.com/dbt-labs/dbt-utils/pull/583)) 
 
 ## Fixes
 - `get_column_values()` once more raises an error when the model doesn't exist and there is no default provided ([#531](https://github.com/dbt-labs/dbt-utils/issues/531), [#533](https://github.com/dbt-labs/dbt-utils/pull/533))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - [@graciegoheen](https://github.com/graciegoheen) (#545)
 - [@judahrand](https://github.com/judahrand) (#552)
 - [@clausherther](https://github.com/clausherther) (#555)
+- [@epapineau](https://github.com/epapineau) (#582)
 
 # dbt-utils v0.8.4
 ## Fixes
@@ -22,6 +23,7 @@
 - A macro for deduplicating data, `deduplicate()` ([#335](https://github.com/dbt-labs/dbt-utils/issues/335), [#512](https://github.com/dbt-labs/dbt-utils/pull/512))
 - A cross-database implementation of `listagg()` ([#530](https://github.com/dbt-labs/dbt-utils/pull/530))
 - A new macro to get the columns in a relation as a list, `get_filtered_columns_in_relation()`. This is similar to the `star()` macro, but creates a Jinja list instead of a comma-separated string. ([#516](https://github.com/dbt-labs/dbt-utils/pull/516))
+- Add an optional `where` clause parameter to `get_column_values()` to filter vaklues returned ([#511](https://github.com/dbt-labs/dbt-utils/issues/511), [#583](https://github.com/dbt-labs/dbt-utils/pull/583)) 
 
 ## Fixes
 - `get_column_values()` once more raises an error when the model doesn't exist and there is no default provided ([#531](https://github.com/dbt-labs/dbt-utils/issues/531), [#533](https://github.com/dbt-labs/dbt-utils/pull/533))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@
 - [@graciegoheen](https://github.com/graciegoheen) (#545)
 - [@judahrand](https://github.com/judahrand) (#552)
 - [@clausherther](https://github.com/clausherther) (#555)
-- [@epapineau](https://github.com/epapineau) (#582)
+- [@epapineau](https://github.com/epapineau) (#583)
 
 # dbt-utils v0.8.4
 ## Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 # Unreleased
+## New features
+- Add an optional `where` clause parameter to `get_column_values()` to filter values returned ([#511](https://github.com/dbt-labs/dbt-utils/issues/511), [#583](https://github.com/dbt-labs/dbt-utils/pull/583)) 
 
 ## Quality of life
 - Documentation about listagg macro ([#544](https://github.com/dbt-labs/dbt-utils/issues/544), [#560](https://github.com/dbt-labs/dbt-utils/pull/560))
@@ -23,7 +25,6 @@
 - A macro for deduplicating data, `deduplicate()` ([#335](https://github.com/dbt-labs/dbt-utils/issues/335), [#512](https://github.com/dbt-labs/dbt-utils/pull/512))
 - A cross-database implementation of `listagg()` ([#530](https://github.com/dbt-labs/dbt-utils/pull/530))
 - A new macro to get the columns in a relation as a list, `get_filtered_columns_in_relation()`. This is similar to the `star()` macro, but creates a Jinja list instead of a comma-separated string. ([#516](https://github.com/dbt-labs/dbt-utils/pull/516))
-- Add an optional `where` clause parameter to `get_column_values()` to filter values returned ([#511](https://github.com/dbt-labs/dbt-utils/issues/511), [#583](https://github.com/dbt-labs/dbt-utils/pull/583)) 
 
 ## Fixes
 - `get_column_values()` once more raises an error when the model doesn't exist and there is no default provided ([#531](https://github.com/dbt-labs/dbt-utils/issues/531), [#533](https://github.com/dbt-labs/dbt-utils/pull/533))

--- a/README.md
+++ b/README.md
@@ -553,6 +553,7 @@ This macro returns the unique values for a column in a given [relation](https://
 **Args:**
 - `table` (required): a [Relation](https://docs.getdbt.com/reference/dbt-classes#relation) (a `ref` or `source`) that contains the list of columns you wish to select from
 - `column` (required): The name of the column you wish to find the column values of
+- `where` (optiona, default=`none`): A where clause to filter the column values by. 
 - `order_by` (optional, default=`'count(*) desc'`): How the results should be ordered. The default is to order by `count(*) desc`, i.e. decreasing frequency. Setting this as `'my_column'` will sort alphabetically, while `'min(created_at)'` will sort by when thevalue was first observed.
 - `max_records` (optional, default=`none`): The maximum number of column values you want to return
 - `default` (optional, default=`[]`): The results this macro should return if the relation has not yet been created (and therefore has no column values).

--- a/README.md
+++ b/README.md
@@ -553,7 +553,7 @@ This macro returns the unique values for a column in a given [relation](https://
 **Args:**
 - `table` (required): a [Relation](https://docs.getdbt.com/reference/dbt-classes#relation) (a `ref` or `source`) that contains the list of columns you wish to select from
 - `column` (required): The name of the column you wish to find the column values of
-- `where` (optiona, default=`none`): A where clause to filter the column values by. 
+- `where` (optional, default=`none`): A where clause to filter the column values by. 
 - `order_by` (optional, default=`'count(*) desc'`): How the results should be ordered. The default is to order by `count(*) desc`, i.e. decreasing frequency. Setting this as `'my_column'` will sort alphabetically, while `'min(created_at)'` will sort by when thevalue was first observed.
 - `max_records` (optional, default=`none`): The maximum number of column values you want to return
 - `default` (optional, default=`[]`): The results this macro should return if the relation has not yet been created (and therefore has no column values).

--- a/integration_tests/data/sql/data_get_column_values_where.csv
+++ b/integration_tests/data/sql/data_get_column_values_where.csv
@@ -1,0 +1,12 @@
+field,condition
+a,left
+b,right
+c,left
+d,right
+e,left
+f,right
+g,left
+g,right
+g,left
+g,right
+g,left

--- a/integration_tests/data/sql/data_get_column_values_where_expected.csv
+++ b/integration_tests/data/sql/data_get_column_values_where_expected.csv
@@ -1,0 +1,5 @@
+field
+a
+c
+e
+g

--- a/integration_tests/models/sql/schema.yml
+++ b/integration_tests/models/sql/schema.yml
@@ -50,6 +50,33 @@ models:
               values:
                 - '5'
 
+  - name: test_get_column_values_where
+    columns:
+      - name: count_a
+        tests:
+          - accepted_values:
+              values:
+                - '1'
+
+      - name: count_c
+        tests:
+          - accepted_values:
+              values:
+                - '1'
+
+      - name: count_e
+        tests:
+          - accepted_values:
+              values:
+                - '1'
+
+      - name: count_g
+        tests:
+          - accepted_values:
+              values:
+                - '3'
+      # I'd like to add a column test here also? (https://github.com/calogica/dbt-expectations#expect_table_columns_to_not_contain_set)
+
   - name: test_get_filtered_columns_in_relation
     tests:
       - dbt_utils.equality:

--- a/integration_tests/models/sql/schema.yml
+++ b/integration_tests/models/sql/schema.yml
@@ -51,31 +51,9 @@ models:
                 - '5'
 
   - name: test_get_column_values_where
-    columns:
-      - name: count_a
-        tests:
-          - accepted_values:
-              values:
-                - '1'
-
-      - name: count_c
-        tests:
-          - accepted_values:
-              values:
-                - '1'
-
-      - name: count_e
-        tests:
-          - accepted_values:
-              values:
-                - '1'
-
-      - name: count_g
-        tests:
-          - accepted_values:
-              values:
-                - '3'
-      # I'd like to add a column test here also? (https://github.com/calogica/dbt-expectations#expect_table_columns_to_not_contain_set)
+    tests:
+      - dbt_utils.equality:
+          compare_model: ref('data_get_column_values_where_expected')
 
   - name: test_get_filtered_columns_in_relation
     tests:

--- a/integration_tests/models/sql/test_get_column_values_where.sql
+++ b/integration_tests/models/sql/test_get_column_values_where.sql
@@ -1,0 +1,31 @@
+
+{% set column_values = dbt_utils.get_column_values(ref('data_get_column_values_where'), 'field', default=[], order_by="field", where="condition='left'") %}
+
+
+{% if target.type == 'snowflake' %}
+
+select
+    {% for val in column_values -%}
+
+        sum(case when field = '{{ val }}' then 1 else 0 end) as count_{{ val }}
+        {%- if not loop.last %},{% endif -%}
+
+    {%- endfor %}
+
+from {{ ref('data_get_column_values_where') }}
+where condition = 'left'
+
+{% else %}
+
+select
+    {% for val in column_values -%}
+
+        {{dbt_utils.safe_cast("sum(case when field = '" ~ val ~ "' then 1 else 0 end)", dbt_utils.type_string()) }} as count_{{ val }}
+        {%- if not loop.last %},{% endif -%}
+
+    {%- endfor %}
+
+from {{ ref('data_get_column_values_where') }}
+where condition = 'left'
+
+{% endif %}

--- a/integration_tests/models/sql/test_get_column_values_where.sql
+++ b/integration_tests/models/sql/test_get_column_values_where.sql
@@ -1,31 +1,6 @@
+{% set column_values = dbt_utils.get_column_values(ref('data_get_column_values_where'), 'field', where="condition = 'left'") %}
 
-{% set column_values = dbt_utils.get_column_values(ref('data_get_column_values_where'), 'field', default=[], order_by="field", where="condition='left'") %}
-
-
-{% if target.type == 'snowflake' %}
-
-select
-    {% for val in column_values -%}
-
-        sum(case when field = '{{ val }}' then 1 else 0 end) as count_{{ val }}
-        {%- if not loop.last %},{% endif -%}
-
-    {%- endfor %}
-
-from {{ ref('data_get_column_values_where') }}
-where condition = 'left'
-
-{% else %}
-
-select
-    {% for val in column_values -%}
-
-        {{dbt_utils.safe_cast("sum(case when field = '" ~ val ~ "' then 1 else 0 end)", dbt_utils.type_string()) }} as count_{{ val }}
-        {%- if not loop.last %},{% endif -%}
-
-    {%- endfor %}
-
-from {{ ref('data_get_column_values_where') }}
-where condition = 'left'
-
-{% endif %}
+-- Create a relation using the values
+{% for val in column_values -%}
+select {{ dbt_utils.string_literal(val) }} as field {% if not loop.last %}union all{% endif %} 
+{% endfor %}

--- a/macros/sql/get_column_values.sql
+++ b/macros/sql/get_column_values.sql
@@ -1,8 +1,8 @@
-{% macro get_column_values(table, column, where=none, order_by='count(*) desc', max_records=none, default=none) -%}
-    {{ return(adapter.dispatch('get_column_values', 'dbt_utils')(table, column, where, order_by, max_records, default)) }}
+{% macro get_column_values(table, column, order_by='count(*) desc', max_records=none, default=none, where=none) -%}
+    {{ return(adapter.dispatch('get_column_values', 'dbt_utils')(table, column, order_by, max_records, default, where)) }}
 {% endmacro %}
 
-{% macro default__get_column_values(table, column, where, order_by='count(*) desc', max_records=none, default=none) -%}
+{% macro default__get_column_values(table, column, order_by='count(*) desc', max_records=none, default=none, where=none) -%}
     {#-- Prevent querying of db in parsing mode. This works because this macro does not create any new refs. #}
     {%- if not execute -%}
         {% set default = [] if not default %}

--- a/macros/sql/get_column_values.sql
+++ b/macros/sql/get_column_values.sql
@@ -1,8 +1,8 @@
-{% macro get_column_values(table, column, order_by='count(*) desc', max_records=none, default=none) -%}
-    {{ return(adapter.dispatch('get_column_values', 'dbt_utils')(table, column, order_by, max_records, default)) }}
+{% macro get_column_values(table, column, where=none, order_by='count(*) desc', max_records=none, default=none) -%}
+    {{ return(adapter.dispatch('get_column_values', 'dbt_utils')(table, column, where, order_by, max_records, default)) }}
 {% endmacro %}
 
-{% macro default__get_column_values(table, column, order_by='count(*) desc', max_records=none, default=none) -%}
+{% macro default__get_column_values(table, column, where, order_by='count(*) desc', max_records=none, default=none) -%}
     {#-- Prevent querying of db in parsing mode. This works because this macro does not create any new refs. #}
     {%- if not execute -%}
         {% set default = [] if not default %}
@@ -37,6 +37,11 @@
                 {{ column }} as value
 
             from {{ target_relation }}
+
+            {% if where is not none %}
+            where {{ where }}
+            {% endif %}
+
             group by {{ column }}
             order by {{ order_by }}
 


### PR DESCRIPTION
Closes #511 closes #582

This is a:
- [ ] documentation update
- [ ] bug fix with no breaking changes
- [x] new functionality
- [ ] a breaking change

All pull requests from community contributors should target the `main` branch (default).

## Description & motivation
<!---
Describe your changes, and why you're making them.
-->
Closes #511 & redundant #582. Adds a `where` clause parameter to the `get_column_values` macro to enable filtering the returned columns.
## Checklist
- [x] I have verified that these changes work locally on the following warehouses (Note: it's okay if you do not have access to all warehouses, this helps us understand what has been covered)
    - [ ] BigQuery
    - [x] Postgres
    - [ ] Redshift
    - [ ] Snowflake
- [ ] I followed guidelines to ensure that my changes will work on "non-core" adapters by:
    - [ ] dispatching any new macro(s) so non-core adapters can also use them (e.g. [the `star()` source](https://github.com/fishtown-analytics/dbt-utils/blob/master/macros/sql/star.sql))
    - [ ] using the `limit_zero()` macro in place of the literal string: `limit 0`
    - [ ] using `dbt_utils.type_*` macros instead of explicit datatypes (e.g. `dbt_utils.type_timestamp()` instead of `TIMESTAMP`
- [x] I have updated the README.md (if applicable)
- [x] I have added tests & descriptions to my models (and macros if applicable)
- [x] I have added an entry to CHANGELOG.md
