### PR TITLE
Experiment with a macro that utilizes a dummy table when needed

### DIFF
--- a/macros/cross_db_utils/dual.sql
+++ b/macros/cross_db_utils/dual.sql
@@ -1,0 +1,14 @@
+{%- macro from_dual() -%}
+  {{ return(adapter.dispatch('from_dual', 'dbt_utils')()) }}
+{%- endmacro -%}
+
+{% macro default__from_dual() %}
+{% endmacro %}
+
+{% macro snowflake__from_dual() %}
+    from dual
+{% endmacro %}
+
+{% macro oracle__from_dual() %}
+    from dual
+{% endmacro %}

--- a/tests/functional/cross_db_utils/fixture_cast_bool_to_text.py
+++ b/tests/functional/cross_db_utils/fixture_cast_bool_to_text.py
@@ -4,9 +4,9 @@
 models__test_cast_bool_to_text_sql = """
 with data as (
 
-    select 0=1 as input, 'false' as expected {{ from_dual() }} union all
-    select 1=1 as input, 'true' as expected {{ from_dual() }} union all
-    select null as input, null as expected {{ from_dual() }}
+    select 0=1 as input, 'false' as expected {{ dbt_utils.from_dual() }} union all
+    select 1=1 as input, 'true' as expected {{ dbt_utils.from_dual() }} union all
+    select null as input, null as expected {{ dbt_utils.from_dual() }}
 
 )
 

--- a/tests/functional/cross_db_utils/fixture_cast_bool_to_text.py
+++ b/tests/functional/cross_db_utils/fixture_cast_bool_to_text.py
@@ -4,9 +4,9 @@
 models__test_cast_bool_to_text_sql = """
 with data as (
 
-    select 0=1 as input, 'false' as expected union all
-    select 1=1 as input, 'true' as expected union all
-    select null as input, null as expected
+    select 0=1 as input, 'false' as expected {{ from_dual() }} union all
+    select 1=1 as input, 'true' as expected {{ from_dual() }} union all
+    select null as input, null as expected {{ from_dual() }}
 
 )
 

--- a/tests/functional/cross_db_utils/fixture_datediff.py
+++ b/tests/functional/cross_db_utils/fixture_datediff.py
@@ -42,16 +42,16 @@ from data
 
 -- Also test correct casting of literal values.
 
-union all select {{ dbt_utils.datediff("'1999-12-31 23:59:59.999999'", "'2000-01-01 00:00:00.000000'", "microsecond") }} as actual, 1 as expected
-union all select {{ dbt_utils.datediff("'1999-12-31 23:59:59.999999'", "'2000-01-01 00:00:00.000000'", "millisecond") }} as actual, 1 as expected
-union all select {{ dbt_utils.datediff("'1999-12-31 23:59:59.999999'", "'2000-01-01 00:00:00.000000'", "second") }} as actual, 1 as expected
-union all select {{ dbt_utils.datediff("'1999-12-31 23:59:59.999999'", "'2000-01-01 00:00:00.000000'", "minute") }} as actual, 1 as expected
-union all select {{ dbt_utils.datediff("'1999-12-31 23:59:59.999999'", "'2000-01-01 00:00:00.000000'", "hour") }} as actual, 1 as expected
-union all select {{ dbt_utils.datediff("'1999-12-31 23:59:59.999999'", "'2000-01-01 00:00:00.000000'", "day") }} as actual, 1 as expected
-union all select {{ dbt_utils.datediff("'1999-12-31 23:59:59.999999'", "'2000-01-03 00:00:00.000000'", "week") }} as actual, 1 as expected
-union all select {{ dbt_utils.datediff("'1999-12-31 23:59:59.999999'", "'2000-01-01 00:00:00.000000'", "month") }} as actual, 1 as expected
-union all select {{ dbt_utils.datediff("'1999-12-31 23:59:59.999999'", "'2000-01-01 00:00:00.000000'", "quarter") }} as actual, 1 as expected
-union all select {{ dbt_utils.datediff("'1999-12-31 23:59:59.999999'", "'2000-01-01 00:00:00.000000'", "year") }} as actual, 1 as expected
+union all select {{ dbt_utils.datediff("'1999-12-31 23:59:59.999999'", "'2000-01-01 00:00:00.000000'", "microsecond") }} as actual, 1 as expected {{ from_dual() }}
+union all select {{ dbt_utils.datediff("'1999-12-31 23:59:59.999999'", "'2000-01-01 00:00:00.000000'", "millisecond") }} as actual, 1 as expected {{ from_dual() }}
+union all select {{ dbt_utils.datediff("'1999-12-31 23:59:59.999999'", "'2000-01-01 00:00:00.000000'", "second") }} as actual, 1 as expected {{ from_dual() }}
+union all select {{ dbt_utils.datediff("'1999-12-31 23:59:59.999999'", "'2000-01-01 00:00:00.000000'", "minute") }} as actual, 1 as expected {{ from_dual() }}
+union all select {{ dbt_utils.datediff("'1999-12-31 23:59:59.999999'", "'2000-01-01 00:00:00.000000'", "hour") }} as actual, 1 as expected {{ from_dual() }}
+union all select {{ dbt_utils.datediff("'1999-12-31 23:59:59.999999'", "'2000-01-01 00:00:00.000000'", "day") }} as actual, 1 as expected {{ from_dual() }}
+union all select {{ dbt_utils.datediff("'1999-12-31 23:59:59.999999'", "'2000-01-03 00:00:00.000000'", "week") }} as actual, 1 as expected {{ from_dual() }}
+union all select {{ dbt_utils.datediff("'1999-12-31 23:59:59.999999'", "'2000-01-01 00:00:00.000000'", "month") }} as actual, 1 as expected {{ from_dual() }}
+union all select {{ dbt_utils.datediff("'1999-12-31 23:59:59.999999'", "'2000-01-01 00:00:00.000000'", "quarter") }} as actual, 1 as expected {{ from_dual() }}
+union all select {{ dbt_utils.datediff("'1999-12-31 23:59:59.999999'", "'2000-01-01 00:00:00.000000'", "year") }} as actual, 1 as expected {{ from_dual() }}
 """
 
 

--- a/tests/functional/cross_db_utils/fixture_datediff.py
+++ b/tests/functional/cross_db_utils/fixture_datediff.py
@@ -42,16 +42,16 @@ from data
 
 -- Also test correct casting of literal values.
 
-union all select {{ dbt_utils.datediff("'1999-12-31 23:59:59.999999'", "'2000-01-01 00:00:00.000000'", "microsecond") }} as actual, 1 as expected {{ from_dual() }}
-union all select {{ dbt_utils.datediff("'1999-12-31 23:59:59.999999'", "'2000-01-01 00:00:00.000000'", "millisecond") }} as actual, 1 as expected {{ from_dual() }}
-union all select {{ dbt_utils.datediff("'1999-12-31 23:59:59.999999'", "'2000-01-01 00:00:00.000000'", "second") }} as actual, 1 as expected {{ from_dual() }}
-union all select {{ dbt_utils.datediff("'1999-12-31 23:59:59.999999'", "'2000-01-01 00:00:00.000000'", "minute") }} as actual, 1 as expected {{ from_dual() }}
-union all select {{ dbt_utils.datediff("'1999-12-31 23:59:59.999999'", "'2000-01-01 00:00:00.000000'", "hour") }} as actual, 1 as expected {{ from_dual() }}
-union all select {{ dbt_utils.datediff("'1999-12-31 23:59:59.999999'", "'2000-01-01 00:00:00.000000'", "day") }} as actual, 1 as expected {{ from_dual() }}
-union all select {{ dbt_utils.datediff("'1999-12-31 23:59:59.999999'", "'2000-01-03 00:00:00.000000'", "week") }} as actual, 1 as expected {{ from_dual() }}
-union all select {{ dbt_utils.datediff("'1999-12-31 23:59:59.999999'", "'2000-01-01 00:00:00.000000'", "month") }} as actual, 1 as expected {{ from_dual() }}
-union all select {{ dbt_utils.datediff("'1999-12-31 23:59:59.999999'", "'2000-01-01 00:00:00.000000'", "quarter") }} as actual, 1 as expected {{ from_dual() }}
-union all select {{ dbt_utils.datediff("'1999-12-31 23:59:59.999999'", "'2000-01-01 00:00:00.000000'", "year") }} as actual, 1 as expected {{ from_dual() }}
+union all select {{ dbt_utils.datediff("'1999-12-31 23:59:59.999999'", "'2000-01-01 00:00:00.000000'", "microsecond") }} as actual, 1 as expected {{ dbt_utils.from_dual() }}
+union all select {{ dbt_utils.datediff("'1999-12-31 23:59:59.999999'", "'2000-01-01 00:00:00.000000'", "millisecond") }} as actual, 1 as expected {{ dbt_utils.from_dual() }}
+union all select {{ dbt_utils.datediff("'1999-12-31 23:59:59.999999'", "'2000-01-01 00:00:00.000000'", "second") }} as actual, 1 as expected {{ dbt_utils.from_dual() }}
+union all select {{ dbt_utils.datediff("'1999-12-31 23:59:59.999999'", "'2000-01-01 00:00:00.000000'", "minute") }} as actual, 1 as expected {{ dbt_utils.from_dual() }}
+union all select {{ dbt_utils.datediff("'1999-12-31 23:59:59.999999'", "'2000-01-01 00:00:00.000000'", "hour") }} as actual, 1 as expected {{ dbt_utils.from_dual() }}
+union all select {{ dbt_utils.datediff("'1999-12-31 23:59:59.999999'", "'2000-01-01 00:00:00.000000'", "day") }} as actual, 1 as expected {{ dbt_utils.from_dual() }}
+union all select {{ dbt_utils.datediff("'1999-12-31 23:59:59.999999'", "'2000-01-03 00:00:00.000000'", "week") }} as actual, 1 as expected {{ dbt_utils.from_dual() }}
+union all select {{ dbt_utils.datediff("'1999-12-31 23:59:59.999999'", "'2000-01-01 00:00:00.000000'", "month") }} as actual, 1 as expected {{ dbt_utils.from_dual() }}
+union all select {{ dbt_utils.datediff("'1999-12-31 23:59:59.999999'", "'2000-01-01 00:00:00.000000'", "quarter") }} as actual, 1 as expected {{ dbt_utils.from_dual() }}
+union all select {{ dbt_utils.datediff("'1999-12-31 23:59:59.999999'", "'2000-01-01 00:00:00.000000'", "year") }} as actual, 1 as expected {{ dbt_utils.from_dual() }}
 """
 
 

--- a/tests/functional/cross_db_utils/fixture_escape_single_quotes.py
+++ b/tests/functional/cross_db_utils/fixture_escape_single_quotes.py
@@ -2,15 +2,15 @@
 # escape_single_quotes
 
 models__test_escape_single_quotes_quote_sql = """
-select '{{ dbt_utils.escape_single_quotes("they're") }}' as actual, 'they''re' as expected union all
-select '{{ dbt_utils.escape_single_quotes("they are") }}' as actual, 'they are' as expected
+select '{{ dbt_utils.escape_single_quotes("they're") }}' as actual, 'they''re' as expected {{ from_dual() }} union all
+select '{{ dbt_utils.escape_single_quotes("they are") }}' as actual, 'they are' as expected {{ from_dual() }}
 """
 
 
 # The expected literal is 'they\'re'. The second backslash is to escape it from Python.
 models__test_escape_single_quotes_backslash_sql = """
-select '{{ dbt_utils.escape_single_quotes("they're") }}' as actual, 'they\\'re' as expected union all
-select '{{ dbt_utils.escape_single_quotes("they are") }}' as actual, 'they are' as expected
+select '{{ dbt_utils.escape_single_quotes("they're") }}' as actual, 'they\\'re' as expected {{ from_dual() }} union all
+select '{{ dbt_utils.escape_single_quotes("they are") }}' as actual, 'they are' as expected {{ from_dual() }}
 """
 
 

--- a/tests/functional/cross_db_utils/fixture_escape_single_quotes.py
+++ b/tests/functional/cross_db_utils/fixture_escape_single_quotes.py
@@ -2,15 +2,15 @@
 # escape_single_quotes
 
 models__test_escape_single_quotes_quote_sql = """
-select '{{ dbt_utils.escape_single_quotes("they're") }}' as actual, 'they''re' as expected {{ from_dual() }} union all
-select '{{ dbt_utils.escape_single_quotes("they are") }}' as actual, 'they are' as expected {{ from_dual() }}
+select '{{ dbt_utils.escape_single_quotes("they're") }}' as actual, 'they''re' as expected {{ dbt_utils.from_dual() }} union all
+select '{{ dbt_utils.escape_single_quotes("they are") }}' as actual, 'they are' as expected {{ dbt_utils.from_dual() }}
 """
 
 
 # The expected literal is 'they\'re'. The second backslash is to escape it from Python.
 models__test_escape_single_quotes_backslash_sql = """
-select '{{ dbt_utils.escape_single_quotes("they're") }}' as actual, 'they\\'re' as expected {{ from_dual() }} union all
-select '{{ dbt_utils.escape_single_quotes("they are") }}' as actual, 'they are' as expected {{ from_dual() }}
+select '{{ dbt_utils.escape_single_quotes("they're") }}' as actual, 'they\\'re' as expected {{ dbt_utils.from_dual() }} union all
+select '{{ dbt_utils.escape_single_quotes("they are") }}' as actual, 'they are' as expected {{ dbt_utils.from_dual() }}
 """
 
 

--- a/tests/functional/cross_db_utils/fixture_string_literal.py
+++ b/tests/functional/cross_db_utils/fixture_string_literal.py
@@ -2,10 +2,10 @@
 # string_literal
 
 models__test_string_literal_sql = """
-select {{ dbt_utils.string_literal("abc") }} as actual, 'abc' as expected union all
-select {{ dbt_utils.string_literal("1") }} as actual, '1' as expected union all
-select {{ dbt_utils.string_literal("") }} as actual, '' as expected union all
-select {{ dbt_utils.string_literal(none) }} as actual, 'None' as expected
+select {{ dbt_utils.string_literal("abc") }} as actual, 'abc' as expected {{ from_dual() }} union all
+select {{ dbt_utils.string_literal("1") }} as actual, '1' as expected {{ from_dual() }} union all
+select {{ dbt_utils.string_literal("") }} as actual, '' as expected {{ from_dual() }} union all
+select {{ dbt_utils.string_literal(none) }} as actual, 'None' as expected {{ from_dual() }}
 """
 
 

--- a/tests/functional/cross_db_utils/fixture_string_literal.py
+++ b/tests/functional/cross_db_utils/fixture_string_literal.py
@@ -2,10 +2,10 @@
 # string_literal
 
 models__test_string_literal_sql = """
-select {{ dbt_utils.string_literal("abc") }} as actual, 'abc' as expected {{ from_dual() }} union all
-select {{ dbt_utils.string_literal("1") }} as actual, '1' as expected {{ from_dual() }} union all
-select {{ dbt_utils.string_literal("") }} as actual, '' as expected {{ from_dual() }} union all
-select {{ dbt_utils.string_literal(none) }} as actual, 'None' as expected {{ from_dual() }}
+select {{ dbt_utils.string_literal("abc") }} as actual, 'abc' as expected {{ dbt_utils.from_dual() }} union all
+select {{ dbt_utils.string_literal("1") }} as actual, '1' as expected {{ dbt_utils.from_dual() }} union all
+select {{ dbt_utils.string_literal("") }} as actual, '' as expected {{ dbt_utils.from_dual() }} union all
+select {{ dbt_utils.string_literal(none) }} as actual, 'None' as expected {{ dbt_utils.from_dual() }}
 """
 
 


### PR DESCRIPTION
This is a:
- [ ] documentation update
- [ ] bug fix with no breaking changes
- [X] new functionality
- [ ] a breaking change

## Description & motivation
Postgres, Snowflake, BigQuery, and Redshift all allow selection of attributes without a `from` clause. For a minority of databases, a `from` clause is required (most notably [Oracle's DUAL table](https://en.wikipedia.org/wiki/DUAL_table#In_other_database_systems)).

We could consider creating a cross-database `from_dual` macro that returns an empty string in the default case. This would allow us to create datasets on the fly in a cross-database manner. The most common use-case might be within a CTE for the purposes of unit/functional/integration testing.

## Example

```sql
select {{ dbt_utils.string_literal("") }} as actual, '' as expected {{ from_dual() }} union all
select {{ dbt_utils.string_literal(none) }} as actual, 'None' as expected {{ from_dual() }}
```

For BigQuery, this would render to:
```sql
select '' as actual, '' as expected union all
select  'None' as actual, 'None' as expected
```

But for Oracle, it would render to:
```sql
select '' as actual, '' as expected from dual union all
select  'None' as actual, 'None' as expected from dual
```

## Checklist
- [ ] I have verified that these changes work locally on the following warehouses (Note: it's okay if you do not have access to all warehouses, this helps us understand what has been covered)
    - [ ] BigQuery
    - [ ] Postgres
    - [ ] Redshift
    - [ ] Snowflake
- [ ] I followed guidelines to ensure that my changes will work on "non-core" adapters by:
    - [ ] dispatching any new macro(s) so non-core adapters can also use them (e.g. [the `star()` source](https://github.com/fishtown-analytics/dbt-utils/blob/master/macros/sql/star.sql))
    - [ ] using the `limit_zero()` macro in place of the literal string: `limit 0`
    - [ ] using `dbt_utils.type_*` macros instead of explicit datatypes (e.g. `dbt_utils.type_timestamp()` instead of `TIMESTAMP`
- [ ] I have updated the README.md (if applicable)
- [ ] I have added tests & descriptions to my models (and macros if applicable)
- [ ] I have added an entry to CHANGELOG.md
