### PR TITLE
Docs cleanup

### DIFF
--- a/.github/ISSUE_TEMPLATE/dbt_minor_release.md
+++ b/.github/ISSUE_TEMPLATE/dbt_minor_release.md
@@ -26,4 +26,4 @@ If tests fail, this _is_ a breaking change. You'll need to create a minor releas
 - [ ] Fix any errors
 - [ ] Merge `dev` into `master`
 - [ ] Create a minor release
-- [ ] Once the release is available on hub, [create a new issue](https://github.com/fishtown-analytics/dbt-utils/issues/new/choose) using the "dbt-utils Minor Release Checklist" template
+- [ ] Once the release is available on hub, [create a new issue](https://github.com/dbt-labs/dbt-utils/issues/new/choose) using the "dbt-utils Minor Release Checklist" template

--- a/.github/ISSUE_TEMPLATE/dbt_minor_release.md
+++ b/.github/ISSUE_TEMPLATE/dbt_minor_release.md
@@ -14,16 +14,16 @@ In the future, we will consider doing pre-releases.
 First, check if this is a breaking change
 - [ ] Increase the upper bound of the `require-dbt-version` config in the `dbt_project.yml`
 - [ ] Increase the upper bound of the dbt version in `run_test.sh`
-- [ ] Create a PR against the `master` branch to see if tests pass
+- [ ] Create a PR against the `main` branch to see if tests pass
 
 If test pass, this is _not_ a breaking change. You should:
-- [ ] Merge into `master`
+- [ ] Merge into `main`
 - [ ] Create a patch release
 
 If tests fail, this _is_ a breaking change. You'll need to create a minor release:
 - [ ] Change the PR base to be against the next `dev` branch.
 - [ ] Increase the lower bound to the current dbt minor version in both the `dbt_project.yml` and `run_test.sh` files
 - [ ] Fix any errors
-- [ ] Merge `dev` into `master`
+- [ ] Merge `dev` into `main`
 - [ ] Create a minor release
 - [ ] Once the release is available on hub, [create a new issue](https://github.com/dbt-labs/dbt-utils/issues/new/choose) using the "dbt-utils Minor Release Checklist" template

--- a/.github/ISSUE_TEMPLATE/utils_minor_release.md
+++ b/.github/ISSUE_TEMPLATE/utils_minor_release.md
@@ -27,12 +27,12 @@ If this _is_ a breaking change:
 ## Checklist of dependent packages
 | Package                                                                      | PR     | Release     |
 |------------------------------------------------------------------------------|--------|-------------|
-| [audit-helper](https://github.com/fishtown-analytics/dbt-audit-helper)       | [PR]() | [Release]() |
-| [codegen](https://github.com/fishtown-analytics/dbt-codegen)                 | [PR]() | [Release]() |
-| [redshift](https://github.com/fishtown-analytics/redshift)                   | [PR]() | [Release]() |
-| [event-logging](https://github.com/fishtown-analytics/dbt-event-logging)     | [PR]() | [Release]() |
-| [snowplow](https://github.com/fishtown-analytics/snowplow)                   | [PR]() | [Release]() |
-| [external-tables](https://github.com/fishtown-analytics/dbt-external-tables) | [PR]() | [Release]() |
-| [segment](https://github.com/fishtown-analytics/segment)                     | [PR]() | [Release]() |
-| [facebook-ads](https://github.com/fishtown-analytics/facebook-ads)           | [PR]() | [Release]() |
-| [stitch-utils](https://github.com/fishtown-analytics/stitch-utils)           | [PR]() | [Release]() |
+| [audit-helper](https://github.com/dbt-labs/dbt-audit-helper)                 | [PR]() | [Release]() |
+| [codegen](https://github.com/dbt-labs/dbt-codegen)                           | [PR]() | [Release]() |
+| [redshift](https://github.com/dbt-labs/redshift)                             | [PR]() | [Release]() |
+| [event-logging](https://github.com/dbt-labs/dbt-event-logging)               | [PR]() | [Release]() |
+| [snowplow](https://github.com/dbt-labs/snowplow)                             | [PR]() | [Release]() |
+| [external-tables](https://github.com/dbt-labs/dbt-external-tables)           | [PR]() | [Release]() |
+| [segment](https://github.com/dbt-labs/segment)                               | [PR]() | [Release]() |
+| [facebook-ads](https://github.com/dbt-labs/facebook-ads)                     | [PR]() | [Release]() |
+| [stitch-utils](https://github.com/dbt-labs/stitch-utils)                     | [PR]() | [Release]() |

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -18,7 +18,7 @@ Describe your changes, and why you're making them.
     - [ ] Redshift
     - [ ] Snowflake
 - [ ] I followed guidelines to ensure that my changes will work on "non-core" adapters by:
-    - [ ] dispatching any new macro(s) so non-core adapters can also use them (e.g. [the `star()` source](https://github.com/dbt-labs/dbt-utils/blob/master/macros/sql/star.sql))
+    - [ ] dispatching any new macro(s) so non-core adapters can also use them (e.g. [the `star()` source](https://github.com/dbt-labs/dbt-utils/blob/main/macros/sql/star.sql))
     - [ ] using the `limit_zero()` macro in place of the literal string: `limit 0`
     - [ ] using `dbt_utils.type_*` macros instead of explicit datatypes (e.g. `dbt_utils.type_timestamp()` instead of `TIMESTAMP`
 - [ ] I have updated the README.md (if applicable)

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -18,7 +18,7 @@ Describe your changes, and why you're making them.
     - [ ] Redshift
     - [ ] Snowflake
 - [ ] I followed guidelines to ensure that my changes will work on "non-core" adapters by:
-    - [ ] dispatching any new macro(s) so non-core adapters can also use them (e.g. [the `star()` source](https://github.com/fishtown-analytics/dbt-utils/blob/master/macros/sql/star.sql))
+    - [ ] dispatching any new macro(s) so non-core adapters can also use them (e.g. [the `star()` source](https://github.com/dbt-labs/dbt-utils/blob/master/macros/sql/star.sql))
     - [ ] using the `limit_zero()` macro in place of the literal string: `limit 0`
     - [ ] using `dbt_utils.type_*` macros instead of explicit datatypes (e.g. `dbt_utils.type_timestamp()` instead of `TIMESTAMP`
 - [ ] I have updated the README.md (if applicable)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -214,7 +214,7 @@ After:
 
 ## Under the hood
 
-- Declare compatibility with dbt v0.21.0, which has no breaking changes for this package ([#398](https://github.com/fishtown-analytics/dbt-utils/pull/398))
+- Declare compatibility with dbt v0.21.0, which has no breaking changes for this package ([#398](https://github.com/https://github.com/dbt-labs/dbt-utils-analytics/dbt-utils/pull/398))
 
 
 # dbt-utils v0.7.0
@@ -262,68 +262,68 @@ If you were relying on the position to match up your optional arguments, this ma
 ```
 
 ## Features
-* Add new argument, `order_by`, to `get_column_values` (code originally in [#289](https://github.com/fishtown-analytics/dbt-utils/pull/289/) from [@clausherther](https://github.com/clausherther), merged via [#349](https://github.com/fishtown-analytics/dbt-utils/pull/349/))
-* Add `slugify` macro, and use it in the pivot macro. :rotating_light: This macro uses the `re` module, which is only available in dbt v0.19.0+. As a result, this feature introduces a breaking change. ([#314](https://github.com/fishtown-analytics/dbt-utils/pull/314))
+* Add new argument, `order_by`, to `get_column_values` (code originally in [#289](https://github.com/https://github.com/dbt-labs/dbt-utils-analytics/dbt-utils/pull/289/) from [@clausherther](https://github.com/clausherther), merged via [#349](https://github.com/https://github.com/dbt-labs/dbt-utils-analytics/dbt-utils/pull/349/))
+* Add `slugify` macro, and use it in the pivot macro. :rotating_light: This macro uses the `re` module, which is only available in dbt v0.19.0+. As a result, this feature introduces a breaking change. ([#314](https://github.com/https://github.com/dbt-labs/dbt-utils-analytics/dbt-utils/pull/314))
 * Add `not_null_proportion` generic test that allows the user to specify the minimum (`at_least`) tolerated proportion (e.g., `0.95`) of non-null values
 
 ## Under the hood
-* Update the default implementation of concat macro to use `||` operator ([#373](https://github.com/fishtown-analytics/dbt-utils/pull/314) from [@ChristopheDuong](https://github.com/ChristopheDuong)). Note this may be a breaking change for adapters that support `concat()` but not `||`, such as Apache Spark.
-- Use `power()` instead of `pow()` in `generate_series()` and `haversine_distance()` as they are synonyms in most SQL dialects, but some dialects only have `power()` ([#354](https://github.com/fishtown-analytics/dbt-utils/pull/354) from [@swanderz](https://github.com/swanderz))
+* Update the default implementation of concat macro to use `||` operator ([#373](https://github.com/https://github.com/dbt-labs/dbt-utils-analytics/dbt-utils/pull/314) from [@ChristopheDuong](https://github.com/ChristopheDuong)). Note this may be a breaking change for adapters that support `concat()` but not `||`, such as Apache Spark.
+- Use `power()` instead of `pow()` in `generate_series()` and `haversine_distance()` as they are synonyms in most SQL dialects, but some dialects only have `power()` ([#354](https://github.com/https://github.com/dbt-labs/dbt-utils-analytics/dbt-utils/pull/354) from [@swanderz](https://github.com/swanderz))
 - Make `get_column_values` return the default value passed as a parameter instead of an empty string before compilation ([#304](https://github.com/dbt-labs/dbt-utils/pull/386) from [@jmriego](https://github.com/jmriego)
 
 # dbt-utils v0.6.6
 
 ## Fixes
 
-- make `sequential_values` generic test use `dbt_utils.type_timestamp()` to allow for compatibility with db's without timestamp data type. [#376](https://github.com/fishtown-analytics/dbt-utils/pull/376) from [@swanderz](https://github.com/swanderz)
+- make `sequential_values` generic test use `dbt_utils.type_timestamp()` to allow for compatibility with db's without timestamp data type. [#376](https://github.com/https://github.com/dbt-labs/dbt-utils-analytics/dbt-utils/pull/376) from [@swanderz](https://github.com/swanderz)
 
 # dbt-utils v0.6.5
 ## Features
-* Add new `accepted_range` test ([#276](https://github.com/fishtown-analytics/dbt-utils/pull/276) [@joellabes](https://github.com/joellabes))
-* Make `expression_is_true` work as a column test (code originally in [#226](https://github.com/fishtown-analytics/dbt-utils/pull/226/) from [@elliottohara](https://github.com/elliottohara), merged via [#313](https://github.com/fishtown-analytics/dbt-utils/pull/313/))
-* Add new generic test, `not_accepted_values` ([#284](https://github.com/fishtown-analytics/dbt-utils/pull/284) [@JavierMonton](https://github.com/JavierMonton))
-* Support a new argument, `zero_length_range_allowed` in the `mutually_exclusive_ranges` test ([#307](https://github.com/fishtown-analytics/dbt-utils/pull/307) [@zemekeneng](https://github.com/zemekeneng))
-* Add new generic test, `sequential_values` ([#318](https://github.com/fishtown-analytics/dbt-utils/pull/318), inspired by [@hundredwatt](https://github.com/hundredwatt))
-* Support `quarter` in the `postgres__last_day` macro ([#333](https://github.com/fishtown-analytics/dbt-utils/pull/333/files) [@seunghanhong](https://github.com/seunghanhong))
-* Add new argument, `unit`, to `haversine_distance` ([#340](https://github.com/fishtown-analytics/dbt-utils/pull/340) [@bastienboutonnet](https://github.com/bastienboutonnet))
-* Add new generic test, `fewer_rows_than` (code originally in [#221](https://github.com/fishtown-analytics/dbt-utils/pull/230/) from [@dmarts](https://github.com/dmarts), merged via [#343](https://github.com/fishtown-analytics/dbt-utils/pull/343/))
+* Add new `accepted_range` test ([#276](https://github.com/https://github.com/dbt-labs/dbt-utils-analytics/dbt-utils/pull/276) [@joellabes](https://github.com/joellabes))
+* Make `expression_is_true` work as a column test (code originally in [#226](https://github.com/https://github.com/dbt-labs/dbt-utils-analytics/dbt-utils/pull/226/) from [@elliottohara](https://github.com/elliottohara), merged via [#313](https://github.com/https://github.com/dbt-labs/dbt-utils-analytics/dbt-utils/pull/313/))
+* Add new generic test, `not_accepted_values` ([#284](https://github.com/https://github.com/dbt-labs/dbt-utils-analytics/dbt-utils/pull/284) [@JavierMonton](https://github.com/JavierMonton))
+* Support a new argument, `zero_length_range_allowed` in the `mutually_exclusive_ranges` test ([#307](https://github.com/https://github.com/dbt-labs/dbt-utils-analytics/dbt-utils/pull/307) [@zemekeneng](https://github.com/zemekeneng))
+* Add new generic test, `sequential_values` ([#318](https://github.com/https://github.com/dbt-labs/dbt-utils-analytics/dbt-utils/pull/318), inspired by [@hundredwatt](https://github.com/hundredwatt))
+* Support `quarter` in the `postgres__last_day` macro ([#333](https://github.com/https://github.com/dbt-labs/dbt-utils-analytics/dbt-utils/pull/333/files) [@seunghanhong](https://github.com/seunghanhong))
+* Add new argument, `unit`, to `haversine_distance` ([#340](https://github.com/https://github.com/dbt-labs/dbt-utils-analytics/dbt-utils/pull/340) [@bastienboutonnet](https://github.com/bastienboutonnet))
+* Add new generic test, `fewer_rows_than` (code originally in [#221](https://github.com/https://github.com/dbt-labs/dbt-utils-analytics/dbt-utils/pull/230/) from [@dmarts](https://github.com/dmarts), merged via [#343](https://github.com/https://github.com/dbt-labs/dbt-utils-analytics/dbt-utils/pull/343/))
 
 ## Fixes
-* Handle booleans gracefully in the unpivot macro ([#305](https://github.com/fishtown-analytics/dbt-utils/pull/305) [@avishalom](https://github.com/avishalom))
-* Fix a bug in `get_relation_by_prefix` that happens with Snowflake external tables. Now the macro will retrieve tables that match the prefix which are external tables ([#351](https://github.com/fishtown-analytics/dbt-utils/pull/351))
-* Fix `cardinality_equality` test when the two tables' column names differed ([#334](https://github.com/fishtown-analytics/dbt-utils/pull/334) [@joellabes](https://github.com/joellabes))
+* Handle booleans gracefully in the unpivot macro ([#305](https://github.com/https://github.com/dbt-labs/dbt-utils-analytics/dbt-utils/pull/305) [@avishalom](https://github.com/avishalom))
+* Fix a bug in `get_relation_by_prefix` that happens with Snowflake external tables. Now the macro will retrieve tables that match the prefix which are external tables ([#351](https://github.com/https://github.com/dbt-labs/dbt-utils-analytics/dbt-utils/pull/351))
+* Fix `cardinality_equality` test when the two tables' column names differed ([#334](https://github.com/https://github.com/dbt-labs/dbt-utils-analytics/dbt-utils/pull/334) [@joellabes](https://github.com/joellabes))
 
 ## Under the hood
-* Fix Markdown formatting for hub rendering ([#336](https://github.com/fishtown-analytics/dbt-utils/issues/350) [@coapacetic](https://github.com/coapacetic))
+* Fix Markdown formatting for hub rendering ([#336](https://github.com/https://github.com/dbt-labs/dbt-utils-analytics/dbt-utils/issues/350) [@coapacetic](https://github.com/coapacetic))
 * Reorder readme and improve docs
 
 # dbt-utils v0.6.4
 
 ### Fixes
-- Fix `insert_by_period` to support `dbt v0.19.0`, with backwards compatibility for earlier versions ([#319](https://github.com/fishtown-analytics/dbt-utils/pull/319), [#320](https://github.com/fishtown-analytics/dbt-utils/pull/320))
+- Fix `insert_by_period` to support `dbt v0.19.0`, with backwards compatibility for earlier versions ([#319](https://github.com/https://github.com/dbt-labs/dbt-utils-analytics/dbt-utils/pull/319), [#320](https://github.com/https://github.com/dbt-labs/dbt-utils-analytics/dbt-utils/pull/320))
 
 ### Under the hood
-- Speed up CI via threads, workflows ([#315](https://github.com/fishtown-analytics/dbt-utils/pull/315), [#316](https://github.com/fishtown-analytics/dbt-utils/pull/316))
-- Fix `equality` test when used with ephemeral models + explicit column set ([#321](https://github.com/fishtown-analytics/dbt-utils/pull/321))
-- Fix `get_query_results_as_dict` integration test with consistent ordering ([#322](https://github.com/fishtown-analytics/dbt-utils/pull/322))
-- All macros are now properly dispatched, making it possible for non-core adapters to implement a shim package for dbt-utils ([#312](https://github.com/fishtown-analytics/dbt-utils/pull/312)) Thanks [@chaerinlee1](https://github.com/chaerinlee1) and [@swanderz](https://github.com/swanderz)
-- Small, non-breaking changes to accomodate TSQL (can't group by column number references, no real TRUE/FALSE values, aggregation CTEs need named columns) ([#310](https://github.com/fishtown-analytics/dbt-utils/pull/310)) Thanks [@swanderz](https://github.com/swanderz)
-- Make `get_relations_by_pattern` and `get_relations_by_prefix` more powerful by returning `relation.type` ([#323](https://github.com/fishtown-analytics/dbt-utils/pull/323))
+- Speed up CI via threads, workflows ([#315](https://github.com/https://github.com/dbt-labs/dbt-utils-analytics/dbt-utils/pull/315), [#316](https://github.com/https://github.com/dbt-labs/dbt-utils-analytics/dbt-utils/pull/316))
+- Fix `equality` test when used with ephemeral models + explicit column set ([#321](https://github.com/https://github.com/dbt-labs/dbt-utils-analytics/dbt-utils/pull/321))
+- Fix `get_query_results_as_dict` integration test with consistent ordering ([#322](https://github.com/https://github.com/dbt-labs/dbt-utils-analytics/dbt-utils/pull/322))
+- All macros are now properly dispatched, making it possible for non-core adapters to implement a shim package for dbt-utils ([#312](https://github.com/https://github.com/dbt-labs/dbt-utils-analytics/dbt-utils/pull/312)) Thanks [@chaerinlee1](https://github.com/chaerinlee1) and [@swanderz](https://github.com/swanderz)
+- Small, non-breaking changes to accomodate TSQL (can't group by column number references, no real TRUE/FALSE values, aggregation CTEs need named columns) ([#310](https://github.com/https://github.com/dbt-labs/dbt-utils-analytics/dbt-utils/pull/310)) Thanks [@swanderz](https://github.com/swanderz)
+- Make `get_relations_by_pattern` and `get_relations_by_prefix` more powerful by returning `relation.type` ([#323](https://github.com/https://github.com/dbt-labs/dbt-utils-analytics/dbt-utils/pull/323))
 
 # dbt-utils v0.6.3
 
-- Bump `require-dbt-version` to `[">=0.18.0", "<0.20.0"]` to support dbt v0.19.0 ([#308](https://github.com/fishtown-analytics/dbt-utils/pull/308), [#309](https://github.com/fishtown-analytics/dbt-utils/pull/309))
+- Bump `require-dbt-version` to `[">=0.18.0", "<0.20.0"]` to support dbt v0.19.0 ([#308](https://github.com/https://github.com/dbt-labs/dbt-utils-analytics/dbt-utils/pull/308), [#309](https://github.com/https://github.com/dbt-labs/dbt-utils-analytics/dbt-utils/pull/309))
 
 # dbt-utils v0.6.2
 
 ## Fixes
-- Fix the logic in `get_tables_by_pattern_sql` to ensure non-default arguments are respected ([#279](https://github.com/fishtown-analytics/dbt-utils/pull/279))
+- Fix the logic in `get_tables_by_pattern_sql` to ensure non-default arguments are respected ([#279](https://github.com/https://github.com/dbt-labs/dbt-utils-analytics/dbt-utils/pull/279))
 
 
 # dbt-utils v0.6.1
 
 ## Fixes
-- Fix the logic in `get_tables_by_pattern_sql` for matching a schema pattern on BigQuery ([#275](https://github.com/fishtown-analytics/dbt-utils/pull/275/))
+- Fix the logic in `get_tables_by_pattern_sql` for matching a schema pattern on BigQuery ([#275](https://github.com/https://github.com/dbt-labs/dbt-utils-analytics/dbt-utils/pull/275/))
 
 # dbt-utils v0.6.0
 
@@ -357,18 +357,18 @@ If you were relying on the position to match up your optional arguments, this ma
 
 * Switch usage of `adapter_macro` to `adapter.dispatch`, and define `dbt_utils_dispatch_list`,
 enabling users of community-supported database plugins to add or override macro implementations
-specific to their database ([#267](https://github.com/fishtown-analytics/dbt-utils/pull/267))
+specific to their database ([#267](https://github.com/https://github.com/dbt-labs/dbt-utils-analytics/dbt-utils/pull/267))
 * Use `add_ephemeral_prefix` instead of hard-coding a string literal, to support
-database adapters that use different prefixes ([#267](https://github.com/fishtown-analytics/dbt-utils/pull/267))
-* Implement a quote_columns argument in the unique_combination_of_columns generic test ([#270](https://github.com/fishtown-analytics/dbt-utils/pull/270) [@JoshuaHuntley](https://github.com/JoshuaHuntley))
+database adapters that use different prefixes ([#267](https://github.com/https://github.com/dbt-labs/dbt-utils-analytics/dbt-utils/pull/267))
+* Implement a quote_columns argument in the unique_combination_of_columns generic test ([#270](https://github.com/https://github.com/dbt-labs/dbt-utils-analytics/dbt-utils/pull/270) [@JoshuaHuntley](https://github.com/JoshuaHuntley))
 
 ## Quality of life
-* Remove deprecated macros `get_tables_by_prefix` and `union_tables` ([#268](https://github.com/fishtown-analytics/dbt-utils/pull/268))
-* Remove `get_tables_by_pattern` macro, which is equivalent to the `get_tables_by_pattern_sql` macro (the latter has a more logical name) ([#268](https://github.com/fishtown-analytics/dbt-utils/pull/268))
+* Remove deprecated macros `get_tables_by_prefix` and `union_tables` ([#268](https://github.com/https://github.com/dbt-labs/dbt-utils-analytics/dbt-utils/pull/268))
+* Remove `get_tables_by_pattern` macro, which is equivalent to the `get_tables_by_pattern_sql` macro (the latter has a more logical name) ([#268](https://github.com/https://github.com/dbt-labs/dbt-utils-analytics/dbt-utils/pull/268))
 
 # dbt-utils v0.5.1
 
 ## Quality of life
-* Improve release process, and fix tests ([#251](https://github.com/fishtown-analytics/dbt-utils/pull/251))
-* Make deprecation warnings more useful ([#258](https://github.com/fishtown-analytics/dbt-utils/pull/258) [@tayloramurphy](https://github.com/tayloramurphy))
-* Add more docs for `date_spine` ([#265](https://github.com/fishtown-analytics/dbt-utils/pull/265) [@calvingiles](https://github.com/calvingiles))
+* Improve release process, and fix tests ([#251](https://github.com/https://github.com/dbt-labs/dbt-utils-analytics/dbt-utils/pull/251))
+* Make deprecation warnings more useful ([#258](https://github.com/https://github.com/dbt-labs/dbt-utils-analytics/dbt-utils/pull/258) [@tayloramurphy](https://github.com/tayloramurphy))
+* Add more docs for `date_spine` ([#265](https://github.com/https://github.com/dbt-labs/dbt-utils-analytics/dbt-utils/pull/265) [@calvingiles](https://github.com/calvingiles))

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -58,7 +58,7 @@ A deep understanding of these tools in not required to effectively contribute to
 Ensure that changes will work on "non-core" adapters by:
 - dispatching any new macro(s) so non-core adapters can also use them (e.g. [the `star()` source](https://github.com/fishtown-analytics/dbt-utils/blob/master/macros/sql/star.sql))
 - using the `limit_zero()` macro in place of the literal string: `limit 0`
-- using `dbt_utils.type_*` macros instead of explicit datatypes (e.g. `dbt_utils.type_timestamp()` instead of `TIMESTAMP`
+- using [`type_*` macros](https://docs.getdbt.com/reference/dbt-jinja-functions/cross-database-macros#data-type-functions) instead of explicit datatypes (e.g. [`type_timestamp()`](https://docs.getdbt.com/reference/dbt-jinja-functions/cross-database-macros#type_timestamp) instead of `TIMESTAMP`
 
 ## Testing
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -80,6 +80,6 @@ You don't need to worry about which `dbt-utils` version your change will go into
 
 A `dbt-utils` maintainer will review your PR. They may suggest code revision for style or clarity, or request that you add unit or integration test(s). These are good things! We believe that, with a little bit of help, anyone can contribute high-quality code.
 
-Automated tests run via CircleCI. If you're a first-time contributor, all tests (including code checks and unit tests) will require a maintainer to approve. Changes in the `dbt-utils` repository trigger integration tests against Postgres [TODO]. dbt Labs also provides CI environments in which to test changes to other adapters, triggered by PRs in those adapters' repositories, as well as periodic maintenance checks of each adapter in concert with the latest `dbt-utils` code changes.
+Automated tests run via CircleCI. If you're a first-time contributor, all tests (including code checks and unit tests) will require a maintainer to approve. Changes in the `dbt-utils` repository trigger integration tests.
 
 Once all tests are passing and your PR has been approved, a `dbt-utils` maintainer will merge your changes into the active development branch. And that's it! Happy developing :tada:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -56,7 +56,7 @@ A deep understanding of these tools in not required to effectively contribute to
 ## Implementation guidelines
 
 Ensure that changes will work on "non-core" adapters by:
-- dispatching any new macro(s) so non-core adapters can also use them (e.g. [the `star()` source](https://github.com/fishtown-analytics/dbt-utils/blob/master/macros/sql/star.sql))
+- dispatching any new macro(s) so non-core adapters can also use them (e.g. [the `star()` source](https://github.com/dbt-labs/dbt-utils/blob/main/macros/sql/star.sql))
 - using the `limit_zero()` macro in place of the literal string: `limit 0`
 - using [`type_*` macros](https://docs.getdbt.com/reference/dbt-jinja-functions/cross-database-macros#data-type-functions) instead of explicit datatypes (e.g. [`type_timestamp()`](https://docs.getdbt.com/reference/dbt-jinja-functions/cross-database-macros#type_timestamp) instead of `TIMESTAMP`
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -16,20 +16,20 @@ There's a few scenarios that might prompt a release:
 ## Branching strategy
 
 At any point, there should be two long-lived branches:
-- `master` (default): This reflects the most recent release of dbt-utils
+- `main` (default): This reflects the most recent release of dbt-utils
 - `dev/0.x.0`: This reflects the next minor release, where `x` will be replaced with the minor version number
 
-The `dev/0.x.0` branch should be merged into `master` branch when new releases are created.
+The `dev/0.x.0` branch should be merged into `main` branch when new releases are created.
 
 ## Process for minor releases
 e.g. for releasing `0.x.0`
-1. Create the PR to merge `dev/0.x.0` into `master`. Also update the `Changelog` as part of this PR, and merge it.
-2. Create the GitHub release from the `master` branch.
-3. Delete the `dev/0.x.0` branch, and create a new branch `dev/0.x+1.0` from `master`, adding branch protection to it.
-4. [Create a new issue](https://github.com/fishtown-analytics/dbt-utils/issues/new/choose) from the "dbt-utils Minor Release Follow-Up" template to also update any dependencies.
+1. Create the PR to merge `dev/0.x.0` into `main`. Also update the `CHANGELOG` as part of this PR, and merge it.
+2. Create the GitHub release from the `main` branch.
+3. Delete the `dev/0.x.0` branch, and create a new branch `dev/0.x+1.0` from `main`, adding branch protection to it.
+4. [Create a new issue](https://github.com/dbt-labs/dbt-utils/issues/new/choose) from the "dbt-utils Minor Release Follow-Up" template to also update any dependencies.
 
 ## Process for patch releases
 1. Create the release.
-2. Then rebase the current `dev/0.x.0` branch on top of the `master` branch so that any fixes will be included in the next minor release.
+2. Then rebase the current `dev/0.x.0` branch on top of the `main` branch so that any fixes will be included in the next minor release.
 
 No dependent packages need to be updated for patch releases (e.g. codegen, audit-helper)

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,5 +1,7 @@
 # dbt-utils releases
 
+TODO - update the following content since it is not up-to-date.
+
 ## When do we release?
 There's a few scenarios that might prompt a release:
 

--- a/integration_tests/README.md
+++ b/integration_tests/README.md
@@ -108,10 +108,10 @@ This directory contains an example dbt project which tests the macros in the `db
 
 For an example integration tests, check out the tests for the `get_url_parameter` macro:
 
-1. [Macro definition](https://github.com/fishtown-analytics/dbt-utils/blob/master/macros/web/get_url_parameter.sql)
-2. [Seed file with fake data](https://github.com/fishtown-analytics/dbt-utils/blob/master/integration_tests/data/web/data_urls.csv)
-3. [Model to test the macro](https://github.com/fishtown-analytics/dbt-utils/blob/master/integration_tests/models/web/test_urls.sql)
-4. [A generic test to assert the macro works as expected](https://github.com/fishtown-analytics/dbt-utils/blob/master/integration_tests/models/web/schema.yml#L2)
+1. [Macro definition](https://github.com/dbt-labs/dbt-utils/blob/master/macros/web/get_url_parameter.sql)
+2. [Seed file with fake data](https://github.com/dbt-labs/dbt-utils/blob/master/integration_tests/data/web/data_urls.csv)
+3. [Model to test the macro](https://github.com/dbt-labs/dbt-utils/blob/master/integration_tests/models/web/test_urls.sql)
+4. [A generic test to assert the macro works as expected](https://github.com/dbt-labs/dbt-utils/blob/master/integration_tests/models/web/schema.yml)
 
 Once you've added all of these files, you should be able to run:
 

--- a/integration_tests/README.md
+++ b/integration_tests/README.md
@@ -108,10 +108,10 @@ This directory contains an example dbt project which tests the macros in the `db
 
 For an example integration tests, check out the tests for the `get_url_parameter` macro:
 
-1. [Macro definition](https://github.com/dbt-labs/dbt-utils/blob/master/macros/web/get_url_parameter.sql)
-2. [Seed file with fake data](https://github.com/dbt-labs/dbt-utils/blob/master/integration_tests/data/web/data_urls.csv)
-3. [Model to test the macro](https://github.com/dbt-labs/dbt-utils/blob/master/integration_tests/models/web/test_urls.sql)
-4. [A generic test to assert the macro works as expected](https://github.com/dbt-labs/dbt-utils/blob/master/integration_tests/models/web/schema.yml)
+1. [Macro definition](https://github.com/dbt-labs/dbt-utils/blob/main/macros/web/get_url_parameter.sql)
+2. [Seed file with fake data](https://github.com/dbt-labs/dbt-utils/blob/main/integration_tests/data/web/data_urls.csv)
+3. [Model to test the macro](https://github.com/dbt-labs/dbt-utils/blob/main/integration_tests/models/web/test_urls.sql)
+4. [A generic test to assert the macro works as expected](https://github.com/dbt-labs/dbt-utils/blob/main/integration_tests/models/web/schema.yml)
 
 Once you've added all of these files, you should be able to run:
 


### PR DESCRIPTION
This is a:
- [X] documentation update
- [ ] bug fix with no breaking changes
- [ ] new functionality
- [ ] a breaking change

All pull requests from community contributors should target the `main` branch (default).

## Description & motivation
The docs were out-of-date in a few areas:
- GitHub URLs referring to fishtown-analytics org
- name of default branch
- other little bits

So this was a quick pass at cleaning up some areas. It was not fully comprehensive; I left a TODO regarding updating `RELEASE.md`.

## Checklist
None of the following items were applicable in this case:
- [X] ~I have updated the README.md (if applicable)~
- [X] ~I have added tests & descriptions to my models (and macros if applicable)~
- [X] ~I have added an entry to CHANGELOG.md (if applicable)~
