### PR TITLE
dbt Core 1.2 and utils 0.9.0 prep

### DIFF
--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -1,7 +1,7 @@
 name: 'dbt_utils'
 version: '0.1.0'
 
-require-dbt-version: [">=1.2.0-rc1", "<2.0.0"]
+require-dbt-version: [">=1.2.0", "<2.0.0"]
 
 config-version: 2
 

--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -1,7 +1,7 @@
 name: 'dbt_utils'
 version: '0.1.0'
 
-require-dbt-version: [">=1.0.0", "<2.0.0"]
+require-dbt-version: [">=1.2.0-rc1", "<2.0.0"]
 
 config-version: 2
 

--- a/macros/cross_db_utils/any_value.sql
+++ b/macros/cross_db_utils/any_value.sql
@@ -1,9 +1,8 @@
-{# This is here for backwards compatibility only #}
-
 {% macro any_value(expression) -%}
     {{ return(adapter.dispatch('any_value', 'dbt_utils') (expression)) }}
 {% endmacro %}
 
 {% macro default__any_value(expression) -%}
+    {% do dbt_utils.xdb_deprecation_warning('any_value', model.package_name, model.name) %}
     {{ return(adapter.dispatch('any_value', 'dbt') (expression)) }}
 {% endmacro %}

--- a/macros/cross_db_utils/bool_or.sql
+++ b/macros/cross_db_utils/bool_or.sql
@@ -1,9 +1,8 @@
-{# This is here for backwards compatibility only #}
-
 {% macro bool_or(expression) -%}
     {{ return(adapter.dispatch('bool_or', 'dbt_utils') (expression)) }}
 {% endmacro %}
 
 {% macro default__bool_or(expression) -%}
+    {% do dbt_utils.xdb_deprecation_warning('bool_or', model.package_name, model.name) %}
     {{ return(adapter.dispatch('bool_or', 'dbt') (expression)) }}
 {% endmacro %}

--- a/macros/cross_db_utils/cast_bool_to_text.sql
+++ b/macros/cross_db_utils/cast_bool_to_text.sql
@@ -1,9 +1,8 @@
-{# This is here for backwards compatibility only #}
-
 {% macro cast_bool_to_text(field) %}
   {{ adapter.dispatch('cast_bool_to_text', 'dbt_utils') (field) }}
 {% endmacro %}
 
 {% macro default__cast_bool_to_text(field) %}
+  {% do dbt_utils.xdb_deprecation_warning('cast_bool_to_text', model.package_name, model.name) %}
   {{ adapter.dispatch('cast_bool_to_text', 'dbt') (field) }}
 {% endmacro %}

--- a/macros/cross_db_utils/concat.sql
+++ b/macros/cross_db_utils/concat.sql
@@ -1,9 +1,8 @@
-{# This is here for backwards compatibility only #}
-
 {% macro concat(fields) -%}
   {{ return(adapter.dispatch('concat', 'dbt_utils')(fields)) }}
 {%- endmacro %}
 
 {% macro default__concat(fields) -%}
+  {% do dbt_utils.xdb_deprecation_warning('concat', model.package_name, model.name) %}
   {{ return(adapter.dispatch('concat', 'dbt')(fields)) }}
 {%- endmacro %}

--- a/macros/cross_db_utils/datatypes.sql
+++ b/macros/cross_db_utils/datatypes.sql
@@ -1,6 +1,3 @@
-{# These macros have been moved into dbt-core #}
-{# Here for backwards compatibility ONLY #}
-
 {# string  -------------------------------------------------     #}
 
 {%- macro type_string() -%}
@@ -8,6 +5,7 @@
 {%- endmacro -%}
 
 {% macro default__type_string() %}
+    {% do dbt_utils.xdb_deprecation_warning('type_string', model.package_name, model.name) %}
     {{ return(adapter.dispatch('type_string', 'dbt')()) }}
 {% endmacro %}
 
@@ -19,6 +17,7 @@
 {%- endmacro -%}
 
 {% macro default__type_timestamp() %}
+    {% do dbt_utils.xdb_deprecation_warning('type_timestamp', model.package_name, model.name) %}
     {{ return(adapter.dispatch('type_timestamp', 'dbt')()) }}
 {% endmacro %}
 
@@ -30,6 +29,7 @@
 {%- endmacro -%}
 
 {% macro default__type_float() %}
+    {% do dbt_utils.xdb_deprecation_warning('type_float', model.package_name, model.name) %}
     {{ return(adapter.dispatch('type_float', 'dbt')()) }}
 {% endmacro %}
 
@@ -41,6 +41,7 @@
 {%- endmacro -%}
 
 {% macro default__type_numeric() %}
+    {% do dbt_utils.xdb_deprecation_warning('type_numeric', model.package_name, model.name) %}
     {{ return(adapter.dispatch('type_numeric', 'dbt')()) }}
 {% endmacro %}
 
@@ -52,6 +53,7 @@
 {%- endmacro -%}
 
 {% macro default__type_bigint() %}
+    {% do dbt_utils.xdb_deprecation_warning('type_bigint', model.package_name, model.name) %}
     {{ return(adapter.dispatch('type_bigint', 'dbt')()) }}
 {% endmacro %}
 
@@ -63,5 +65,6 @@
 {%- endmacro -%}
 
 {% macro default__type_int() %}
+    {% do dbt_utils.xdb_deprecation_warning('type_int', model.package_name, model.name) %}
     {{ return(adapter.dispatch('type_int', 'dbt')()) }}
 {% endmacro %}

--- a/macros/cross_db_utils/date_trunc.sql
+++ b/macros/cross_db_utils/date_trunc.sql
@@ -1,9 +1,8 @@
-{# This is here for backwards compatibility only #}
-
 {% macro date_trunc(datepart, date) -%}
   {{ return(adapter.dispatch('date_trunc', 'dbt_utils') (datepart, date)) }}
 {%- endmacro %}
 
 {% macro default__date_trunc(datepart, date) -%}
+  {% do dbt_utils.xdb_deprecation_warning('date_trunc', model.package_name, model.name) %}
   {{ return(adapter.dispatch('date_trunc', 'dbt') (datepart, date)) }}
 {%- endmacro %}

--- a/macros/cross_db_utils/dateadd.sql
+++ b/macros/cross_db_utils/dateadd.sql
@@ -1,9 +1,8 @@
-{# This is here for backwards compatibility only #}
-
 {% macro dateadd(datepart, interval, from_date_or_timestamp) %}
   {{ return(adapter.dispatch('dateadd', 'dbt_utils')(datepart, interval, from_date_or_timestamp)) }}
 {% endmacro %}
 
 {% macro default__dateadd(datepart, interval, from_date_or_timestamp) %}
+  {% do dbt_utils.xdb_deprecation_warning('dateadd', model.package_name, model.name) %}
   {{ return(adapter.dispatch('dateadd', 'dbt')(datepart, interval, from_date_or_timestamp)) }}
 {% endmacro %}

--- a/macros/cross_db_utils/datediff.sql
+++ b/macros/cross_db_utils/datediff.sql
@@ -1,9 +1,8 @@
-{# This is here for backwards compatibility only #}
-
 {% macro datediff(first_date, second_date, datepart) %}
   {{ return(adapter.dispatch('datediff', 'dbt_utils')(first_date, second_date, datepart)) }}
 {% endmacro %}
 
 {% macro default__datediff(first_date, second_date, datepart) %}
+  {% do dbt_utils.xdb_deprecation_warning('datediff', model.package_name, model.name) %}
   {{ return(adapter.dispatch('datediff', 'dbt')(first_date, second_date, datepart)) }}
 {% endmacro %}

--- a/macros/cross_db_utils/escape_single_quotes.sql
+++ b/macros/cross_db_utils/escape_single_quotes.sql
@@ -1,9 +1,8 @@
-{# This is here for backwards compatibility only #}
-
 {% macro escape_single_quotes(expression) %}
       {{ return(adapter.dispatch('escape_single_quotes', 'dbt_utils') (expression)) }}
 {% endmacro %}
 
 {% macro default__escape_single_quotes(expression) %}
+      {% do dbt_utils.xdb_deprecation_warning('escape_single_quotes', model.package_name, model.name) %}
       {{ return(adapter.dispatch('escape_single_quotes', 'dbt') (expression)) }}
 {% endmacro %}

--- a/macros/cross_db_utils/except.sql
+++ b/macros/cross_db_utils/except.sql
@@ -1,9 +1,8 @@
-{# This is here for backwards compatibility only #}
-
 {% macro except() %}
   {{ return(adapter.dispatch('except', 'dbt_utils')()) }}
 {% endmacro %}
 
 {% macro default__except() %}
+  {% do dbt_utils.xdb_deprecation_warning('except', model.package_name, model.name) %}
   {{ return(adapter.dispatch('except', 'dbt')()) }}
 {% endmacro %}

--- a/macros/cross_db_utils/hash.sql
+++ b/macros/cross_db_utils/hash.sql
@@ -1,9 +1,8 @@
-{# This is here for backwards compatibility only #}
-
 {% macro hash(field) -%}
   {{ return(adapter.dispatch('hash', 'dbt_utils') (field)) }}
 {%- endmacro %}
 
 {% macro default__hash(field) -%}
+  {% do dbt_utils.xdb_deprecation_warning('hash', model.package_name, model.name) %}
   {{ return(adapter.dispatch('hash', 'dbt') (field)) }}
 {%- endmacro %}

--- a/macros/cross_db_utils/intersect.sql
+++ b/macros/cross_db_utils/intersect.sql
@@ -1,9 +1,8 @@
-{# This is here for backwards compatibility only #}
-
 {% macro intersect() %}
   {{ return(adapter.dispatch('intersect', 'dbt_utils')()) }}
 {% endmacro %}
 
 {% macro default__intersect() %}
+  {% do dbt_utils.xdb_deprecation_warning('intersect', model.package_name, model.name) %}
   {{ return(adapter.dispatch('intersect', 'dbt')()) }}
 {% endmacro %}

--- a/macros/cross_db_utils/last_day.sql
+++ b/macros/cross_db_utils/last_day.sql
@@ -1,5 +1,3 @@
-{# This is here for backwards compatibility only #}
-
 /*
 This function has been tested with dateparts of month and quarters. Further
 testing is required to validate that it will work on other dateparts.
@@ -10,5 +8,6 @@ testing is required to validate that it will work on other dateparts.
 {% endmacro %}
 
 {% macro default__last_day(date, datepart) %}
+  {% do dbt_utils.xdb_deprecation_warning('last_day', model.package_name, model.name) %}
   {{ return(adapter.dispatch('last_day', 'dbt') (date, datepart)) }}
 {% endmacro %}

--- a/macros/cross_db_utils/length.sql
+++ b/macros/cross_db_utils/length.sql
@@ -1,9 +1,8 @@
-{# This is here for backwards compatibility only #}
-
 {% macro length(expression) -%}
     {{ return(adapter.dispatch('length', 'dbt_utils') (expression)) }}
 {% endmacro %}
 
 {% macro default__length(expression) -%}
+    {% do dbt_utils.xdb_deprecation_warning('length', model.package_name, model.name) %}
     {{ return(adapter.dispatch('length', 'dbt') (expression)) }}
 {% endmacro %}

--- a/macros/cross_db_utils/listagg.sql
+++ b/macros/cross_db_utils/listagg.sql
@@ -1,9 +1,8 @@
-{# This is here for backwards compatibility only #}
-
 {% macro listagg(measure, delimiter_text="','", order_by_clause=none, limit_num=none) -%}
     {{ return(adapter.dispatch('listagg', 'dbt_utils') (measure, delimiter_text, order_by_clause, limit_num)) }}
 {%- endmacro %}
 
 {% macro default__listagg(measure, delimiter_text="','", order_by_clause=none, limit_num=none) -%}
+    {% do dbt_utils.xdb_deprecation_warning('listagg', model.package_name, model.name) %}
     {{ return(adapter.dispatch('listagg', 'dbt') (measure, delimiter_text, order_by_clause, limit_num)) }}
 {%- endmacro %}

--- a/macros/cross_db_utils/literal.sql
+++ b/macros/cross_db_utils/literal.sql
@@ -1,9 +1,8 @@
-{# This is here for backwards compatibility only #}
-
 {%- macro string_literal(value) -%}
   {{ return(adapter.dispatch('string_literal', 'dbt_utils') (value)) }}
 {%- endmacro -%}
 
 {%- macro default__string_literal(value) -%}
+  {% do dbt_utils.xdb_deprecation_warning('string_literal', model.package_name, model.name) %}
   {{ return(adapter.dispatch('string_literal', 'dbt') (value)) }}
 {%- endmacro -%}

--- a/macros/cross_db_utils/position.sql
+++ b/macros/cross_db_utils/position.sql
@@ -1,9 +1,8 @@
-{# This is here for backwards compatibility only #}
-
 {% macro position(substring_text, string_text) -%}
     {{ return(adapter.dispatch('position', 'dbt_utils') (substring_text, string_text)) }}
 {% endmacro %}
 
 {% macro default__position(substring_text, string_text) -%}
+    {% do dbt_utils.xdb_deprecation_warning('position', model.package_name, model.name) %}
     {{ return(adapter.dispatch('position', 'dbt') (substring_text, string_text)) }}
 {% endmacro %}

--- a/macros/cross_db_utils/replace.sql
+++ b/macros/cross_db_utils/replace.sql
@@ -1,9 +1,8 @@
-{# This is here for backwards compatibility only #}
-
 {% macro replace(field, old_chars, new_chars) -%}
     {{ return(adapter.dispatch('replace', 'dbt_utils') (field, old_chars, new_chars)) }}
 {% endmacro %}
 
 {% macro default__replace(field, old_chars, new_chars) -%}
+  {% do dbt_utils.xdb_deprecation_warning('replace', model.package_name, model.name) %}
     {{ return(adapter.dispatch('replace', 'dbt') (field, old_chars, new_chars)) }}
 {% endmacro %}

--- a/macros/cross_db_utils/right.sql
+++ b/macros/cross_db_utils/right.sql
@@ -1,9 +1,8 @@
-{# This is here for backwards compatibility only #}
-
 {% macro right(string_text, length_expression) -%}
     {{ return(adapter.dispatch('right', 'dbt_utils') (string_text, length_expression)) }}
 {% endmacro %}
 
 {% macro default__right(string_text, length_expression) -%}
+    {% do dbt_utils.xdb_deprecation_warning('right', model.package_name, model.name) %}
     {{ return(adapter.dispatch('right', 'dbt') (string_text, length_expression)) }}
 {% endmacro %}

--- a/macros/cross_db_utils/safe_cast.sql
+++ b/macros/cross_db_utils/safe_cast.sql
@@ -1,9 +1,8 @@
-{# This is here for backwards compatibility only #}
-
 {% macro safe_cast(field, type) %}
   {{ return(adapter.dispatch('safe_cast', 'dbt_utils') (field, type)) }}
 {% endmacro %}
 
 {% macro default__safe_cast(field, type) %}
+  {% do dbt_utils.xdb_deprecation_warning('safe_cast', model.package_name, model.name) %}
   {{ return(adapter.dispatch('safe_cast', 'dbt') (field, type)) }}
 {% endmacro %}

--- a/macros/cross_db_utils/split_part.sql
+++ b/macros/cross_db_utils/split_part.sql
@@ -1,9 +1,8 @@
-{# This is here for backwards compatibility only #}
-
 {% macro split_part(string_text, delimiter_text, part_number) %}
   {{ return(adapter.dispatch('split_part', 'dbt_utils') (string_text, delimiter_text, part_number)) }}
 {% endmacro %}
 
 {% macro default__split_part(string_text, delimiter_text, part_number) %}
+  {% do dbt_utils.xdb_deprecation_warning('split_part', model.package_name, model.name) %}
   {{ return(adapter.dispatch('split_part', 'dbt') (string_text, delimiter_text, part_number)) }}
 {% endmacro %}

--- a/macros/cross_db_utils/xdb_deprecation_warning.sql
+++ b/macros/cross_db_utils/xdb_deprecation_warning.sql
@@ -1,4 +1,4 @@
 {% macro xdb_deprecation_warning(macro, package, model) %}
-    {%- set error_message = "Warning: the `" ~ macro ~"` macro is no longer available in dbt_utils and backwards compatibility will be removed in a future version. Use `dbt." ~ macro ~ "` instead. The " ~ package ~ "." ~ model ~ " model triggered this warning." -%}
+    {%- set error_message = "Warning: the `" ~ macro ~"` macro is now provided in dbt Core. It is no longer available in dbt_utils and backwards compatibility will be removed in a future version of the package. Use `" ~ macro ~ "` (no prefix) instead. The " ~ package ~ "." ~ model ~ " model triggered this warning." -%}
     {%- do exceptions.warn(error_message) -%}
 {% endmacro %}

--- a/macros/cross_db_utils/xdb_deprecation_warning.sql
+++ b/macros/cross_db_utils/xdb_deprecation_warning.sql
@@ -1,0 +1,4 @@
+{% macro xdb_deprecation_warning(macro, package, model) %}
+    {%- set error_message = "Warning: the `" ~ macro ~"` macro is no longer available in dbt_utils and backwards compatibility will be removed in a future version. Use `dbt." ~ macro ~ "` instead. The " ~ package ~ "." ~ model ~ " model triggered this warning." -%}
+    {%- do exceptions.warn(error_message) -%}
+{% endmacro %}

--- a/macros/materializations/insert_by_period_materialization.sql
+++ b/macros/materializations/insert_by_period_materialization.sql
@@ -55,6 +55,9 @@
   {%- set start_date = config.require('start_date') -%}
   {%- set stop_date = config.get('stop_date') or '' -%}
   {%- set period = config.get('period') or 'week' -%}
+  
+  {%- set deprecation_warning = "Warning: the `insert_by_period` materialization will be removed from dbt_utils in version 1.0.0. Prepare to switch to installing from dbt-labs/dbt-labs-experimental-features (see https://github.com/dbt-labs/dbt-utils/discussions/487). The " ~ package ~ "." ~ model ~ " model triggered this warning." -%}
+  {%- do exceptions.warn(deprecation_warning) -%}
 
   {%- if sql.find('__PERIOD_FILTER__') == -1 -%}
     {%- set error_message -%}

--- a/macros/materializations/insert_by_period_materialization.sql
+++ b/macros/materializations/insert_by_period_materialization.sql
@@ -56,7 +56,7 @@
   {%- set stop_date = config.get('stop_date') or '' -%}
   {%- set period = config.get('period') or 'week' -%}
   
-  {%- set deprecation_warning = "Warning: the `insert_by_period` materialization will be removed from dbt_utils in version 1.0.0. Prepare to switch to installing from dbt-labs/dbt-labs-experimental-features (see https://github.com/dbt-labs/dbt-utils/discussions/487). The " ~ package ~ "." ~ model ~ " model triggered this warning." -%}
+  {%- set deprecation_warning = "Warning: the `insert_by_period` materialization will be removed from dbt_utils in version 1.0.0. Install from dbt-labs/dbt-labs-experimental-features instead (see https://github.com/dbt-labs/dbt-utils/discussions/487). The " ~ package ~ "." ~ model ~ " model triggered this warning." -%}
   {%- do exceptions.warn(deprecation_warning) -%}
 
   {%- if sql.find('__PERIOD_FILTER__') == -1 -%}


### PR DESCRIPTION
This is a:
- [ ] documentation update
- [x] bug fix with no breaking changes
- [ ] new functionality
- [ ] a breaking change

All pull requests from community contributors should target the `main` branch (default).

## Description & motivation
The cross-db macros have been moved to dbt Core in v1.2. They already were dispatched to the `dbt` project, but now there are also deprecation warnings which will show during compilation. I've also bumped the min dbt version to 1.2-rc1. 

I think that with these changes, we could release utils 0.9.0-rc1 immediately, and release 0.9.0 final when 1.2 final ships.

## Checklist
- [ ] I have verified that these changes work locally on the following warehouses (Note: it's okay if you do not have access to all warehouses, this helps us understand what has been covered)
    - [ ] BigQuery
    - [ ] Postgres
    - [ ] Redshift
    - [ ] Snowflake
- [ ] I followed guidelines to ensure that my changes will work on "non-core" adapters by:
    - [ ] dispatching any new macro(s) so non-core adapters can also use them (e.g. [the `star()` source](https://github.com/dbt-labs/dbt-utils/blob/main/macros/sql/star.sql))
    - [ ] using the `limit_zero()` macro in place of the literal string: `limit 0`
    - [ ] using `dbt_utils.type_*` macros instead of explicit datatypes (e.g. `dbt_utils.type_timestamp()` instead of `TIMESTAMP`
- [ ] I have updated the README.md (if applicable)
- [ ] I have added tests & descriptions to my models (and macros if applicable)
- [ ] I have added an entry to CHANGELOG.md
