### PR TITLE
standardize yml indentation under the 'models:' line on the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,17 +163,17 @@ This macro can also be used at the column level. When this is done, the `express
 ```yaml
 version: 2
 models:
-    - name: model_name
-      columns:
-        - name: col_a
-          tests:
-            - dbt_utils.expression_is_true:
-                expression: '>= 1'
-        - name: col_b
-          tests:
-            - dbt_utils.expression_is_true:
-                expression: '= 1'
-                condition: col_a = 1
+  - name: model_name
+    columns:
+      - name: col_a
+        tests:
+          - dbt_utils.expression_is_true:
+              expression: '>= 1'
+      - name: col_b
+        tests:
+          - dbt_utils.expression_is_true:
+              expression: '= 1'
+              condition: col_a = 1
 ```
 
 #### recency ([source](macros/generic_tests/recency.sql))
@@ -383,13 +383,13 @@ to the `lower_` and `upper_bound_column` arguments, like so:
 version: 2
 
 models:
-- name: subscriptions
-  tests:
-    - dbt_utils.mutually_exclusive_ranges:
-        lower_bound_column: coalesce(started_at, '1900-01-01')
-        upper_bound_column: coalesce(ended_at, '2099-12-31')
-        partition_by: customer_id
-        gaps: allowed
+  - name: subscriptions
+    tests:
+      - dbt_utils.mutually_exclusive_ranges:
+          lower_bound_column: coalesce(started_at, '1900-01-01')
+          upper_bound_column: coalesce(ended_at, '2099-12-31')
+          partition_by: customer_id
+          gaps: allowed
 ```
 <details>
 <summary>Additional `gaps` and `zero_length_range_allowed` examples</summary>


### PR DESCRIPTION
This is a:
- [x] documentation update
- [ ] bug fix with no breaking changes
- [ ] new functionality
- [ ] a breaking change

All pull requests from community contributors should target the `main` branch (default).

## Description & motivation
The yml indentation in the README is inconsistent. As someone who is not a yml expert but tries to stay consistent, wants my team to be consistent, and aspires to mostly get my yml indentation right on the first go, it is confusing to see inconsistency in the README.

## Checklist
- [ ] I have verified that these changes work locally on the following warehouses (Note: it's okay if you do not have access to all warehouses, this helps us understand what has been covered)
    - [ ] BigQuery
    - [ ] Postgres
    - [ ] Redshift
    - [ ] Snowflake
- [ ] I followed guidelines to ensure that my changes will work on "non-core" adapters by:
    - [ ] dispatching any new macro(s) so non-core adapters can also use them (e.g. [the `star()` source](https://github.com/fishtown-analytics/dbt-utils/blob/master/macros/sql/star.sql))
    - [ ] using the `limit_zero()` macro in place of the literal string: `limit 0`
    - [ ] using `dbt_utils.type_*` macros instead of explicit datatypes (e.g. `dbt_utils.type_timestamp()` instead of `TIMESTAMP`
- [x] I have updated the README.md (if applicable)
- [ ] I have added tests & descriptions to my models (and macros if applicable)
- [ ] I have added an entry to CHANGELOG.md
