### PR TITLE
Remove cross-db dbt_utils references

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,88 +1,96 @@
 This [dbt](https://github.com/dbt-labs/dbt) package contains macros that can be (re)used across dbt projects.
 
 ## Installation Instructions
+
 Check [dbt Hub](https://hub.getdbt.com/dbt-labs/dbt_utils/latest/) for the latest installation instructions, or [read the docs](https://docs.getdbt.com/docs/package-management) for more information on installing packages.
 
 ## Compatibility matrix
+
 For compatibility details between versions of dbt-core and dbt-utils, [see this spreadsheet](https://docs.google.com/spreadsheets/d/1RoDdC69auAtrwiqmkRsgcFdZ3MdNpeKcJrWkmEpXVIs/edit#gid=0).
 
 ----
+
 ## Contents
 
 **[Generic tests](#generic-tests)**
-  - [equal_rowcount](#equal_rowcount-source)
-  - [fewer_rows_than](#fewer_rows_than-source)
-  - [equality](#equality-source)
-  - [expression_is_true](#expression_is_true-source)
-  - [recency](#recency-source)
-  - [at_least_one](#at_least_one-source)
-  - [not_constant](#not_constant-source)
-  - [cardinality_equality](#cardinality_equality-source)
-  - [unique_where](#unique_where-source)
-  - [not_null_where](#not_null_where-source)
-  - [not_null_proportion](#not_null_proportion-source)
-  - [not_accepted_values](#not_accepted_values-source)
-  - [relationships_where](#relationships_where-source)
-  - [mutually_exclusive_ranges](#mutually_exclusive_ranges-source)
-  - [unique_combination_of_columns](#unique_combination_of_columns-source)
-  - [accepted_range](#accepted_range-source)
+
+- [equal_rowcount](#equal_rowcount-source)
+- [fewer_rows_than](#fewer_rows_than-source)
+- [equality](#equality-source)
+- [expression_is_true](#expression_is_true-source)
+- [recency](#recency-source)
+- [at_least_one](#at_least_one-source)
+- [not_constant](#not_constant-source)
+- [cardinality_equality](#cardinality_equality-source)
+- [unique_where](#unique_where-source)
+- [not_null_where](#not_null_where-source)
+- [not_null_proportion](#not_null_proportion-source)
+- [not_accepted_values](#not_accepted_values-source)
+- [relationships_where](#relationships_where-source)
+- [mutually_exclusive_ranges](#mutually_exclusive_ranges-source)
+- [unique_combination_of_columns](#unique_combination_of_columns-source)
+- [accepted_range](#accepted_range-source)
 
 **[Macros](#macros)**
 
 - [Introspective macros](#introspective-macros):
-    - [get_column_values](#get_column_values-source)
-    - [get_filtered_columns_in_relation](#get_filtered_columns_in_relation-source)
-    - [get_relations_by_pattern](#get_relations_by_pattern-source)
-    - [get_relations_by_prefix](#get_relations_by_prefix-source)
-    - [get_query_results_as_dict](#get_query_results_as_dict-source)
+  - [get_column_values](#get_column_values-source)
+  - [get_filtered_columns_in_relation](#get_filtered_columns_in_relation-source)
+  - [get_relations_by_pattern](#get_relations_by_pattern-source)
+  - [get_relations_by_prefix](#get_relations_by_prefix-source)
+  - [get_query_results_as_dict](#get_query_results_as_dict-source)
 
 - [SQL generators](#sql-generators)
-    - [date_spine](#date_spine-source)
-    - [deduplicate](#deduplicate-source)
-    - [haversine_distance](#haversine_distance-source)
-    - [group_by](#group_by-source)
-    - [star](#star-source)
-    - [union_relations](#union_relations-source)
-    - [generate_series](#generate_series-source)
-    - [surrogate_key](#surrogate_key-source)
-    - [safe_add](#safe_add-source)
-    - [pivot](#pivot-source)
-    - [unpivot](#unpivot-source)
-    - [width_bucket](#width_bucket-source)
-
+  - [date_spine](#date_spine-source)
+  - [deduplicate](#deduplicate-source)
+  - [haversine_distance](#haversine_distance-source)
+  - [group_by](#group_by-source)
+  - [star](#star-source)
+  - [union_relations](#union_relations-source)
+  - [generate_series](#generate_series-source)
+  - [surrogate_key](#surrogate_key-source)
+  - [safe_add](#safe_add-source)
+  - [pivot](#pivot-source)
+  - [unpivot](#unpivot-source)
+  - [width_bucket](#width_bucket-source)
 
 - [Web macros](#web-macros)
-    - [get_url_parameter](#get_url_parameter-source)
-    - [get_url_host](#get_url_host-source)
-    - [get_url_path](#get_url_path-source)
+  - [get_url_parameter](#get_url_parameter-source)
+  - [get_url_host](#get_url_host-source)
+  - [get_url_path](#get_url_path-source)
 
 - [Cross-database macros](#cross-database-macros):
-    - [current_timestamp](#current_timestamp-source)
-    - [dateadd](#dateadd-source)
-    - [datediff](#datediff-source)
-    - [split_part](#split_part-source)
-    - [last_day](#last_day-source)
-    - [listagg](#listagg-source)
-    - [array_construct](#array_construct-source)
-    - [array_append](#array_append-source)
-    - [array_concat](#array_concat-source)
-    - [cast_array_to_string](#cast_array_to_string-source)
+  - [current_timestamp](#current_timestamp-source)
+  - [dateadd](#dateadd-source)
+  - [datediff](#datediff-source)
+  - [split_part](#split_part-source)
+  - [last_day](#last_day-source)
+  - [listagg](#listagg-source)
+  - [array_construct](#array_construct-source)
+  - [array_append](#array_append-source)
+  - [array_concat](#array_concat-source)
+  - [cast_array_to_string](#cast_array_to_string-source)
 
 - [Jinja Helpers](#jinja-helpers)
-    - [pretty_time](#pretty_time-source)
-    - [pretty_log_format](#pretty_log_format-source)
-    - [log_info](#log_info-source)
-    - [slugify](#slugify-source)
+  - [pretty_time](#pretty_time-source)
+  - [pretty_log_format](#pretty_log_format-source)
+  - [log_info](#log_info-source)
+  - [slugify](#slugify-source)
 
 [Materializations](#materializations):
+
 - [insert_by_period](#insert_by_period-source)
 
 ----
+
 ### Generic Tests
+
 #### equal_rowcount ([source](macros/generic_tests/equal_rowcount.sql))
+
 Asserts that two relations have the same number of rows.
 
 **Usage:**
+
 ```yaml
 version: 2
 
@@ -95,9 +103,11 @@ models:
 ```
 
 #### fewer_rows_than ([source](macros/generic_tests/fewer_rows_than.sql))
+
 Asserts that the respective model has fewer rows than the model being compared.
 
 Usage:
+
 ```yaml
 version: 2
 
@@ -109,9 +119,11 @@ models:
 ```
 
 #### equality ([source](macros/generic_tests/equality.sql))
+
 Asserts the equality of two relations. Optionally specify a subset of columns to compare.
 
 **Usage:**
+
 ```yaml
 version: 2
 
@@ -126,6 +138,7 @@ models:
 ```
 
 #### expression_is_true ([source](macros/generic_tests/expression_is_true.sql))
+
 Asserts that a valid SQL expression is true for all records. This is useful when checking integrity across columns.
 Examples:
 
@@ -134,6 +147,7 @@ Examples:
 - Verify the truth value of a column.
 
 **Usage:**
+
 ```yaml
 version: 2
 
@@ -179,9 +193,11 @@ models:
 ```
 
 #### recency ([source](macros/generic_tests/recency.sql))
+
 Asserts that a timestamp column in the reference model contains data that is at least as recent as the defined date interval.
 
 **Usage:**
+
 ```yaml
 version: 2
 
@@ -195,9 +211,11 @@ models:
 ```
 
 #### at_least_one ([source](macros/generic_tests/at_least_one.sql))
+
 Asserts that a column has at least one value.
 
 **Usage:**
+
 ```yaml
 version: 2
 
@@ -210,9 +228,11 @@ models:
 ```
 
 #### not_constant ([source](macros/generic_tests/not_constant.sql))
+
 Asserts that a column does not have the same value in all rows.
 
 **Usage:**
+
 ```yaml
 version: 2
 
@@ -225,9 +245,11 @@ models:
 ```
 
 #### cardinality_equality ([source](macros/generic_tests/cardinality_equality.sql))
+
 Asserts that values in a given column have exactly the same cardinality as values from a different column in a different model.
 
 **Usage:**
+
 ```yaml
 version: 2
 
@@ -242,11 +264,13 @@ models:
 ```
 
 #### unique_where ([source](macros/generic_tests/test_unique_where.sql))
+
 Asserts that there are no duplicate values present in a field for a subset of rows by specifying a `where` clause.
 
 *Warning*: This test is no longer supported. Starting in dbt v0.20.0, the built-in `unique` test supports a `where` config. [See the dbt docs for more details](https://docs.getdbt.com/reference/resource-configs/where).
 
 **Usage:**
+
 ```yaml
 version: 2
 
@@ -260,11 +284,13 @@ models:
 ```
 
 #### not_null_where ([source](macros/generic_tests/test_not_null_where.sql))
+
 Asserts that there are no null values present in a column for a subset of rows by specifying a `where` clause.
 
 *Warning*: This test is no longer supported. Starting in dbt v0.20.0, the built-in `not_null` test supports a `where` config. [See the dbt docs for more details](https://docs.getdbt.com/reference/resource-configs/where).
 
 **Usage:**
+
 ```yaml
 version: 2
 
@@ -278,9 +304,11 @@ models:
 ```
 
 #### not_null_proportion ([source](macros/generic_tests/not_null_proportion.sql))
+
 Asserts that the proportion of non-null values present in a column is between a specified range [`at_least`, `at_most`] where `at_most` is an optional argument (default: `1.0`).
 
 **Usage:**
+
 ```yaml
 version: 2
 
@@ -294,9 +322,11 @@ models:
 ```
 
 #### not_accepted_values ([source](macros/generic_tests/not_accepted_values.sql))
+
 Asserts that there are no rows that match the given values.
 
 Usage:
+
 ```yaml
 version: 2
 
@@ -310,9 +340,11 @@ models:
 ```
 
 #### relationships_where ([source](macros/generic_tests/relationships_where.sql))
+
 Asserts the referential integrity between two relations (same as the core relationships assertions) with an added predicate to filter out some rows from the test. This is useful to exclude records such as test entities, rows created in the last X minutes/hours to account for temporary gaps due to ETL limitations, etc.
 
 **Usage:**
+
 ```yaml
 version: 2
 
@@ -329,11 +361,13 @@ models:
 ```
 
 #### mutually_exclusive_ranges ([source](macros/generic_tests/mutually_exclusive_ranges.sql))
+
 Asserts that for a given lower_bound_column and upper_bound_column,
 the ranges between the lower and upper bounds do not overlap with the ranges
 of another row.
 
 **Usage:**
+
 ```yaml
 version: 2
 
@@ -366,21 +400,23 @@ models:
 ```
 
 **Args:**
-* `lower_bound_column` (required): The name of the column that represents the
+
+- `lower_bound_column` (required): The name of the column that represents the
 lower value of the range. Must be not null.
-* `upper_bound_column` (required): The name of the column that represents the
+- `upper_bound_column` (required): The name of the column that represents the
 upper value of the range. Must be not null.
-* `partition_by` (optional): If a subset of records should be mutually exclusive
+- `partition_by` (optional): If a subset of records should be mutually exclusive
 (e.g. all periods for a single subscription_id are mutually exclusive), use this
 argument to indicate which column to partition by. `default=none`
-* `gaps` (optional): Whether there can be gaps are allowed between ranges.
+- `gaps` (optional): Whether there can be gaps are allowed between ranges.
 `default='allowed', one_of=['not_allowed', 'allowed', 'required']`
-* `zero_length_range_allowed` (optional): Whether ranges can start and end on the same date.
+- `zero_length_range_allowed` (optional): Whether ranges can start and end on the same date.
 `default=False`
 
 **Note:** Both `lower_bound_column` and `upper_bound_column` should be not null.
 If this is not the case in your data source, consider passing a coalesce function
 to the `lower_` and `upper_bound_column` arguments, like so:
+
 ```yaml
 version: 2
 
@@ -393,12 +429,14 @@ models:
           partition_by: customer_id
           gaps: allowed
 ```
+
 <details>
 <summary>Additional `gaps` and `zero_length_range_allowed` examples</summary>
   **Understanding the `gaps` argument:**
 
   Here are a number of examples for each allowed `gaps` argument.
-  * `gaps: not_allowed`: The upper bound of one record must be the lower bound of
+
+- `gaps: not_allowed`: The upper bound of one record must be the lower bound of
   the next record.
 
   | lower_bound | upper_bound |
@@ -407,7 +445,7 @@ models:
   | 1           | 2           |
   | 2           | 3           |
 
-  * `gaps: allowed` (default): There may be a gap between the upper bound of one
+- `gaps: allowed` (default): There may be a gap between the upper bound of one
   record and the lower bound of the next record.
 
   | lower_bound | upper_bound |
@@ -416,7 +454,7 @@ models:
   | 2           | 3           |
   | 3           | 4           |
 
-  * `gaps: required`: There must be a gap between the upper bound of one record and
+- `gaps: required`: There must be a gap between the upper bound of one record and
   the lower bound of the next record (common for date ranges).
 
   | lower_bound | upper_bound |
@@ -427,7 +465,8 @@ models:
 
   **Understanding the `zero_length_range_allowed` argument:**
   Here are a number of examples for each allowed `zero_length_range_allowed` argument.
-  * `zero_length_range_allowed: false`: (default) The upper bound of each record must be greater than its lower bound.
+
+- `zero_length_range_allowed: false`: (default) The upper bound of each record must be greater than its lower bound.
 
   | lower_bound | upper_bound |
   |-------------|-------------|
@@ -435,18 +474,21 @@ models:
   | 1           | 2           |
   | 2           | 3           |
 
-  * `zero_length_range_allowed: true`: The upper bound of each record can be greater than or equal to its lower bound.
+- `zero_length_range_allowed: true`: The upper bound of each record can be greater than or equal to its lower bound.
 
   | lower_bound | upper_bound |
   |-------------|-------------|
   | 0           | 1           |
   | 2           | 2           |
   | 3           | 4           |
+
 </details>
 
 #### sequential_values ([source](macros/generic_tests/sequential_values.sql))
+
 This test confirms that a column contains sequential values. It can be used
 for both numeric values, and datetime values, as follows:
+
 ```yml
 version: 2
 
@@ -469,23 +511,27 @@ seeds:
 ```
 
 **Args:**
-* `interval` (default=1): The gap between two sequential values
-* `datepart` (default=None): Used when the gaps are a unit of time. If omitted, the test will check for a numeric gap.
+
+- `interval` (default=1): The gap between two sequential values
+- `datepart` (default=None): Used when the gaps are a unit of time. If omitted, the test will check for a numeric gap.
 
 #### unique_combination_of_columns ([source](macros/generic_tests/unique_combination_of_columns.sql))
+
 Asserts that the combination of columns is unique. For example, the
 combination of month and product is unique, however neither column is unique
 in isolation.
 
 We generally recommend testing this uniqueness condition by either:
-* generating a [surrogate_key](#surrogate_key-source) for your model and testing
+
+- generating a [surrogate_key](#surrogate_key-source) for your model and testing
 the uniqueness of said key, OR
-* passing the `unique` test a concatenation of the columns (as discussed [here](https://docs.getdbt.com/docs/building-a-dbt-project/testing-and-documentation/testing/#testing-expressions)).
+- passing the `unique` test a concatenation of the columns (as discussed [here](https://docs.getdbt.com/docs/building-a-dbt-project/testing-and-documentation/testing/#testing-expressions)).
 
 However, these approaches can become non-perfomant on large data sets, in which
 case we recommend using this test instead.
 
 **Usage:**
+
 ```yaml
 - name: revenue_by_product_by_month
   tests:
@@ -509,11 +555,13 @@ An optional `quote_columns` argument (`default=false`) can also be used if a col
 ```
 
 #### accepted_range ([source](macros/generic_tests/accepted_range.sql))
+
 Asserts that a column's values fall inside an expected range. Any combination of `min_value` and `max_value` is allowed, and the range can be inclusive or exclusive. Provide a `where` argument to filter to specific records only.
 
 In addition to comparisons to a scalar value, you can also compare to another column's values. Any data type that supports the `>` or `<` operators can be compared, so you could also run tests like checking that all order dates are in the past.
 
 **Usage:**
+
 ```yaml
 version: 2
 
@@ -551,22 +599,24 @@ models:
 ## Macros
 
 ### Introspective macros
+
 These macros run a query and return the results of the query as objects. They are typically abstractions over the [statement blocks](https://docs.getdbt.com/reference/dbt-jinja-functions/statement-blocks) in dbt.
 
-
 #### get_column_values ([source](macros/sql/get_column_values.sql))
+
 This macro returns the unique values for a column in a given [relation](https://docs.getdbt.com/docs/writing-code-in-dbt/class-reference/#relation) as an array.
 
 **Args:**
+
 - `table` (required): a [Relation](https://docs.getdbt.com/reference/dbt-classes#relation) (a `ref` or `source`) that contains the list of columns you wish to select from
 - `column` (required): The name of the column you wish to find the column values of
-- `where` (optional, default=`none`): A where clause to filter the column values by. 
+- `where` (optional, default=`none`): A where clause to filter the column values by.
 - `order_by` (optional, default=`'count(*) desc'`): How the results should be ordered. The default is to order by `count(*) desc`, i.e. decreasing frequency. Setting this as `'my_column'` will sort alphabetically, while `'min(created_at)'` will sort by when thevalue was first observed.
 - `max_records` (optional, default=`none`): The maximum number of column values you want to return
 - `default` (optional, default=`[]`): The results this macro should return if the relation has not yet been created (and therefore has no column values).
 
-
 **Usage:**
+
 ```sql
 -- Returns a list of the payment_methods in the stg_payments model_
 {% set payment_methods = dbt_utils.get_column_values(table=ref('stg_payments'), column='payment_method') %}
@@ -600,17 +650,22 @@ This macro returns the unique values for a column in a given [relation](https://
 ```
 
 #### get_filtered_columns_in_relation ([source](macros/sql/get_filtered_columns_in_relation.sql))
+
 This macro returns an iterable Jinja list of columns for a given [relation](https://docs.getdbt.com/docs/writing-code-in-dbt/class-reference/#relation), (i.e. not from a CTE)
+
 - optionally exclude columns
 - the input values are not case-sensitive (input uppercase or lowercase and it will work!)
+
 > Note: The native [`adapter.get_columns_in_relation` macro](https://docs.getdbt.com/reference/dbt-jinja-functions/adapter#get_columns_in_relation) allows you
 to pull column names in a non-filtered fashion, also bringing along with it other (potentially unwanted) information, such as dtype, char_size, numeric_precision, etc.
 
 **Args:**
+
 - `from` (required): a [Relation](https://docs.getdbt.com/reference/dbt-classes#relation) (a `ref` or `source`) that contains the list of columns you wish to select from
 - `except` (optional, default=`[]`): The name of the columns you wish to exclude. (case-insensitive)
 
 **Usage:**
+
 ```sql
 -- Returns a list of the columns from a relation, so you can then iterate in a for loop
 {% set column_names = dbt_utils.get_filtered_columns_in_relation(from=ref('your_model'), except=["field_1", "field_2"]) %}
@@ -622,12 +677,14 @@ to pull column names in a non-filtered fashion, also bringing along with it othe
 ```
 
 #### get_relations_by_pattern ([source](macros/sql/get_relations_by_pattern.sql))
+
 Returns a list of [Relations](https://docs.getdbt.com/docs/writing-code-in-dbt/class-reference/#relation)
 that match a given schema- or table-name pattern.
 
 This macro is particularly handy when paired with `union_relations`.
 
 **Usage:**
+
 ```
 -- Returns a list of relations that match schema_pattern%.table
 {% set relations = dbt_utils.get_relations_by_pattern('schema_pattern%', 'table_pattern') %}
@@ -644,14 +701,16 @@ This macro is particularly handy when paired with `union_relations`.
 ```
 
 **Args:**
-* `schema_pattern` (required): The schema pattern to inspect for relations.
-* `table_pattern` (required): The name of the table/view (case insensitive).
-* `exclude` (optional): Exclude any relations that match this table pattern.
-* `database` (optional, default = `target.database`): The database to inspect
+
+- `schema_pattern` (required): The schema pattern to inspect for relations.
+- `table_pattern` (required): The name of the table/view (case insensitive).
+- `exclude` (optional): Exclude any relations that match this table pattern.
+- `database` (optional, default = `target.database`): The database to inspect
 for relations.
 
 **Examples:**
 Generate drop statements for all Relations that match a naming pattern:
+
 ```sql
 {% set relations_to_drop = dbt_utils.get_relations_by_pattern(
     schema_pattern='public',
@@ -672,6 +731,7 @@ Generate drop statements for all Relations that match a naming pattern:
 ```
 
 #### get_relations_by_prefix ([source](macros/sql/get_relations_by_prefix.sql))
+
 > This macro will soon be deprecated in favor of the more flexible `get_relations_by_pattern` macro (above)
 
 Returns a list of [Relations](https://docs.getdbt.com/docs/writing-code-in-dbt/class-reference/#relation)
@@ -693,16 +753,19 @@ handy paired with `union_relations`.
 ```
 
 **Args:**
-* `schema` (required): The schema to inspect for relations.
-* `prefix` (required): The prefix of the table/view (case insensitive)
-* `exclude` (optional): Exclude any relations that match this pattern.
-* `database` (optional, default = `target.database`): The database to inspect
+
+- `schema` (required): The schema to inspect for relations.
+- `prefix` (required): The prefix of the table/view (case insensitive)
+- `exclude` (optional): Exclude any relations that match this pattern.
+- `database` (optional, default = `target.database`): The database to inspect
 for relations.
 
 #### get_query_results_as_dict ([source](macros/sql/get_query_results_as_dict.sql))
+
 This macro returns a dictionary from a sql query, so that you don't need to interact with the Agate library to operate on the result
 
 **Usage:**
+
 ```
 {% set sql_statement %}
     select city, state from {{ ref('users') }}
@@ -726,9 +789,11 @@ from {{ ref('users') }}
 ```
 
 ### SQL generators
+
 These macros generate SQL (either a complete query, or a part of a query). They often implement patterns that should be easy in SQL, but for some reason are much harder than they need to be.
 
 #### date_spine ([source](macros/sql/date_spine.sql))
+
 This macro returns the sql required to build a date spine. The spine will include the `start_date` (if it is aligned to the `datepart`), but it will not include the `end_date`.
 
 **Usage:**
@@ -743,12 +808,14 @@ This macro returns the sql required to build a date spine. The spine will includ
 ```
 
 #### deduplicate ([source](macros/sql/deduplicate.sql))
+
 This macro returns the sql required to remove duplicate rows from a model, source, or CTE.
 
 **Args:**
- - `relation` (required): a [Relation](https://docs.getdbt.com/reference/dbt-classes#relation) (a `ref` or `source`) or string which identifies the model to deduplicate.
- - `partition_by` (required): column names (or expressions) to use to identify a set/window of rows out of which to select one as the deduplicated row.
- - `order_by` (required): column names (or expressions) that determine the priority order of which row should be chosen if there are duplicates (comma-separated string). *NB.* if this order by clause results in ties then which row is returned may be nondeterministic across runs.
+
+- `relation` (required): a [Relation](https://docs.getdbt.com/reference/dbt-classes#relation) (a `ref` or `source`) or string which identifies the model to deduplicate.
+- `partition_by` (required): column names (or expressions) to use to identify a set/window of rows out of which to select one as the deduplicated row.
+- `order_by` (required): column names (or expressions) that determine the priority order of which row should be chosen if there are duplicates (comma-separated string). *NB.* if this order by clause results in ties then which row is returned may be nondeterministic across runs.
 
 **Usage:**
 
@@ -786,6 +853,7 @@ with my_cte as (
 ```
 
 #### haversine_distance ([source](macros/sql/haversine_distance.sql))
+
 This macro calculates the [haversine distance](http://daynebatten.com/2015/09/latitude-longitude-distance-sql/) between a pair of x/y coordinates.
 
 Optionally takes a `unit` string argument ('km' or 'mi') which defaults to miles (imperial system).
@@ -805,6 +873,7 @@ Optionally takes a `unit` string argument ('km' or 'mi') which defaults to miles
 ```
 
 **Args:**
+
 - `lat1` (required): latitude of first location
 - `lon1` (required): longitude of first location
 - `lat2` (required): latitude of second location
@@ -812,6 +881,7 @@ Optionally takes a `unit` string argument ('km' or 'mi') which defaults to miles
 - `unit` (optional, default=`'mi'`): one of `mi` (miles) or `km` (kilometers)
 
 #### group_by ([source](macros/sql/groupby.sql))
+
 This macro build a group by statement for fields 1...N
 
 **Usage:**
@@ -827,6 +897,7 @@ group by 1,2,3
 ```
 
 #### star ([source](macros/sql/star.sql))
+
 This macro generates a comma-separated list of all fields that exist in the `from` relation, excluding any fields
 listed in the `except` argument. The construction is identical to `select * from {{ref('my_model')}}`, replacing star (`*`) with
 the star macro.
@@ -835,6 +906,7 @@ The macro also has optional `prefix` and `suffix` arguments. When one or both ar
 in the output (`prefix` ~ `field_name` ~ `suffix`). NB: This prevents the output from being used in any context other than a select statement.
 
 **Args:**
+
 - `from` (required): a [Relation](https://docs.getdbt.com/reference/dbt-classes#relation) (a `ref` or `source`) that contains the list of columns you wish to select from
 - `except` (optional, default=`[]`): The name of the columns you wish to exclude. (case-insensitive)
 - `relation_alias` (optional, default=`''`): will prefix all generated fields with an alias (`relation_alias`.`field_name`).
@@ -842,6 +914,7 @@ in the output (`prefix` ~ `field_name` ~ `suffix`). NB: This prevents the output
 - `suffix` (optional, default=`''`): will suffix the output `field_name` (`field_name as field_name_suffix`).
 
 **Usage:**
+
 ```sql
 select
   {{ dbt_utils.star(ref('my_model')) }}
@@ -872,6 +945,7 @@ relations will be filled with `null` where not present. A new column
 (`_dbt_source_relation`) is also added to indicate the source for each record.
 
 **Usage:**
+
 ```
 {{ dbt_utils.union_relations(
     relations=[ref('my_model'), source('my_source', 'my_table')],
@@ -880,45 +954,54 @@ relations will be filled with `null` where not present. A new column
 ```
 
 **Args:**
-* `relations` (required): An array of [Relations](https://docs.getdbt.com/docs/writing-code-in-dbt/class-reference/#relation).
-* `exclude` (optional): A list of column names that should be excluded from
+
+- `relations` (required): An array of [Relations](https://docs.getdbt.com/docs/writing-code-in-dbt/class-reference/#relation).
+- `exclude` (optional): A list of column names that should be excluded from
 the final query.
-* `include` (optional): A list of column names that should be included in the
+- `include` (optional): A list of column names that should be included in the
 final query. Note the `include` and `exclude` arguments are mutually exclusive.
-* `column_override` (optional): A dictionary of explicit column type overrides,
+- `column_override` (optional): A dictionary of explicit column type overrides,
 e.g. `{"some_field": "varchar(100)"}`.``
-* `source_column_name` (optional, `default="_dbt_source_relation"`): The name of
+- `source_column_name` (optional, `default="_dbt_source_relation"`): The name of
 the column that records the source of this row. Pass `None` to omit this column from the results.
-* `where` (optional): Filter conditions to include in the `where` clause.
+- `where` (optional): Filter conditions to include in the `where` clause.
 
 #### generate_series ([source](macros/sql/generate_series.sql))
+
 This macro implements a cross-database mechanism to generate an arbitrarily long list of numbers. Specify the maximum number you'd like in your list and it will create a 1-indexed SQL result set.
 
 **Usage:**
+
 ```
 {{ dbt_utils.generate_series(upper_bound=1000) }}
 ```
 
 #### surrogate_key ([source](macros/sql/surrogate_key.sql))
+
 Implements a cross-database way to generate a hashed surrogate key using the fields specified.
 
 **Usage:**
+
 ```
 {{ dbt_utils.surrogate_key(['field_a', 'field_b'[,...]]) }}
 ```
 
 #### safe_add ([source](macros/sql/safe_add.sql))
+
 Implements a cross-database way to sum nullable fields using the fields specified.
 
 **Usage:**
+
 ```
 {{ dbt_utils.safe_add('field_a', 'field_b'[,...]) }}
 ```
 
 #### pivot ([source](macros/sql/pivot.sql))
+
 This macro pivots values from rows to columns.
 
 **Usage:**
+
 ```
 {{ dbt_utils.pivot(<column>, <list of values>) }}
 ```
@@ -951,6 +1034,7 @@ This macro pivots values from rows to columns.
     | M    | 1   | 0    |
 
 **Args:**
+
 - `column`: Column name, required
 - `values`: List of row values to turn into columns, required
 - `alias`: Whether to create column aliases, default is True
@@ -963,10 +1047,12 @@ This macro pivots values from rows to columns.
 - `quote_identifiers`: Whether to surround column aliases with double quotes, default is true
 
 #### unpivot ([source](macros/sql/unpivot.sql))
+
 This macro "un-pivots" a table from wide format to long format. Functionality is similar to pandas [melt](http://pandas.pydata.org/pandas-docs/stable/generated/pandas.melt.html) function.
 Boolean values are replaced with the strings 'true'|'false'
 
 **Usage:**
+
 ```
 {{ dbt_utils.unpivot(
   relation=ref('table_name'),
@@ -999,6 +1085,7 @@ Boolean values are replaced with the strings 'true'|'false'
     | 2017-03-01 | processing | color      | red   |
 
 **Args:**
+
 - `relation`: The [Relation](https://docs.getdbt.com/docs/writing-code-in-dbt/class-reference/#relation) to unpivot.
 - `cast_to`: The data type to cast the unpivoted values to, default is varchar
 - `exclude`: A list of columns to exclude from the unpivot operation but keep in the resulting table.
@@ -1007,6 +1094,7 @@ Boolean values are replaced with the strings 'true'|'false'
 - `value_name`: column name in the resulting table for value
 
 #### width_bucket ([source](macros/cross_db_utils/width_bucket.sql))
+
 This macro is modeled after the `width_bucket` function natively available in Snowflake.
 
 From the original Snowflake [documentation](https://docs.snowflake.net/manuals/sql-reference/functions/width_bucket.html):
@@ -1015,6 +1103,7 @@ Constructs equi-width histograms, in which the histogram range is divided into i
 Notes:
 
 **Args:**
+
 - `expr`: The expression for which the histogram is created. This expression must evaluate to a numeric value or to a value that can be implicitly converted to a numeric value.
 
 - `min_value` and `max_value`: The low and high end points of the acceptable range for the expression. The end points must also evaluate to numeric values and not be equal.
@@ -1022,106 +1111,149 @@ Notes:
 - `num_buckets`:  The desired number of buckets; must be a positive integer value. A value from the expression is assigned to each bucket, and the function then returns the corresponding bucket number.
 
 When an expression falls outside the range, the function returns:
+
 - `0` if the expression is less than min_value.
 - `num_buckets + 1` if the expression is greater than or equal to max_value.
 
-
 **Usage:**
+
 ```
 {{ dbt_utils.width_bucket(expr, min_value, max_value, num_buckets) }}
 ```
 
 ### Web macros
+
 #### get_url_parameter ([source](macros/web/get_url_parameter.sql))
+
 This macro extracts a url parameter from a column containing a url.
 
 **Usage:**
+
 ```
 {{ dbt_utils.get_url_parameter(field='page_url', url_parameter='utm_source') }}
 ```
 
 #### get_url_host ([source](macros/web/get_url_host.sql))
+
 This macro extracts a hostname from a column containing a url.
 
 **Usage:**
+
 ```
 {{ dbt_utils.get_url_host(field='page_url') }}
 ```
 
 #### get_url_path ([source](macros/web/get_url_path.sql))
+
 This macro extracts a page path from a column containing a url.
 
 **Usage:**
+
 ```
 {{ dbt_utils.get_url_path(field='page_url') }}
 ```
+
 ----
+
 ### Cross-database macros
+
 These macros make it easier for package authors (especially those writing modeling packages) to implement cross-database
 compatibility. In general, you should not use these macros in your own dbt project (unless it is a package)
 
+Note that most of these macros have now moved to dbt-core. Instead of the `dbt_utils.` namespace, you should now call these macros with the `dbt.` prefix, or without a prefix altogether (as shown in the examples below). They will eventuall be removed from `dbt_utils`.
+As highlighted below, some of the cross-database macros are still in the process of being deprecated.
+
 #### current_timestamp ([source](macros/cross_db_utils/current_timestamp.sql))
+
+*DEPRECATED: This macro is deprecated and will be removed in a future version of the package, once equivalent functionality is implemented in dbt Core.*
+
 This macro returns the current timestamp.
 
 **Usage:**
+
 ```
 {{ dbt_utils.current_timestamp() }}
 ```
 
 #### dateadd ([source](macros/cross_db_utils/dateadd.sql))
+
+*DEPRECATED: This macro is now provided in dbt Core. It is no longer available in dbt_utils and backwards compatibility will be removed in a future version of the package.*
+
 This macro adds a time/day interval to the supplied date/timestamp. Note: The `datepart` argument is database-specific.
 
 **Usage:**
+
 ```
-{{ dbt_utils.dateadd(datepart='day', interval=1, from_date_or_timestamp="'2017-01-01'") }}
+{{ dateadd(datepart='day', interval=1, from_date_or_timestamp="'2017-01-01'") }}
 ```
 
 #### datediff ([source](macros/cross_db_utils/datediff.sql))
+
+*DEPRECATED: This macro is now provided in dbt Core. It is no longer available in dbt_utils and backwards compatibility will be removed in a future version of the package.*
+
 This macro calculates the difference between two dates.
 
 **Usage:**
+
 ```
-{{ dbt_utils.datediff("'2018-01-01'", "'2018-01-20'", 'day') }}
+{{ datediff("'2018-01-01'", "'2018-01-20'", 'day') }}
 ```
 
 #### split_part ([source](macros/cross_db_utils/split_part.sql))
+
+*DEPRECATED: This macro is now provided in dbt Core. It is no longer available in dbt_utils and backwards compatibility will be removed in a future version of the package.*
+
 This macro splits a string of text using the supplied delimiter and returns the supplied part number (1-indexed).
 
 **Args:**
+
 - `string_text` (required): Text to be split into parts.
 - `delimiter_text` (required): Text representing the delimiter to split by.
 - `part_number` (required): Requested part of the split (1-based). If the value is negative, the parts are counted backward from the end of the string.
 
 **Usage:**
 When referencing a column, use one pair of quotes. When referencing a string, use single quotes enclosed in double quotes.
+
 ```
-{{ dbt_utils.split_part(string_text='column_to_split', delimiter_text='delimiter_column', part_number=1) }}
-{{ dbt_utils.split_part(string_text="'1|2|3'", delimiter_text="'|'", part_number=1) }}
+{{ split_part(string_text='column_to_split', delimiter_text='delimiter_column', part_number=1) }}
+{{ split_part(string_text="'1|2|3'", delimiter_text="'|'", part_number=1) }}
 ```
 
 #### date_trunc ([source](macros/cross_db_utils/date_trunc.sql))
+
+*DEPRECATED: This macro is now provided in dbt Core. It is no longer available in dbt_utils and backwards compatibility will be removed in a future version of the package.*
+
 Truncates a date or timestamp to the specified datepart. Note: The `datepart` argument is database-specific.
 
 **Usage:**
+
 ```
-{{ dbt_utils.date_trunc(datepart, date) }}
+{{ date_trunc(datepart, date) }}
 ```
 
 #### last_day ([source](macros/cross_db_utils/last_day.sql))
+
+*DEPRECATED: This macro is now provided in dbt Core. It is no longer available in dbt_utils and backwards compatibility will be removed in a future version of the package.*
+
 Gets the last day for a given date and datepart. Notes:
 
 - The `datepart` argument is database-specific.
 - This macro currently only supports dateparts of `month` and `quarter`.
 
 **Usage:**
+
 ```
-{{ dbt_utils.last_day(date, datepart) }}
+{{ last_day(date, datepart) }}
 ```
 
 #### listagg ([source](macros/cross_db_utils/listagg.sql))
+
+*DEPRECATED: This macro is now provided in dbt Core. It is no longer available in dbt_utils and backwards compatibility will be removed in a future version of the package.*
+
 This macro returns the concatenated input values from a group of rows separated by a specified deliminator.
 
 **Args:**
+
 - `measure` (required): The expression (typically a column name) that determines the values to be concatenated. To only include distinct values add keyword DISTINCT to beginning of expression (example: 'DISTINCT column_to_agg').
 - `delimiter_text` (required): Text representing the delimiter to separate concatenated values by.
 - `order_by_clause` (optional): An expression (typically a column name) that determines the order of the concatenated values.
@@ -1130,62 +1262,87 @@ This macro returns the concatenated input values from a group of rows separated 
 Note: If there are instances of `delimiter_text` within your `measure`, you cannot include a `limit_num`.
 
 **Usage:**
+
 ```
-{{ dbt_utils.listagg(measure='column_to_agg', delimiter_text="','", order_by_clause="order by order_by_column", limit_num=10) }}
+{{ listagg(measure='column_to_agg', delimiter_text="','", order_by_clause="order by order_by_column", limit_num=10) }}
 ```
 
 #### array_construct ([source](macros/cross_db_utils/array_construct.sql))
-This macro returns an array constructed from a set of inputs. 
+
+*DEPRECATED: This macro is deprecated and will be removed in a future version of the package, once equivalent functionality is implemented in dbt Core.*
+
+This macro returns an array constructed from a set of inputs.
 
 **Args:**
+
 - `inputs` (optional): The list of array contents. If not provided, this macro will create an empty array. All inputs must be the *same data type* in order to match Postgres functionality and *not null* to match Bigquery functionality.
 - `data_type` (optional): Specifies the data type of the constructed array. This is only relevant when creating an empty array (will otherwise use the data type of the inputs). If `inputs` are `data_type` are both not provided, this macro will create an empty array of type integer.
 
 **Usage:**
+
 ```
 {{ dbt_utils.array_construct(['column_1', 'column_2', 'column_3']) }}
 {{ dbt_utils.array_construct([],'integer') }}
 ```
 
 #### array_append ([source](macros/cross_db_utils/array_append.sql))
+
+*DEPRECATED: This macro is deprecated and will be removed in a future version of the package, once equivalent functionality is implemented in dbt Core.*
+
 This macro appends an element to the end of an array and returns the appended array.
 
 **Args:**
-- `array` (required): The array to append to. 
-- `new_element` (required): The element to be appended. This element must *match the data type of the existing elements* in the array in order to match Postgres functionality and *not null* to match Bigquery functionality. 
+
+- `array` (required): The array to append to.
+- `new_element` (required): The element to be appended. This element must *match the data type of the existing elements* in the array in order to match Postgres functionality and *not null* to match Bigquery functionality.
 
 **Usage:**
+
 ```
 {{ dbt_utils.array_append('array_column', 'element_column') }}
 ```
 
 #### array_concat ([source](macros/cross_db_utils/array_concat.sql))
+
+*DEPRECATED: This macro is deprecated and will be removed in a future version of the package, once equivalent functionality is implemented in dbt Core.*
+
 This macro returns the concatenation of two arrays.
 
 **Args:**
-- `array_1` (required): The array to append to. 
+
+- `array_1` (required): The array to append to.
 - `array_2` (required): The array to be appended to `array_1`. This array must match the data type of `array_1` in order to match Postgres functionality.
 
 **Usage:**
+
 ```
 {{ dbt_utils.array_concat('array_column_1', 'array_column_2') }}
 ```
 
 #### cast_array_to_string ([source](macros/cross_db_utils/cast_array_to_string.sql))
-This macro converts an array to a single string value and returns the resulting string. 
+
+*DEPRECATED: This macro is deprecated and will be removed in a future version of the package, once equivalent functionality is implemented in dbt Core.*
+
+This macro converts an array to a single string value and returns the resulting string.
 
 **Args:**
+
 - `array` (required): The array to convert to a string.
 
 **Usage:**
+
 ```
 {{ dbt_utils.cast_array_to_string('array_column') }}
 ```
 
 ---
+
 ### Jinja Helpers
+
 #### pretty_time ([source](macros/jinja_helpers/pretty_time.sql))
+
 This macro returns a string of the current timestamp, optionally taking a datestring format.
+
 ```sql
 {#- This will return a string like '14:50:34' -#}
 {{ dbt_utils.pretty_time() }}
@@ -1195,7 +1352,9 @@ This macro returns a string of the current timestamp, optionally taking a datest
 ```
 
 #### pretty_log_format ([source](macros/jinja_helpers/pretty_log_format.sql))
+
 This macro formats the input in a way that will print nicely to the command line when you `log` it.
+
 ```sql
 {#- This will return a string like:
 "11:07:31 + my pretty message"
@@ -1203,8 +1362,11 @@ This macro formats the input in a way that will print nicely to the command line
 
 {{ dbt_utils.pretty_log_format("my pretty message") }}
 ```
+
 #### log_info ([source](macros/jinja_helpers/log_info.sql))
+
 This macro logs a formatted message (with a timestamp) to the command line.
+
 ```sql
 {{ dbt_utils.log_info("my pretty message") }}
 ```
@@ -1215,6 +1377,7 @@ This macro logs a formatted message (with a timestamp) to the command line.
 ```
 
 #### slugify ([source](macros/jinja_helpers/slugify.sql))
+
 This macro is useful for transforming Jinja strings into "slugs", and can be useful when using a Jinja object as a column name, especially when that Jinja object is not hardcoded.
 
 For this example, let's pretend that we have payment methods in our payments table like `['venmo App', 'ca$h-money']`, which we can't use as a column name due to the spaces and special characters. This macro does its best to strip those out in a sensible way: `['venmo_app',
@@ -1249,7 +1412,9 @@ sum(case when payment_method = 'ca$h money' then amount end)
 ```
 
 ### Materializations
+
 #### insert_by_period ([source](macros/materializations/insert_by_period_materialization.sql))
+
 `insert_by_period` allows dbt to insert records into a table one period (i.e. day, week) at a time.
 
 This materialization is appropriate for event data that can be processed in discrete periods. It is similar in concept to the built-in incremental materialization, but has the added benefit of building the model in chunks even during a full-refresh so is particularly useful for models where the initial run can be problematic.
@@ -1259,6 +1424,7 @@ Should a run of a model using this materialization be interrupted, a subsequent 
 Progress is logged in the command line for easy monitoring.
 
 **Usage:**
+
 ```sql
 {{
   config(
@@ -1282,22 +1448,27 @@ with events as (
 ```
 
 **Configuration values:**
-* `period`: period to break the model into, must be a valid [datepart](https://docs.aws.amazon.com/redshift/latest/dg/r_Dateparts_for_datetime_functions.html) (default='Week')
-* `timestamp_field`: the column name of the timestamp field that will be used to break the model into smaller queries
-* `start_date`: literal date or timestamp - generally choose a date that is earlier than the start of your data
-* `stop_date`: literal date or timestamp (default=current_timestamp)
+
+- `period`: period to break the model into, must be a valid [datepart](https://docs.aws.amazon.com/redshift/latest/dg/r_Dateparts_for_datetime_functions.html) (default='Week')
+- `timestamp_field`: the column name of the timestamp field that will be used to break the model into smaller queries
+- `start_date`: literal date or timestamp - generally choose a date that is earlier than the start of your data
+- `stop_date`: literal date or timestamp (default=current_timestamp)
 
 **Caveats:**
-* This materialization is compatible with dbt 0.10.1.
-* This materialization has been written for Redshift.
-* This materialization can only be used for a model where records are not expected to change after they are created.
-* Any model post-hooks that use `{{ this }}` will fail using this materialization. For example:
+
+- This materialization is compatible with dbt 0.10.1.
+- This materialization has been written for Redshift.
+- This materialization can only be used for a model where records are not expected to change after they are created.
+- Any model post-hooks that use `{{ this }}` will fail using this materialization. For example:
+
 ```yaml
 models:
     project-name:
         post-hook: "grant select on {{ this }} to db_reader"
 ```
+
 A useful workaround is to change the above post-hook to:
+
 ```yaml
         post-hook: "grant select on {{ this.schema }}.{{ this.name }} to db_reader"
 ```
@@ -1308,13 +1479,14 @@ A useful workaround is to change the above post-hook to:
 
 - Want to report a bug or request a feature? Let us know in the `#package-ecosystem` channel on [Slack](http://community.getdbt.com/), or open [an issue](https://github.com/dbt-labs/dbt-utils/issues/new)
 - Want to help us build dbt-utils? Check out the [Contributing Guide](https://github.com/dbt-utils/dbt-core/blob/HEAD/CONTRIBUTING.md)
-    - **TL;DR** Open a Pull Request with 1) your changes, 2) updated documentation for the `README.md` file, and 3) a working integration test.
+  - **TL;DR** Open a Pull Request with 1) your changes, 2) updated documentation for the `README.md` file, and 3) a working integration test.
 
 ----
 
 ### Dispatch macros
 
 **Note:** This is primarily relevant to:
+
 - Users and maintainers of community-supported [adapter plugins](https://docs.getdbt.com/docs/available-adapters)
 - Users who wish to override a low-lying `dbt_utils` macro with a custom implementation, and have that implementation used by other `dbt_utils` macros
 
@@ -1325,6 +1497,7 @@ dbt v0.18.0 introduced [`adapter.dispatch()`](https://docs.getdbt.com/reference/
 dbt v0.20.0 introduced a new project-level `dispatch` config that enables an "override" setting for all dispatched macros. If you set this config in your project, when dbt searches for implementations of a macro in the `dbt_utils` namespace, it will search through your list of packages instead of just looking in the `dbt_utils` package.
 
 Set the config in `dbt_project.yml`:
+
 ```yml
 dispatch:
   - macro_namespace: dbt_utils
@@ -1337,6 +1510,7 @@ dispatch:
 If overriding a dispatched macro with a custom implementation in your own project's `macros/` directory, you must name your custom macro with a prefix: either `default__` (note the two underscores), or the name of your adapter followed by two underscores. For example, if you're running on Postgres and wish to override the behavior of `dbt_utils.datediff` (such that `dbt_utils.date_spine` will use your version instead), you can do this by defining a macro called either `default__datediff` or `postgres__datediff`.
 
 Let's say we have the config defined above, and we're running on Spark. When dbt goes to dispatch `dbt_utils.datediff`, it will search for macros the following in order:
+
 ```
 first_package_to_search.spark__datediff
 first_package_to_search.default__datediff
@@ -1355,12 +1529,9 @@ dbt_utils.default__datediff
 - [Installation](https://docs.getdbt.com/dbt-cli/installation)
 - Join the [chat](https://www.getdbt.com/community/) on Slack for live questions and support.
 
-
 ## Code of Conduct
 
 Everyone interacting in the dbt project's codebases, issue trackers, chat rooms, and mailing lists is expected to follow the [PyPA Code of Conduct].
-
-
 
 [PyPA Code of Conduct]: https://www.pypa.io/en/latest/code-of-conduct/
 [slack-url]: http://ac-slackin.herokuapp.com/

--- a/README.md
+++ b/README.md
@@ -1160,9 +1160,9 @@ This macro extracts a page path from a column containing a url.
 These macros make it easier for package authors (especially those writing modeling packages) to implement cross-database
 compatibility. In general, you should not use these macros in your own dbt project (unless it is a package)
 
-Note that most of these macros moved to dbt Core as of dbt_utils v0.9.0 and dbt Core v1.2.0, and will soon be removed from `dbt_utils`. 
+Note that most of these macros moved to dbt Core as of dbt_utils v0.9.0 and dbt Core v1.2.0, and will soon be removed from `dbt_utils`.
 
-To access the version defined in dbt Core, remove the `dbt_utils.` prefix (see [https://docs.getdbt.com/reference/dbt-jinja-functions/cross-database-macros](https://docs.getdbt.com/reference/dbt-jinja-functions/cross-database-macros) for examples). 
+To access the version defined in dbt Core, remove the `dbt_utils.` prefix (see [https://docs.getdbt.com/reference/dbt-jinja-functions/cross-database-macros](https://docs.getdbt.com/reference/dbt-jinja-functions/cross-database-macros) for examples).
 As highlighted below, some of the cross-database macros are still in the process of being deprecated.
 
 #### current_timestamp ([source](macros/cross_db_utils/current_timestamp.sql))
@@ -1186,7 +1186,7 @@ This macro adds a time/day interval to the supplied date/timestamp. Note: The `d
 **Usage:**
 
 ```
-{{ dateadd(datepart='day', interval=1, from_date_or_timestamp="'2017-01-01'") }}
+{{ dbt_utils.dateadd(datepart='day', interval=1, from_date_or_timestamp="'2017-01-01'") }}
 ```
 
 #### datediff ([source](macros/cross_db_utils/datediff.sql))
@@ -1198,7 +1198,7 @@ This macro calculates the difference between two dates.
 **Usage:**
 
 ```
-{{ datediff("'2018-01-01'", "'2018-01-20'", 'day') }}
+{{ dbt_utils.datediff("'2018-01-01'", "'2018-01-20'", 'day') }}
 ```
 
 #### split_part ([source](macros/cross_db_utils/split_part.sql))
@@ -1217,8 +1217,8 @@ This macro splits a string of text using the supplied delimiter and returns the 
 When referencing a column, use one pair of quotes. When referencing a string, use single quotes enclosed in double quotes.
 
 ```
-{{ split_part(string_text='column_to_split', delimiter_text='delimiter_column', part_number=1) }}
-{{ split_part(string_text="'1|2|3'", delimiter_text="'|'", part_number=1) }}
+{{ dbt_utils.split_part(string_text='column_to_split', delimiter_text='delimiter_column', part_number=1) }}
+{{ dbt_utils.split_part(string_text="'1|2|3'", delimiter_text="'|'", part_number=1) }}
 ```
 
 #### date_trunc ([source](macros/cross_db_utils/date_trunc.sql))
@@ -1230,7 +1230,7 @@ Truncates a date or timestamp to the specified datepart. Note: The `datepart` ar
 **Usage:**
 
 ```
-{{ date_trunc(datepart, date) }}
+{{ dbt_utils.date_trunc(datepart, date) }}
 ```
 
 #### last_day ([source](macros/cross_db_utils/last_day.sql))
@@ -1245,7 +1245,7 @@ Gets the last day for a given date and datepart. Notes:
 **Usage:**
 
 ```
-{{ last_day(date, datepart) }}
+{{ dbt_utils.last_day(date, datepart) }}
 ```
 
 #### listagg ([source](macros/cross_db_utils/listagg.sql))
@@ -1266,7 +1266,7 @@ Note: If there are instances of `delimiter_text` within your `measure`, you cann
 **Usage:**
 
 ```
-{{ listagg(measure='column_to_agg', delimiter_text="','", order_by_clause="order by order_by_column", limit_num=10) }}
+{{ dbt_utils.listagg(measure='column_to_agg', delimiter_text="','", order_by_clause="order by order_by_column", limit_num=10) }}
 ```
 
 #### array_construct ([source](macros/cross_db_utils/array_construct.sql))

--- a/README.md
+++ b/README.md
@@ -1160,7 +1160,9 @@ This macro extracts a page path from a column containing a url.
 These macros make it easier for package authors (especially those writing modeling packages) to implement cross-database
 compatibility. In general, you should not use these macros in your own dbt project (unless it is a package)
 
-Note that most of these macros have now moved to dbt-core. Instead of the `dbt_utils.` namespace, you should now call these macros with the `dbt.` prefix, or without a prefix altogether (as shown in the examples below). They will eventuall be removed from `dbt_utils`.
+Note that most of these macros moved to dbt Core as of dbt_utils v0.9.0 and dbt Core v1.2.0, and will soon be removed from `dbt_utils`. 
+
+To access the version defined in dbt Core, remove the `dbt_utils.` prefix (see [https://docs.getdbt.com/reference/dbt-jinja-functions/cross-database-macros](https://docs.getdbt.com/reference/dbt-jinja-functions/cross-database-macros) for examples). 
 As highlighted below, some of the cross-database macros are still in the process of being deprecated.
 
 #### current_timestamp ([source](macros/cross_db_utils/current_timestamp.sql))

--- a/integration_tests/tests/generic/expect_table_columns_to_match_set.sql
+++ b/integration_tests/tests/generic/expect_table_columns_to_match_set.sql
@@ -1,7 +1,7 @@
 {#
     This macro is copied and slightly edited from the dbt_expectations package.
     At the time of this addition, dbt_expectations couldn't be added because
-    integration_tests is installing dbt_utils from local without a hard-coded 
+    integration_tests is installing dbt_utils from local without a hard-coded
     path. dbt is not able to resolve duplicate dependencies of dbt_utils
     due to this.
 #}
@@ -9,12 +9,12 @@
 {%- test expect_table_columns_to_match_set(model, column_list, transform="upper") -%}
 {%- if execute -%}
     {%- set column_list = column_list | map(transform) | list -%}
-    
-    {# Replaces dbt_expectations._get_column_list() #} 
-    {%- set relation_column_names = adapter.get_columns_in_relation(model) 
-                                    | map(attribute="name") 
-                                    | map(transform) 
-                                    | list 
+
+    {# Replaces dbt_expectations._get_column_list() #}
+    {%- set relation_column_names = adapter.get_columns_in_relation(model)
+                                    | map(attribute="name")
+                                    | map(transform)
+                                    | list
     -%}
 
     {# Replaces dbt_expectations._list_intersect() #}
@@ -28,14 +28,14 @@
     with relation_columns as (
 
         {% for col_name in relation_column_names %}
-        select cast('{{ col_name }}' as {{ dbt_utils.type_string() }}) as relation_column
+        select cast('{{ col_name }}' as {{ type_string() }}) as relation_column
         {% if not loop.last %}union all{% endif %}
         {% endfor %}
     ),
     input_columns as (
 
         {% for col_name in column_list %}
-        select cast('{{ col_name }}' as {{ dbt_utils.type_string() }}) as input_column
+        select cast('{{ col_name }}' as {{ type_string() }}) as input_column
         {% if not loop.last %}union all{% endif %}
         {% endfor %}
     )

--- a/macros/cross_db_utils/cast_array_to_string.sql
+++ b/macros/cross_db_utils/cast_array_to_string.sql
@@ -4,18 +4,18 @@
 {% endmacro %}
 
 {% macro default__cast_array_to_string(array) %}
-    cast({{ array }} as {{ dbt_utils.type_string() }})
+    cast({{ array }} as {{ type_string() }})
 {% endmacro %}
 
 {# when casting as array to string, postgres uses {} (ex: {1,2,3}) while other dbs use [] (ex: [1,2,3]) #}
 {% macro postgres__cast_array_to_string(array) %}
-    {%- set array_as_string -%}cast({{ array }} as {{ dbt_utils.type_string() }}){%- endset -%}
-    {{ dbt_utils.replace(dbt_utils.replace(array_as_string,"'}'","']'"),"'{'","'['") }}
+    {%- set array_as_string -%}cast({{ array }} as {{ type_string() }}){%- endset -%}
+    {{ replace(replace(array_as_string,"'}'","']'"),"'{'","'['") }}
 {% endmacro %}
 
 {# redshift should use default instead of postgres #}
 {% macro redshift__cast_array_to_string(array) %}
-    cast({{ array }} as {{ dbt_utils.type_string() }})
+    cast({{ array }} as {{ type_string() }})
 {% endmacro %}
 
 {% macro bigquery__cast_array_to_string(array) %}

--- a/macros/cross_db_utils/current_timestamp.sql
+++ b/macros/cross_db_utils/current_timestamp.sql
@@ -4,7 +4,7 @@
 {%- endmacro %}
 
 {% macro default__current_timestamp() %}
-    current_timestamp::{{dbt_utils.type_timestamp()}}
+    current_timestamp::{{ type_timestamp() }}
 {% endmacro %}
 
 {% macro redshift__current_timestamp() %}
@@ -23,15 +23,15 @@
 {%- endmacro %}
 
 {% macro default__current_timestamp_in_utc() %}
-    {{dbt_utils.current_timestamp()}}
+    {{ current_timestamp() }}
 {% endmacro %}
 
 {% macro snowflake__current_timestamp_in_utc() %}
-    convert_timezone('UTC', {{dbt_utils.current_timestamp()}})::{{dbt_utils.type_timestamp()}}
+    convert_timezone('UTC', {{current_timestamp() }})::{{ type_timestamp() }}
 {% endmacro %}
 
 {% macro postgres__current_timestamp_in_utc() %}
-    (current_timestamp at time zone 'utc')::{{dbt_utils.type_timestamp()}}
+    (current_timestamp at time zone 'utc')::{{ type_timestamp() }}
 {% endmacro %}
 
 {# redshift should use default instead of postgres #}

--- a/macros/cross_db_utils/current_timestamp.sql
+++ b/macros/cross_db_utils/current_timestamp.sql
@@ -23,11 +23,11 @@
 {%- endmacro %}
 
 {% macro default__current_timestamp_in_utc() %}
-    {{ current_timestamp() }}
+    {{ dbt_utils.current_timestamp() }}
 {% endmacro %}
 
 {% macro snowflake__current_timestamp_in_utc() %}
-    convert_timezone('UTC', {{current_timestamp() }})::{{ type_timestamp() }}
+    convert_timezone('UTC', {{ dbt_utils.current_timestamp() }})::{{ type_timestamp() }}
 {% endmacro %}
 
 {% macro postgres__current_timestamp_in_utc() %}

--- a/macros/generic_tests/cardinality_equality.sql
+++ b/macros/generic_tests/cardinality_equality.sql
@@ -26,7 +26,7 @@ group by {{ field }}
 except_a as (
   select *
   from table_a
-  {{ dbt_utils.except() }}
+  {{ except() }}
   select *
   from table_b
 ),
@@ -34,7 +34,7 @@ except_a as (
 except_b as (
   select *
   from table_b
-  {{ dbt_utils.except() }}
+  {{ except() }}
   select *
   from table_a
 ),

--- a/macros/generic_tests/equality.sql
+++ b/macros/generic_tests/equality.sql
@@ -49,7 +49,7 @@ b as (
 a_minus_b as (
 
     select {{compare_cols_csv}} from a
-    {{ dbt_utils.except() }}
+    {{ except() }}
     select {{compare_cols_csv}} from b
 
 ),
@@ -57,7 +57,7 @@ a_minus_b as (
 b_minus_a as (
 
     select {{compare_cols_csv}} from b
-    {{ dbt_utils.except() }}
+    {{ except() }}
     select {{compare_cols_csv}} from a
 
 ),

--- a/macros/generic_tests/recency.sql
+++ b/macros/generic_tests/recency.sql
@@ -4,7 +4,7 @@
 
 {% macro default__test_recency(model, field, datepart, interval) %}
 
-{% set threshold = dbt_utils.dateadd(datepart, interval * -1, dbt_utils.current_timestamp()) %}
+{% set threshold = dateadd(datepart, interval * -1, current_timestamp()) %}
 
 with recency as (
 

--- a/macros/generic_tests/sequential_values.sql
+++ b/macros/generic_tests/sequential_values.sql
@@ -23,7 +23,7 @@ validation_errors as (
         *
     from windowed
     {% if datepart %}
-    where not(cast({{ column_name }} as {{ dbt_utils.type_timestamp() }})= cast({{ dbt_utils.dateadd(datepart, interval, previous_column_name) }} as {{ dbt_utils.type_timestamp() }}))
+    where not(cast({{ column_name }} as {{ type_timestamp() }})= cast({{ dateadd(datepart, interval, previous_column_name) }} as {{ type_timestamp() }}))
     {% else %}
     where not({{ column_name }} = {{ previous_column_name }} + {{ interval }})
     {% endif %}

--- a/macros/materializations/insert_by_period_materialization.sql
+++ b/macros/materializations/insert_by_period_materialization.sql
@@ -12,7 +12,7 @@
             {{ dateadd('millisecond',
                                 -1,
                                 "nullif('" ~ stop_date ~ "','')::timestamp") }},
-            {{ current_timestamp() }}
+            {{ dbt_utils.current_timestamp() }}
           ) as stop_timestamp
       from "{{target_schema}}"."{{target_table}}"
     )

--- a/macros/materializations/insert_by_period_materialization.sql
+++ b/macros/materializations/insert_by_period_materialization.sql
@@ -9,10 +9,10 @@
       select
           coalesce(max("{{timestamp_field}}"), '{{start_date}}')::timestamp as start_timestamp,
           coalesce(
-            {{dbt_utils.dateadd('millisecond',
+            {{ dateadd('millisecond',
                                 -1,
-                                "nullif('" ~ stop_date ~ "','')::timestamp")}},
-            {{dbt_utils.current_timestamp()}}
+                                "nullif('" ~ stop_date ~ "','')::timestamp") }},
+            {{ current_timestamp() }}
           ) as stop_timestamp
       from "{{target_schema}}"."{{target_table}}"
     )
@@ -20,9 +20,9 @@
     select
       start_timestamp,
       stop_timestamp,
-      {{dbt_utils.datediff('start_timestamp',
+      {{ datediff('start_timestamp',
                            'stop_timestamp',
-                           period)}}  + 1 as num_periods
+                           period) }}  + 1 as num_periods
     from data
   {%- endcall %}
 
@@ -55,7 +55,7 @@
   {%- set start_date = config.require('start_date') -%}
   {%- set stop_date = config.get('stop_date') or '' -%}
   {%- set period = config.get('period') or 'week' -%}
-  
+
   {%- set deprecation_warning = "Warning: the `insert_by_period` materialization will be removed from dbt_utils in version 1.0.0. Install from dbt-labs/dbt-labs-experimental-features instead (see https://github.com/dbt-labs/dbt-utils/discussions/487). The " ~ package ~ "." ~ model ~ " model triggered this warning." -%}
   {%- do exceptions.warn(deprecation_warning) -%}
 
@@ -159,7 +159,7 @@
     {% else %} {# older versions #}
         {% set rows_inserted = result['status'].split(" ")[2] | int %}
     {% endif %}
-    
+
     {%- set sum_rows_inserted = loop_vars['sum_rows_inserted'] + rows_inserted -%}
     {%- if loop_vars.update({'sum_rows_inserted': sum_rows_inserted}) %} {% endif -%}
 
@@ -187,6 +187,6 @@
   {%- endcall %}
 
   -- Return the relations created in this materialization
-  {{ return({'relations': [target_relation]}) }}  
+  {{ return({'relations': [target_relation]}) }}
 
 {%- endmaterialization %}

--- a/macros/sql/date_spine.sql
+++ b/macros/sql/date_spine.sql
@@ -5,7 +5,7 @@
 {% macro default__get_intervals_between(start_date, end_date, datepart) -%}
     {%- call statement('get_intervals_between', fetch_result=True) %}
 
-        select {{dbt_utils.datediff(start_date, end_date, datepart)}}
+        select {{ datediff(start_date, end_date, datepart) }}
 
     {%- endcall -%}
 
@@ -51,7 +51,7 @@ all_periods as (
 
     select (
         {{
-            dbt_utils.dateadd(
+            dateadd(
                 datepart,
                 "row_number() over (order by 1) - 1",
                 start_date

--- a/macros/sql/surrogate_key.sql
+++ b/macros/sql/surrogate_key.sql
@@ -37,7 +37,7 @@ deprecated in a future release of dbt-utils. The {}.{} model triggered this warn
 {%- for field in field_list_xf -%}
 
     {%- set _ = fields.append(
-        "coalesce(cast(" ~ field ~ " as " ~ dbt_utils.type_string() ~ "), '')"
+        "coalesce(cast(" ~ field ~ " as " ~ type_string() ~ "), '')"
     ) -%}
 
     {%- if not loop.last %}
@@ -46,6 +46,6 @@ deprecated in a future release of dbt-utils. The {}.{} model triggered this warn
 
 {%- endfor -%}
 
-{{dbt_utils.hash(dbt_utils.concat(fields))}}
+{{ hash(concat(fields)) }}
 
 {%- endmacro -%}

--- a/macros/sql/union.sql
+++ b/macros/sql/union.sql
@@ -86,7 +86,7 @@
             select
 
                 {%- if source_column_name != none %}
-                cast({{ dbt_utils.string_literal(relation) }} as {{ dbt_utils.type_string() }}) as {{ source_column_name }},
+                cast({{ dbt_utils.string_literal(relation) }} as {{ type_string() }}) as {{ source_column_name }},
                 {%- endif %}
 
                 {% for col_name in ordered_column_names -%}

--- a/macros/sql/unpivot.sql
+++ b/macros/sql/unpivot.sql
@@ -61,9 +61,9 @@ Arguments:
         {{ exclude_col }},
       {%- endfor %}
 
-      cast('{{ col.column }}' as {{ dbt_utils.type_string() }}) as {{ field_name }},
+      cast('{{ col.column }}' as {{ type_string() }}) as {{ field_name }},
       cast(  {% if col.data_type == 'boolean' %}
-           {{ dbt_utils.cast_bool_to_text(col.column) }}
+           {{ cast_bool_to_text(col.column) }}
              {% else %}
            {{ col.column }}
              {% endif %}

--- a/macros/sql/width_bucket.sql
+++ b/macros/sql/width_bucket.sql
@@ -13,8 +13,8 @@
         case
             when
                 mod(
-                    {{ dbt_utils.safe_cast(expr, dbt_utils.type_numeric() ) }},
-                    {{ dbt_utils.safe_cast(bin_size, dbt_utils.type_numeric() ) }}
+                    {{ dbt.safe_cast(expr, type_numeric() ) }},
+                    {{ dbt.safe_cast(bin_size, type_numeric() ) }}
                 ) = 0
             then 1
             else 0
@@ -38,8 +38,8 @@
         -- to break ties when the amount is exactly at the bucket edge
         case
             when
-                {{ dbt_utils.safe_cast(expr, dbt_utils.type_numeric() ) }} %
-                {{ dbt_utils.safe_cast(bin_size, dbt_utils.type_numeric() ) }}
+                {{ dbt.safe_cast(expr, type_numeric() ) }} %
+                {{ dbt.safe_cast(bin_size, type_numeric() ) }}
                  = 0
             then 1
             else 0

--- a/macros/web/get_url_host.sql
+++ b/macros/web/get_url_host.sql
@@ -5,11 +5,11 @@
 {% macro default__get_url_host(field) -%}
 
 {%- set parsed =
-    dbt_utils.split_part(
-        dbt_utils.split_part(
-            dbt_utils.replace(
-                dbt_utils.replace(
-                    dbt_utils.replace(field, "'android-app://'", "''"
+    split_part(
+        split_part(
+            replace(
+                replace(
+                    replace(field, "'android-app://'", "''"
                     ), "'http://'", "''"
                 ), "'https://'", "''"
             ), "'/'", 1
@@ -19,9 +19,9 @@
 -%}
 
 
-    {{ dbt_utils.safe_cast(
+    {{ dbt.safe_cast(
         parsed,
-        dbt_utils.type_string()
+        type_string()
         )}}
 
 {%- endmacro %}

--- a/macros/web/get_url_parameter.sql
+++ b/macros/web/get_url_parameter.sql
@@ -6,7 +6,7 @@
 
 {%- set formatted_url_parameter = "'" + url_parameter + "='" -%}
 
-{%- set split = dbt_utils.split_part(dbt_utils.split_part(field, formatted_url_parameter, 2), "'&'", 1) -%}
+{%- set split = split_part(split_part(field, formatted_url_parameter, 2), "'&'", 1) -%}
 
 nullif({{ split }},'')
 

--- a/macros/web/get_url_path.sql
+++ b/macros/web/get_url_path.sql
@@ -4,31 +4,31 @@
 
 {% macro default__get_url_path(field) -%}
 
-    {%- set stripped_url = 
-        dbt_utils.replace(
-            dbt_utils.replace(field, "'http://'", "''"), "'https://'", "''")
+    {%- set stripped_url =
+        replace(
+            replace(field, "'http://'", "''"), "'https://'", "''")
     -%}
 
     {%- set first_slash_pos -%}
         coalesce(
-            nullif({{dbt_utils.position("'/'", stripped_url)}}, 0),
-            {{dbt_utils.position("'?'", stripped_url)}} - 1
+            nullif({{ position("'/'", stripped_url) }}, 0),
+            {{ position("'?'", stripped_url) }} - 1
             )
     {%- endset -%}
 
     {%- set parsed_path =
-        dbt_utils.split_part(
-            dbt_utils.right(
-                stripped_url, 
-                dbt_utils.length(stripped_url) ~ "-" ~ first_slash_pos
-                ), 
+        split_part(
+            right(
+                stripped_url,
+                length(stripped_url) ~ "-" ~ first_slash_pos
+                ),
             "'?'", 1
             )
     -%}
 
-    {{ dbt_utils.safe_cast(
+    {{ safe_cast(
         parsed_path,
-        dbt_utils.type_string()
+        type_string()
     )}}
-    
+
 {%- endmacro %}


### PR DESCRIPTION
This PR removes internal references to deprecated `dbt_utils` macros in favor of their `dbt-core` counterparts.

Closes #656 

This is a:
- [x] documentation update
- [x] bug fix with no breaking changes
- [ ] new functionality
- [ ] a breaking change

All pull requests from community contributors should target the `main` branch (default).

## Description & motivation
Several dbt-utils macros internally reference deprecated macros using the `dbt_utils` namespace. This triggers warnings in downstream models and packages.

## Checklist
- [x] This code is associated with an Issue which has been triaged and [accepted for development](https://docs.getdbt.com/docs/contributing/oss-expectations#pull-requests). 
- [x] I have verified that these changes work locally on the following warehouses (Note: it's okay if you do not have access to all warehouses, this helps us understand what has been covered)
    - [x] BigQuery
    - [x] Postgres
    - [ ] Redshift
    - [x] Snowflake
- [ ] I followed guidelines to ensure that my changes will work on "non-core" adapters by:
    - [ ] dispatching any new macro(s) so non-core adapters can also use them (e.g. [the `star()` source](https://github.com/dbt-labs/dbt-utils/blob/main/macros/sql/star.sql))
    - [ ] using the `limit_zero()` macro in place of the literal string: `limit 0`
    - [ ] using `dbt.type_*` macros instead of explicit datatypes (e.g. `dbt.type_timestamp()` instead of `TIMESTAMP`
- [x] I have updated the README.md (if applicable)
- [ ] I have added tests & descriptions to my models (and macros if applicable)
- [ ] I have added an entry to CHANGELOG.md
