### PR TITLE
add cast_string_to_date as cross-db macro

### DIFF
--- a/macros/cross_db_utils/cast_string_to_date.sql
+++ b/macros/cross_db_utils/cast_string_to_date.sql
@@ -1,0 +1,17 @@
+{% macro cast_string_to_date(field, format) %}
+  {{ adapter.dispatch('cast_string_to_date', 'dbt_utils') (field, format) }}
+{% endmacro %}
+
+{% macro default__cast_string_to_date(field, format) %}
+    cast({{ field }} as date)
+{% endmacro %}
+
+
+{#-/* TODO: Reference Only - Delete from Project (provided as 'why' to add this macro) */#}
+{% macro oracle__cast_string_to_date(field, format) %}
+  {%- if format -%}
+    to_date({{field}}, '{{format}}')
+  {%- else -%}
+    to_date({{field}}, 'YYYY-MM-DD')
+  {%- endif -%}
+{% endmacro %}


### PR DESCRIPTION
This is a:
- [ ] documentation update
- [ ] bug fix with no breaking changes
- [x] new functionality
- [ ] a breaking change

All pull requests from community contributors should target the `main` branch (default).

## Description & motivation
<!---
creates additional flexibility for dbt_utils to better handle string-to-date conversions across DBs.
example of oracle usage provided as example after trying to backport dbt_metrics code to work with oracle
-->

## Checklist
- [ ] I have verified that these changes work locally on the following warehouses (Note: it's okay if you do not have access to all warehouses, this helps us understand what has been covered)
    - [ ] BigQuery
    - [ ] Postgres
    - [ ] Redshift
    - [ ] Snowflake
    - [x] Oracle
- [x] I followed guidelines to ensure that my changes will work on "non-core" adapters by:
    - [x] dispatching any new macro(s) so non-core adapters can also use them (e.g. [the `star()` source](https://github.com/dbt-labs/dbt-utils/blob/main/macros/sql/star.sql))
    - [ ] using the `limit_zero()` macro in place of the literal string: `limit 0`
    - [ ] using `dbt_utils.type_*` macros instead of explicit datatypes (e.g. `dbt_utils.type_timestamp()` instead of `TIMESTAMP`
- [ ] I have updated the README.md (if applicable)
- [ ] I have added tests & descriptions to my models (and macros if applicable)
- [ ] I have added an entry to CHANGELOG.md
