### PR TITLE
Replace legacy CircleCI PostgreSQL convenience image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,6 +9,7 @@ jobs:
       - image: cimg/postgres:9.6
         environment:
           POSTGRES_USER: root
+          POSTGRES_PASSWORD: ''
     steps:
       - checkout
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@ jobs:
       - image: cimg/postgres:9.6
         environment:
           POSTGRES_USER: root
-          POSTGRES_PASSWORD: ''
+          POSTGRES_PASSWORD: cipass
     steps:
       - checkout
       - run:
@@ -17,7 +17,7 @@ jobs:
           environment:
             POSTGRES_TEST_HOST: localhost
             POSTGRES_TEST_USER: root
-            POSTGRES_TEST_PASS: ''
+            POSTGRES_TEST_PASS: cipass
             POSTGRES_TEST_PORT: 5432
             POSTGRES_TEST_DBNAME: circle_test
           command: ./run_test.sh postgres

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,6 @@ jobs:
       - image: cimg/postgres:9.6
         environment:
           POSTGRES_USER: root
-          POSTGRES_PASSWORD: cipass
     steps:
       - checkout
       - run:
@@ -17,7 +16,7 @@ jobs:
           environment:
             POSTGRES_TEST_HOST: localhost
             POSTGRES_TEST_USER: root
-            POSTGRES_TEST_PASS: cipass
+            POSTGRES_TEST_PASS: ''
             POSTGRES_TEST_PORT: 5432
             POSTGRES_TEST_DBNAME: circle_test
           command: ./run_test.sh postgres

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,8 @@ jobs:
     docker:
       - image: cimg/python:3.9.9
       - image: cimg/postgres:9.6
-
+        environment:
+          POSTGRES_USER: root
     steps:
       - checkout
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ jobs:
   integration-postgres:
     docker:
       - image: cimg/python:3.9.9
-      - image: circleci/postgres:9.6.5-alpine-ram
+      - image: cimg/postgres:9.6
 
     steps:
       - checkout

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 
 ## Under the hood
 - Fail integration tests appropriately ([#540](https://github.com/dbt-labs/dbt-utils/issues/540), [#545](https://github.com/dbt-labs/dbt-utils/pull/545))
+- Upgrade CircleCI postgres convenience image ([#584](https://github.com/dbt-labs/dbt-utils/issues/584), [#585](https://github.com/dbt-labs/dbt-utils/pull/585))
 
 ## Contributors:
 - [@graciegoheen](https://github.com/graciegoheen) (#545)


### PR DESCRIPTION
Resolves #584

This is:
- [ ] documentation
- [ ] bug fix with no breaking changes
- [ ] new functionality
- [ ] breaking change
- [X] continuous integration testing

All pull requests from community contributors should target the `main` branch (default).

## Description & motivation
Two things:
- upgrade to a next-gen docker convenience image in CircleCI
- change from patch version image to a minor version

The latter is so we will automatically utilize new patch versions of the convenience image as they are rolled out.

## Checklist
- [X] I have verified that these changes work on the supported warehouses
- [X] I have updated the README.md (if applicable)
- [X] I have added tests & descriptions to my models (and macros if applicable)
- [x] I have added an entry to CHANGELOG.md
