### PR TITLE
Feature/add where to unique combination of columns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,11 +8,20 @@
 ## Contributors:
 --->
 
+# Unreleased
+## New features
+- New `where` clause parameter to `unique_combination_of_columns` test to filter values tested ([#612](https://github.com/dbt-labs/dbt-utils/pull/612))
+
+## Fixes
+## Quality of life
+## Under the hood
+## Contributors:
+- [@epapineau](https://github.com/epapineau) (#612)
+
 # dbt-utils v0.8.6
 
 ## New features
 - New macros `array_append` and `array_construct` ([#595](https://github.com/dbt-labs/dbt-utils/pull/595))
-- New `where` clause parameter to `unique_combination_of_columns` test to filter values tested ([#612](https://github.com/dbt-labs/dbt-utils/pull/612))
 
 ## Fixes
 - Use `*` in `star` macro if no columns (for SQLFluff) ([#605](https://github.com/dbt-labs/dbt-utils/issues/605), [#561](https://github.com/dbt-labs/dbt-utils/pull/561))
@@ -27,7 +36,7 @@
 ## Contributors:
 - [@swanjson](https://github.com/swanjson) (#561)
 - [@dataders](https://github.com/dataders) (#561)
-- [@epapineau](https://github.com/epapineau) (#612)
+- [@epapineau](https://github.com/epapineau) (#602)
 - [@graciegoheen](https://github.com/graciegoheen) (#595)
 - [@jeremyyeo](https://github.com/jeremyyeo) (#606)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 ## New features
 - New macros `array_append` and `array_construct` ([#595](https://github.com/dbt-labs/dbt-utils/pull/595))
+- New `where` clause parameter to `unique_combination_of_columns` test to filter values tested ([#612](https://github.com/dbt-labs/dbt-utils/pull/612))
 
 ## Fixes
 - Use `*` in `star` macro if no columns (for SQLFluff) ([#605](https://github.com/dbt-labs/dbt-utils/issues/605), [#561](https://github.com/dbt-labs/dbt-utils/pull/561))
@@ -26,7 +27,7 @@
 ## Contributors:
 - [@swanjson](https://github.com/swanjson) (#561)
 - [@dataders](https://github.com/dataders) (#561)
-- [@epapineau](https://github.com/epapineau) (#583)
+- [@epapineau](https://github.com/epapineau) (#612)
 - [@graciegoheen](https://github.com/graciegoheen) (#595)
 - [@jeremyyeo](https://github.com/jeremyyeo) (#606)
 

--- a/README.md
+++ b/README.md
@@ -478,7 +478,7 @@ in isolation.
 We generally recommend testing this uniqueness condition by either:
 * generating a [surrogate_key](#surrogate_key-source) for your model and testing
 the uniqueness of said key, OR
-* passing the `unique` test a concatenation of the columns (as discussed [here](https://docs.getdbt.com/docs/building-a-dbt-project/testing-and-documentation/testing/#testing-expressions)).
+* passing the `unique` test a concatenation of the columns.
 
 However, these approaches can become non-perfomant on large data sets, in which
 case we recommend using this test instead.

--- a/README.md
+++ b/README.md
@@ -493,18 +493,9 @@ case we recommend using this test instead.
           - product
 ```
 
-An optional `quote_columns` argument (`default=false`) can also be used if a column name needs to be quoted.
-
-```yaml
-- name: revenue_by_product_by_month
-  tests:
-    - dbt_utils.unique_combination_of_columns:
-        combination_of_columns:
-          - month
-          - group
-        quote_columns: true
-
-```
+**Args:**
+* `quote_columns` (default=false): Used when a column name needs to be quoted.
+* `where` (default=None): A where clause to filter the tested column values.
 
 #### accepted_range ([source](macros/generic_tests/accepted_range.sql))
 Asserts that a column's values fall inside an expected range. Any combination of `min_value` and `max_value` is allowed, and the range can be inclusive or exclusive. Provide a `where` argument to filter to specific records only.

--- a/integration_tests/data/schema_tests/data_unique_combination_of_columns_where.csv
+++ b/integration_tests/data/schema_tests/data_unique_combination_of_columns_where.csv
@@ -1,0 +1,7 @@
+id,is_x
+1,true
+1,false
+2,true
+2,false
+2,false
+2,false

--- a/integration_tests/data/schema_tests/data_unique_combination_of_columns_where.csv
+++ b/integration_tests/data/schema_tests/data_unique_combination_of_columns_where.csv
@@ -1,7 +1,0 @@
-id,is_x
-1,true
-1,false
-2,true
-2,false
-2,false
-2,false

--- a/integration_tests/data/schema_tests/data_unique_combination_of_columns_where_failing.csv
+++ b/integration_tests/data/schema_tests/data_unique_combination_of_columns_where_failing.csv
@@ -1,0 +1,7 @@
+id,color
+1,orange
+1,blue
+2,orange
+2,orange
+2,blue
+2,blue

--- a/integration_tests/data/schema_tests/data_unique_combination_of_columns_where_passing.csv
+++ b/integration_tests/data/schema_tests/data_unique_combination_of_columns_where_passing.csv
@@ -1,0 +1,7 @@
+id,color
+1,orange
+1,blue
+2,orange
+2,blue
+2,blue
+2,blue

--- a/integration_tests/models/generic_tests/schema.yml
+++ b/integration_tests/models/generic_tests/schema.yml
@@ -105,6 +105,14 @@ seeds:
             - month
             - product
   
+  - name: data_unique_combination_of_columns_where
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+            - id
+            - is_x
+          where: "is_x = true"
+  
   - name: data_cardinality_equality_a
     columns:
       - name: same_name

--- a/integration_tests/models/generic_tests/schema.yml
+++ b/integration_tests/models/generic_tests/schema.yml
@@ -105,14 +105,26 @@ seeds:
             - month
             - product
   
-  - name: data_unique_combination_of_columns_where
+  - name: data_unique_combination_of_columns_where_passing
     tests:
       - dbt_utils.unique_combination_of_columns:
           combination_of_columns:
             - id
-            - is_x
-          where: "is_x = true"
+            - color
+          where: "color = 'orange'"
   
+  - name: data_unique_combination_of_columns_where_failing
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+            - id
+            - color
+          where: "color = 'orange'"
+          config:
+            severity: error
+            error_if: "<1"
+            warn_if: "<0"
+
   - name: data_cardinality_equality_a
     columns:
       - name: same_name

--- a/macros/generic_tests/unique_combination_of_columns.sql
+++ b/macros/generic_tests/unique_combination_of_columns.sql
@@ -1,8 +1,8 @@
 {% test unique_combination_of_columns(model, combination_of_columns, quote_columns=false) %}
-  {{ return(adapter.dispatch('test_unique_combination_of_columns', 'dbt_utils')(model, combination_of_columns, quote_columns)) }}
+  {{ return(adapter.dispatch('test_unique_combination_of_columns', 'dbt_utils')(model, combination_of_columns, quote_columns, where=none)) }}
 {% endtest %}
 
-{% macro default__test_unique_combination_of_columns(model, combination_of_columns, quote_columns=false) %}
+{% macro default__test_unique_combination_of_columns(model, combination_of_columns, quote_columns=false, where=none) %}
 
 {% if not quote_columns %}
     {%- set column_list=combination_of_columns %}
@@ -25,6 +25,11 @@ with validation_errors as (
     select
         {{ columns_csv }}
     from {{ model }}
+
+    {% if where is not none %}
+        where {{ where }}
+    {% endif %}
+
     group by {{ columns_csv }}
     having count(*) > 1
 


### PR DESCRIPTION
This is a:
- [ ] documentation update
- [ ] bug fix with no breaking changes
- [x] new functionality
- [ ] a breaking change

All pull requests from community contributors should target the `main` branch (default).

## Description & motivation
<!---
Describe your changes, and why you're making them.
-->
Resolves #610 by adding a where clause to `unique_combination_of_columns` test
## Checklist
- [x] I have verified that these changes work locally on the following warehouses (Note: it's okay if you do not have access to all warehouses, this helps us understand what has been covered)
    - [ ] BigQuery
    - [x] Postgres
    - [ ] Redshift
    - [ ] Snowflake
- [ ] I followed guidelines to ensure that my changes will work on "non-core" adapters by:
    - [ ] dispatching any new macro(s) so non-core adapters can also use them (e.g. [the `star()` source](https://github.com/fishtown-analytics/dbt-utils/blob/master/macros/sql/star.sql))
    - [ ] using the `limit_zero()` macro in place of the literal string: `limit 0`
    - [ ] using `dbt_utils.type_*` macros instead of explicit datatypes (e.g. `dbt_utils.type_timestamp()` instead of `TIMESTAMP`
- [x] I have updated the README.md (if applicable)
- [x] I have added tests & descriptions to my models (and macros if applicable)
- [x] I have added an entry to CHANGELOG.md
