### PR TITLE
Add slugify to list of Jinja Helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ For compatibility details between versions of dbt-core and dbt-utils, [see this 
     - [pretty_time](#pretty_time-source)
     - [pretty_log_format](#pretty_log_format-source)
     - [log_info](#log_info-source)
+    - [slugify](#slugify-source)
 
 [Materializations](#materializations):
 - [insert_by_period](#insert_by_period-source)


### PR DESCRIPTION
This is a:
- [x] documentation update
- [ ] bug fix with no breaking changes
- [ ] new functionality
- [ ] a breaking change

All pull requests from community contributors should target the `main` branch (default).

## Description & motivation
<!---
Describe your changes, and why you're making them.
-->
Adds slugify to the list of Jinja Helper macros in the README
## Checklist
- [ ] I have verified that these changes work locally on the following warehouses (Note: it's okay if you do not have access to all warehouses, this helps us understand what has been covered)
    - [ ] BigQuery
    - [ ] Postgres
    - [ ] Redshift
    - [ ] Snowflake
- [ ] I followed guidelines to ensure that my changes will work on "non-core" adapters by:
    - [ ] dispatching any new macro(s) so non-core adapters can also use them (e.g. [the `star()` source](https://github.com/fishtown-analytics/dbt-utils/blob/master/macros/sql/star.sql))
    - [ ] using the `limit_zero()` macro in place of the literal string: `limit 0`
    - [ ] using `dbt_utils.type_*` macros instead of explicit datatypes (e.g. `dbt_utils.type_timestamp()` instead of `TIMESTAMP`
- [x] I have updated the README.md (if applicable)
- [ ] I have added tests & descriptions to my models (and macros if applicable)
- [ ] I have added an entry to CHANGELOG.md
