### PR TITLE
Fix - Quote columns in unpivot

### DIFF
--- a/macros/sql/unpivot.sql
+++ b/macros/sql/unpivot.sql
@@ -10,13 +10,14 @@ Arguments:
     remove: A list of columns to remove from the resulting table. Default is none.
     field_name: Destination table column name for the source table column names.
     value_name: Destination table column name for the pivoted values
+    quote_columns: Flag for whether or not the columns being pivoted require quoting
 #}
 
-{% macro unpivot(relation=none, cast_to='varchar', exclude=none, remove=none, field_name='field_name', value_name='value', table=none) -%}
-    {{ return(adapter.dispatch('unpivot', 'dbt_utils')(relation, cast_to, exclude, remove, field_name, value_name, table)) }}
+{% macro unpivot(relation=none, cast_to='varchar', exclude=none, remove=none, field_name='field_name', value_name='value', quote_columns=false, table=none) -%}
+    {{ return(adapter.dispatch('unpivot', 'dbt_utils')(relation, cast_to, exclude, remove, field_name, value_name, quote_columns, table)) }}
 {% endmacro %}
 
-{% macro default__unpivot(relation=none, cast_to='varchar', exclude=none, remove=none, field_name='field_name', value_name='value', table=none) -%}
+{% macro default__unpivot(relation=none, cast_to='varchar', exclude=none, remove=none, field_name='field_name', value_name='value', quote_columns=false, table=none) -%}
 
     {% if table %}
         {%- set error_message = '
@@ -63,9 +64,9 @@ Arguments:
 
       cast('{{ col.column }}' as {{ dbt_utils.type_string() }}) as {{ field_name }},
       cast(  {% if col.data_type == 'boolean' %}
-           {{ dbt_utils.cast_bool_to_text(col.column) }}
+           {% if quote_columns == true %}"{{ dbt_utils.cast_bool_to_text(col.column) }}"{% else %}{{ dbt_utils.cast_bool_to_text(col.column) }}{% endif %}
              {% else %}
-           {{ col.column }}
+           {% if quote_columns == true %}"{{ col.column }}"{% else %}{{ col.column }}{% endif %}
              {% endif %}
            as {{ cast_to }}) as {{ value_name }}
 


### PR DESCRIPTION
This is a:
- [ ] documentation update
- [x] bug fix with no breaking changes
- [ ] new functionality
- [ ] a breaking change

## Description & motivation
 Closes #216 

When unpivoting column names that require quotations (dates, strings with spaces, etc) `unpivot.sql` doesn't respect `quote_columns=true` or anything like that.

I wanted to open this to get input on best methodology before adding tests:
* Should this be a new argument?
* Should this respect the `quote_columns` config instead?
* Other?

## Checklist
- [x] I have verified that these changes work locally on the following warehouses (Note: it's okay if you do not have access to all warehouses, this helps us understand what has been covered)
    - [ ] BigQuery
    - [ ] Postgres
    - [ ] Redshift
    - [x] Snowflake
- [ ] I followed guidelines to ensure that my changes will work on "non-core" adapters by:
    - [ ] dispatching any new macro(s) so non-core adapters can also use them (e.g. [the `star()` source](https://github.com/dbt-labs/dbt-utils/blob/main/macros/sql/star.sql))
    - [ ] using the `limit_zero()` macro in place of the literal string: `limit 0`
    - [ ] using `dbt_utils.type_*` macros instead of explicit datatypes (e.g. `dbt_utils.type_timestamp()` instead of `TIMESTAMP`
- [ ] I have updated the README.md (if applicable)
- [ ] I have added tests & descriptions to my models (and macros if applicable)
- [ ] I have added an entry to CHANGELOG.md
