### PR TITLE
update union_relations to use core string literal macro

### DIFF
--- a/macros/sql/union.sql
+++ b/macros/sql/union.sql
@@ -86,7 +86,7 @@
             select
 
                 {%- if source_column_name is not none %}
-                cast({{ dbt_utils.string_literal(relation) }} as {{ type_string() }}) as {{ source_column_name }},
+                cast({{ string_literal(relation) }} as {{ type_string() }}) as {{ source_column_name }},
                 {%- endif %}
 
                 {% for col_name in ordered_column_names -%}


### PR DESCRIPTION
resolves #664 

This is a:
- [ ] documentation update
- [x] bug fix with no breaking changes
- [ ] new functionality
- [ ] a breaking change

All pull requests from community contributors should target the `main` branch (default).

## Description & motivation

This updates the `string_literal` cross db macro in `union_relations` to use the core version rather than the dbt_utils version to avoid deprecation warnings. 

### Before 

<img width="990" alt="image" src="https://user-images.githubusercontent.com/73915542/189737910-37ab5c18-3cab-4535-a498-b310337bdfd6.png">


### After

<img width="957" alt="image" src="https://user-images.githubusercontent.com/73915542/189738012-91031a85-fa7d-4957-9d72-b27eed08a9ca.png">


## Checklist
- [x] This code is associated with an Issue which has been triaged and [accepted for development](https://docs.getdbt.com/docs/contributing/oss-expectations#pull-requests). 
- [x] I have verified that these changes work locally on the following warehouses (Note: it's okay if you do not have access to all warehouses, this helps us understand what has been covered)
    - [ ] BigQuery
    - [x] Postgres
    - [ ] Redshift
    - [ ] Snowflake
- [x] I followed guidelines to ensure that my changes will work on "non-core" adapters by:
    - [ ] dispatching any new macro(s) so non-core adapters can also use them (e.g. [the `star()` source](https://github.com/dbt-labs/dbt-utils/blob/main/macros/sql/star.sql))
    - [ ] using the `limit_zero()` macro in place of the literal string: `limit 0`
    - [ ] using `dbt.type_*` macros instead of explicit datatypes (e.g. `dbt.type_timestamp()` instead of `TIMESTAMP`
- [ ] I have updated the README.md (if applicable)
- [ ] I have added tests & descriptions to my models (and macros if applicable)
- [ ] I have added an entry to CHANGELOG.md
