### PR TITLE
Only raise error within `union_relations` for build/run sub-commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-<!--- Uncomment the following headers as-needed for unreleased features
+<!--- Copy, paste, and uncomment the following headers as-needed for unreleased features
 # Unreleased
 ## New features
 ## Fixes
@@ -6,6 +6,19 @@
 ## Under the hood
 ## Contributors:
 --->
+
+# Unreleased
+
+<!--- ## New features --->
+
+## Fixes
+- Only raise error within `union_relations` for `build`/`run` sub-commands ([#606](https://github.com/dbt-labs/dbt-utils/issues/606), [#607](https://github.com/dbt-labs/dbt-utils/pull/607))
+
+<!--- ## Quality of life --->
+<!--- ## Under the hood --->
+
+## Contributors:
+- [@jeremyyeo](https://github.com/jeremyyeo) (#606)
 
 # dbt-utils v0.8.5
 ## 🚨 deduplicate ([#542](https://github.com/dbt-labs/dbt-utils/pull/542), [#548](https://github.com/dbt-labs/dbt-utils/pull/548))

--- a/macros/sql/union.sql
+++ b/macros/sql/union.sql
@@ -60,7 +60,10 @@
     {%- endfor -%}
 
     {%- set ordered_column_names = column_superset.keys() -%}
+    {%- set dbt_command = flags.WHICH -%}
 
+
+    {% if dbt_command in ['run', 'build'] %}
     {% if (include | length > 0 or exclude | length > 0) and not column_superset.keys() %}
         {%- set relations_string -%}
             {%- for relation in relations -%}
@@ -74,6 +77,7 @@
         {%- endset -%}
 
         {{ exceptions.raise_compiler_error(error_message) }}
+    {%- endif -%}
     {%- endif -%}
 
     {%- for relation in relations %}


### PR DESCRIPTION
This is a:
- [ ] documentation update
- [X] bug fix with no breaking changes
- [ ] new functionality
- [ ] a breaking change

All pull requests from community contributors should target the `main` branch (default).

## Description & motivation
Fixes #606

Thanks to @erika-e for reporting the issue with `dbt_utils.union_relations` on dbt Cloud and @jeremyyeo for figuring out what was happening and how to solve it.

Based on the description in #606, I'm guessing [slim CI](https://docs.getdbt.com/docs/dbt-cloud/using-dbt-cloud/cloud-enabling-continuous-integration) or something similar was being used. Regardless, I think we have a fix that will support other use-cases too, like [SQLFluff](https://www.sqlfluff.com/).

## Checklist
- [x] I have verified that these changes work locally
- [x] I have updated the README.md (if applicable)
- [x] I have added tests & descriptions to my models (and macros if applicable)
- [x] I have added an entry to CHANGELOG.md

## Implementation

I considered several variations for the implementation.

### Options for the boolean logic
[`flags.WHICH`](https://docs.getdbt.com/reference/dbt-jinja-functions/flags) isn't very well documented, but it identifies the dbt subcommand that is executing. It looks like it is [planned to be renamed](https://github.com/dbt-labs/dbt-core/issues/5262) in the future.

We know from Erika's error report that the problem is arising during `'generate'`, but it raises the question if more subcommands should be protected from this specific error too.

1. `flags.WHICH != 'generate'`
1. `flags.WHICH not in ['generate']`
1. `flags.WHICH not in ['compile', 'generate']`
1. `flags.WHICH in ['run', 'build']`
1. `flags.WHICH in ['test', 'run', 'build']`

I chose 4. as the most targeted since we know that we want `run` and `build` to raise an error, but the rest of the commands might be debatable.

### Options for readability
1. Partial abstraction
    ```
    {%- set dbt_command = flags.WHICH -%}
    {% if dbt_command in ['run', 'build'] %}
    ```
1. More full abstraction
    ```
    {%- set dbt_command = flags.WHICH -%}
    {%- set relevant_commands = ['run', 'build'] -%}
    {% if dbt_command in relevant_commands %}
    ```
    
Chose 1. as a balance of clarity and brevity.

### Options for where to place the boolean logic

1. Extend the existing if statement even further
    `{% if dbt_command in ['run', 'build'] and (include | length > 0 or exclude | length > 0) and not column_superset.keys() %}`
1. Trim the existing if statement (since parts might not be necessary anymore)
    `{% if dbt_command in ['run', 'build'] and not column_superset.keys() %}`
1. Wrap the existing error-raising section with`{% if dbt_command in ['run', 'build'] %}` ... `{%- endif -%}`
1. Wrap only the line that actually raises the error with`{% if dbt_command in ['run', 'build'] %}`
    ```
    {%- if dbt_command in ['run', 'build'] -%}
        {{ exceptions.raise_compiler_error(error_message) }}
    {%- endif -%}
    ```

I'm feeling too risk averse for 2. (especially given [#509](https://github.com/dbt-labs/dbt-utils/pull/509/files) as the response to #505) 😅 But I _do_ think 2. _would_ work based on what I've seen so far.

Opted for 3. because it guards all the error-raising logic in a tidy wrapper and yields the most readable diff.

### Future hopes
The `union_relations` macro is really cool because it handles the complex logic to union two relations that don't necessarily have the same columns. But it's grown organically and been fragile as a result (see [here](https://github.com/dbt-labs/dbt-utils/issues/606#issuecomment-1155949786) for a partial list of bug reports and fixes).

I'd love to see us:
1. invest in consolidating a prioritized list of all the desired behaviors
2. write applicable tests for each of those scenarios
3. re-factor this macro to meet each of those use-cases.
