### PR TITLE
Use adapter.quote() for get_table_types_sql

### DIFF
--- a/macros/sql/get_table_types_sql.sql
+++ b/macros/sql/get_table_types_sql.sql
@@ -8,7 +8,7 @@
                 when 'EXTERNAL TABLE' then 'external'
                 when 'MATERIALIZED VIEW' then 'materializedview'
                 else lower(table_type)
-            end as "table_type"
+            end as {{ adapter.quote('table_type') }}
 {% endmacro %}
 
 
@@ -18,14 +18,5 @@
                 when 'FOREIGN' then 'external'
                 when 'MATERIALIZED VIEW' then 'materializedview'
                 else lower(table_type)
-            end as "table_type"
-{% endmacro %}
-
-{% macro bigquery__get_table_types_sql() %}
-            case table_type
-                when 'BASE TABLE' then 'table'
-                when 'EXTERNAL TABLE' then 'external'
-                when 'MATERIALIZED VIEW' then 'materializedview'
-                else lower(table_type)
-            end as `table_type`
+            end as {{ adapter.quote('table_type') }}
 {% endmacro %}

--- a/macros/sql/get_tables_by_pattern_sql.sql
+++ b/macros/sql/get_tables_by_pattern_sql.sql
@@ -6,8 +6,8 @@
 {% macro default__get_tables_by_pattern_sql(schema_pattern, table_pattern, exclude='', database=target.database) %}
 
         select distinct
-            table_schema as "table_schema",
-            table_name as "table_name",
+            table_schema as {{ adapter.quote('table_schema') }},
+            table_name as {{ adapter.quote('table_name') }},
             {{ dbt_utils.get_table_types_sql() }}
         from {{ database }}.information_schema.tables
         where table_schema ilike '{{ schema_pattern }}'


### PR DESCRIPTION
Resolves https://github.com/dbt-labs/dbt-utils/issues/572

## Checklist
- [ ] I have verified that these changes work locally on the following warehouses (Note: it's okay if you do not have access to all warehouses, this helps us understand what has been covered)
    - [x] BigQuery
    - [x] Postgres
    - [ ] Redshift
    - [ ] Snowflake
- [ ] I followed guidelines to ensure that my changes will work on "non-core" adapters by:
    - [x] dispatching any new macro(s) so non-core adapters can also use them (e.g. [the `star()` source](https://github.com/dbt-labs/dbt-utils/blob/main/macros/sql/star.sql))
    - [ ] using the `limit_zero()` macro in place of the literal string: `limit 0`
    - [ ] using `dbt_utils.type_*` macros instead of explicit datatypes (e.g. `dbt_utils.type_timestamp()` instead of `TIMESTAMP`
- [ ] I have updated the README.md (if applicable)
- [ ] I have added tests & descriptions to my models (and macros if applicable)
- [ ] I have added an entry to CHANGELOG.md
