### PR TITLE
oracle flavor of generate_series

### DIFF
--- a/macros/sql/generate_series.sql
+++ b/macros/sql/generate_series.sql
@@ -51,3 +51,12 @@
     order by generated_number
 
 {% endmacro %}
+
+{% macro oracle__generate_series(upper_bound) %}
+
+    Select rownum generated_numbers
+    From dual
+    Connect By Rownum <= {{upper_bound}}
+    
+{% endmacro %}
+


### PR DESCRIPTION
This is a:
- [ ] documentation update
- [ ] bug fix with no breaking changes
- [x] new functionality
- [ ] a breaking change

All pull requests from community contributors should target the `main` branch (default).

## Description & motivation
<!---
helps support dbt_metrics use w/oracle
-->

## Checklist
- [x] I have verified that these changes work locally on the following warehouses (Note: it's okay if you do not have access to all warehouses, this helps us understand what has been covered)
    - [ ] BigQuery
    - [ ] Postgres
    - [ ] Redshift
    - [ ] Snowflake
    - [x] oracle
- [x] I followed guidelines to ensure that my changes will work on "non-core" adapters by:
    - [x] dispatching any new macro(s) so non-core adapters can also use them (e.g. [the `star()` source](https://github.com/dbt-labs/dbt-utils/blob/main/macros/sql/star.sql))
    - [ ] using the `limit_zero()` macro in place of the literal string: `limit 0`
    - [ ] using `dbt_utils.type_*` macros instead of explicit datatypes (e.g. `dbt_utils.type_timestamp()` instead of `TIMESTAMP`
- [ ] I have updated the README.md (if applicable)
- [ ] I have added tests & descriptions to my models (and macros if applicable)
- [ ] I have added an entry to CHANGELOG.md
