### PR TITLE
Fully remove varargs usage in surrogate_key and safe_add

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,9 @@
 ## Under the hood
 - Remove deprecated table argument from unpivot ([#671](https://github.com/dbt-labs/dbt-utils/pull/671))
 
+## Under the hood
+- Fully remove varargs usage in surrogate_key ([#674](https://github.com/dbt-labs/dbt-utils/pull/674))
+
 ## Fixes
 - Better handling of whitespaces in the star macro ([#651](https://github.com/dbt-labs/dbt-utils/pull/651))
 - Fix to correct behavior in `mutually_exclusive_ranges` test in certain situations when `zero_length_range_allowed: true` and multiple ranges in a partition have the same value for `lower_bound_column`. ([[#659](https://github.com/dbt-labs/dbt-utils/issues/659)], [#660](https://github.com/dbt-labs/dbt-utils/pull/660))
@@ -27,7 +30,7 @@
 - [@epapineau](https://github.com/epapineau) (#634)
 - [@courentin](https://github.com/courentin) (#651)
 - [@sfc-gh-ancoleman](https://github.com/sfc-gh-ancoleman) (#660)
-- [@miles170](https://github.com/miles170) (#671)
+- [@miles170](https://github.com/miles170)
 - [@emilyriederer](https://github.com/emilyriederer) 
 
 # dbt-utils v0.8.6

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@
 - Remove deprecated table argument from unpivot ([#671](https://github.com/dbt-labs/dbt-utils/pull/671))
 
 ## Under the hood
-- Fully remove varargs usage in surrogate_key ([#674](https://github.com/dbt-labs/dbt-utils/pull/674))
+- Fully remove varargs usage in surrogate_key and safe_add ([#674](https://github.com/dbt-labs/dbt-utils/pull/674))
 
 ## Fixes
 - Better handling of whitespaces in the star macro ([#651](https://github.com/dbt-labs/dbt-utils/pull/651))

--- a/integration_tests/models/sql/schema.yml
+++ b/integration_tests/models/sql/schema.yml
@@ -142,9 +142,6 @@ models:
           actual: actual_column_1_only
           expected: expected_column_1_only
       - assert_equal:
-          actual: actual_all_columns_arguments
-          expected: expected_all_columns
-      - assert_equal:
           actual: actual_all_columns_list
           expected: expected_all_columns
 
@@ -218,4 +215,3 @@ models:
       - assert_equal:
           actual: actual
           expected: expected
-

--- a/integration_tests/models/sql/test_safe_add.sql
+++ b/integration_tests/models/sql/test_safe_add.sql
@@ -6,7 +6,7 @@ with data as (
 )
 
 select
-    {{ dbt_utils.safe_add('field_1', 'field_2', 'field_3') }} as actual,
+    {{ dbt_utils.safe_add(['field_1', 'field_2', 'field_3']) }} as actual,
     expected
 
 from data

--- a/integration_tests/models/sql/test_surrogate_key.sql
+++ b/integration_tests/models/sql/test_surrogate_key.sql
@@ -6,9 +6,8 @@ with data as (
 )
 
 select
-    {{ dbt_utils.surrogate_key('column_1') }} as actual_column_1_only,
+    {{ dbt_utils.surrogate_key(['column_1']) }} as actual_column_1_only,
     expected_column_1_only,
-    {{ dbt_utils.surrogate_key('column_1', 'column_2', 'column_3') }} as actual_all_columns_arguments,
     {{ dbt_utils.surrogate_key(['column_1', 'column_2', 'column_3']) }} as actual_all_columns_list,
     expected_all_columns
 

--- a/macros/sql/safe_add.sql
+++ b/macros/sql/safe_add.sql
@@ -1,15 +1,23 @@
-{%- macro safe_add() -%}
-    {# needed for safe_add to allow for non-keyword arguments see SO post #}
-    {# https://stackoverflow.com/questions/13944751/args-kwargs-in-jinja2-macros #}
-    {% set frustrating_jinja_feature = varargs %}
-    {{ return(adapter.dispatch('safe_add', 'dbt_utils')(*varargs)) }}
+{%- macro safe_add(field_list) -%}
+    {{ return(adapter.dispatch('safe_add', 'dbt_utils')(field_list)) }}
 {% endmacro %}
 
-{%- macro default__safe_add() -%}
+{%- macro default__safe_add(field_list) -%}
+
+{%- if field_list is not iterable or field_list is string or field_list is mapping -%}
+
+{%- set error_message = '
+Warning: the `safe_add` macro now takes a single list argument instead of \
+string arguments. The {}.{} model triggered this warning. \
+'.format(model.package_name, model.name) -%}
+
+{%- do exceptions.warn(error_message) -%}
+
+{%- endif -%}
 
 {% set fields = [] %}
 
-{%- for field in varargs -%}
+{%- for field in field_list -%}
 
     {% do fields.append("coalesce(" ~ field ~ ", 0)") %}
 

--- a/macros/sql/surrogate_key.sql
+++ b/macros/sql/surrogate_key.sql
@@ -1,47 +1,30 @@
 {%- macro surrogate_key(field_list) -%}
-    {# needed for safe_add to allow for non-keyword arguments see SO post #}
-    {# https://stackoverflow.com/questions/13944751/args-kwargs-in-jinja2-macros #}
-    {% set frustrating_jinja_feature = varargs %}
-    {{ return(adapter.dispatch('surrogate_key', 'dbt_utils')(field_list, *varargs)) }}
+    {{ return(adapter.dispatch('surrogate_key', 'dbt_utils')(field_list)) }}
 {% endmacro %}
 
 {%- macro default__surrogate_key(field_list) -%}
 
-{%- if varargs|length >= 1 or field_list is string %}
+{%- if field_list is not iterable or field_list is string or field_list is mapping -%}
 
 {%- set error_message = '
 Warning: the `surrogate_key` macro now takes a single list argument instead of \
-multiple string arguments. Support for multiple string arguments will be \
-deprecated in a future release of dbt-utils. The {}.{} model triggered this warning. \
+string arguments. The {}.{} model triggered this warning. \
 '.format(model.package_name, model.name) -%}
 
 {%- do exceptions.warn(error_message) -%}
 
-{# first argument is not included in varargs, so add first element to field_list_xf #}
-{%- set field_list_xf = [field_list] -%}
-
-{%- for field in varargs %}
-{%- set _ = field_list_xf.append(field) -%}
-{%- endfor -%}
-
-{%- else -%}
-
-{# if using list, just set field_list_xf as field_list #}
-{%- set field_list_xf = field_list -%}
-
 {%- endif -%}
-
 
 {%- set fields = [] -%}
 
-{%- for field in field_list_xf -%}
+{%- for field in field_list -%}
 
-    {%- set _ = fields.append(
+    {%- do fields.append(
         "coalesce(cast(" ~ field ~ " as " ~ type_string() ~ "), '')"
     ) -%}
 
     {%- if not loop.last %}
-        {%- set _ = fields.append("'-'") -%}
+        {%- do fields.append("'-'") -%}
     {%- endif -%}
 
 {%- endfor -%}


### PR DESCRIPTION
Closes #667.

This is a:
- [ ] documentation update
- [ ] bug fix with no breaking changes
- [ ] new functionality
- [x] a breaking change

All pull requests from community contributors should target the `main` branch (default).

## Description & motivation

Remove the `varargs` usage in `surrogate_key`, which now only takes a single list argument.

## Checklist
- [x] This code is associated with an Issue which has been triaged and [accepted for development](https://docs.getdbt.com/docs/contributing/oss-expectations#pull-requests). 
- [x] I have verified that these changes work locally on the following warehouses (Note: it's okay if you do not have access to all warehouses, this helps us understand what has been covered)
    - [ ] BigQuery
    - [x] Postgres
    - [ ] Redshift
    - [ ] Snowflake
- [ ] I followed guidelines to ensure that my changes will work on "non-core" adapters by:
    - [ ] dispatching any new macro(s) so non-core adapters can also use them (e.g. [the `star()` source](https://github.com/dbt-labs/dbt-utils/blob/main/macros/sql/star.sql))
    - [ ] using the `limit_zero()` macro in place of the literal string: `limit 0`
    - [ ] using `dbt.type_*` macros instead of explicit datatypes (e.g. `dbt.type_timestamp()` instead of `TIMESTAMP`
- [ ] I have updated the README.md (if applicable)
- [ ] I have added tests & descriptions to my models (and macros if applicable)
- [x] I have added an entry to CHANGELOG.md
