### PR TITLE
add oracle flavor of date_trunc

### DIFF
--- a/macros/cross_db_utils/date_trunc.sql
+++ b/macros/cross_db_utils/date_trunc.sql
@@ -6,3 +6,20 @@
   {% do dbt_utils.xdb_deprecation_warning('date_trunc', model.package_name, model.name) %}
   {{ return(adapter.dispatch('date_trunc', 'dbt') (datepart, date)) }}
 {%- endmacro %}
+
+{#-/* reference: https://www.techonthenet.com/oracle/functions/trunc_date.php */#}
+{% macro oracle__date_trunc(datepart, date) -%}
+{%- if datepart == 'day' -%}
+    trunc({{date}}, 'DDD')  
+{%- elif datepart == 'week' -%}
+    trunc({{date}}, 'WW')  
+{%- elif datepart == 'month' -%}
+    trunc({{date}}, 'MON') 
+{%- elif datepart == 'quarter' -%}
+    trunc({{date}}, 'Q')        
+{%- elif datepart == 'year' -%}
+    trunc({{date}}, 'YYYY')
+{% else %}
+        {{ exceptions.raise_compiler_error("Unsupported datepart for macro date_trunc in oracle: {!r}".format(datepart)) }}    
+{%- endif -%}    
+{%- endmacro %}


### PR DESCRIPTION


This is a:
- [ ] documentation update
- [ ] bug fix with no breaking changes
- [x ] new functionality
- [ ] a breaking change

All pull requests from community contributors should target the `main` branch (default).

## Description & motivation
<!---
oracle flavor of date_trunc macro
supports day, month, week, quarter, year...to support dbt-metric functionality. 
if something else it picked as an option, compiler error is raised like postgress datediff macro
-->

## Checklist
- [ x] I have verified that these changes work locally on the following warehouses (Note: it's okay if you do not have access to all warehouses, this helps us understand what has been covered)
    - [ ] BigQuery
    - [ ] Postgres
    - [ ] Redshift
    - [ ] Snowflake
    - [ x] Oracle
- [x ] I followed guidelines to ensure that my changes will work on "non-core" adapters by:
    - [ ] dispatching any new macro(s) so non-core adapters can also use them (e.g. [the `star()` source](https://github.com/dbt-labs/dbt-utils/blob/main/macros/sql/star.sql))
    - [ ] using the `limit_zero()` macro in place of the literal string: `limit 0`
    - [ ] using `dbt_utils.type_*` macros instead of explicit datatypes (e.g. `dbt_utils.type_timestamp()` instead of `TIMESTAMP`
- [ ] I have updated the README.md (if applicable)
- [ ] I have added tests & descriptions to my models (and macros if applicable)
- [ ] I have added an entry to CHANGELOG.md
