### PR TITLE
Add retrive_column macro

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@
 
 ## Quality of life
 - Add slugify to list of Jinja Helpers ([#602](https://github.com/dbt-labs/dbt-utils/pull/602))
+- Add retreive_columns to the list of Jinja Helpers
 
 ## Under the hood
 - Fix `make test` for running integration tests locally ([#344](https://github.com/dbt-labs/dbt-utils/issues/344), [#564](https://github.com/dbt-labs/dbt-utils/issues/564), [#591](https://github.com/dbt-labs/dbt-utils/pull/591))

--- a/macros/jinja_helpers/retrieve_columns.sql
+++ b/macros/jinja_helpers/retrieve_columns.sql
@@ -1,0 +1,27 @@
+{% macro retrieve_columns_test(columns, starts=False, is_dict=False, prefix=none) -%}
+{%- if prefix -%}
+    {%- set prefix_and_dot = prefix+'.' -%}
+{% else -%}
+    {%- set prefix_and_dot = '' -%}
+{%- endif -%}
+
+{%- if is_dict  -%}
+    {%- for key, value  in columns.items() %}
+        {% if loop.first and starts-%}
+            {{prefix_and_dot}}{{key}} as {{value}}
+        {% else -%}
+            , {{prefix_and_dot}}{{key}} as {{value}}
+        {%- endif -%}
+    {%- endfor -%}
+
+{% else -%}
+    {%- for col  in columns %}
+        {% if loop.first and starts-%}
+            {{prefix_and_dot}}{{col}}
+        {% else -%}
+            , {{prefix_and_dot}}{{col}}
+        {%- endif -%}
+    {%- endfor %}
+{% endif %}
+
+{% endmacro -%}


### PR DESCRIPTION
This is a:
- [ ] documentation update
- [ ] bug fix with no breaking changes
- [X] new functionality
- [ ] a breaking change

All pull requests from community contributors should target the `main` branch (default).

## Description & motivation
<!---
This is a new jinja helper function. We have been using this function internally for awhile, and individuals find it very useful and it ensures consistency in our code. 
-->

## Checklist
- [ ] I have verified that these changes work locally on the following warehouses (Note: it's okay if you do not have access to all warehouses, this helps us understand what has been covered)
    - [ ] BigQuery
    - [ ] Postgres
    - [ ] Redshift
    - [x] Snowflake
- [ ] I followed guidelines to ensure that my changes will work on "non-core" adapters by:
    - [ ] dispatching any new macro(s) so non-core adapters can also use them (e.g. [the `star()` source](https://github.com/dbt-labs/dbt-utils/blob/main/macros/sql/star.sql))
    - [ ] using the `limit_zero()` macro in place of the literal string: `limit 0`
    - [ ] using `dbt_utils.type_*` macros instead of explicit datatypes (e.g. `dbt_utils.type_timestamp()` instead of `TIMESTAMP`
- [x] I have updated the README.md (if applicable)
- [ ] I have added tests & descriptions to my models (and macros if applicable)
- [x] I have added an entry to CHANGELOG.md
