### PR TITLE
Remove cross-db dbt_utils references

### DIFF
--- a/macros/sql/pivot.sql
+++ b/macros/sql/pivot.sql
@@ -69,7 +69,7 @@ Arguments:
     {{ agg }}(
       {% if distinct %} distinct {% endif %}
       case
-      when {{ column }} {{ cmp }} '{{ dbt_utils.escape_single_quotes(value) }}'
+      when {{ column }} {{ cmp }} '{{ escape_single_quotes(value) }}'
         then {{ then_value }}
       else {{ else_value }}
       end


### PR DESCRIPTION
Remove reference to cross-db utils in pivot macro

resolves #656 

This is a:
- [ ] documentation update
- [X] bug fix with no breaking changes
- [ ] new functionality
- [ ] a breaking change

All pull requests from community contributors should target the `main` branch (default).

## Description & motivation
<!---
Similar [to another PR](https://github.com/dbt-labs/dbt-utils/pull/650), this removes additional references to cross-db dbt_utils that have not already been adjusted and would throw deprecation warnings for dbt-core v1.2+.
-->

## Checklist
- [X] This code is associated with an Issue which has been triaged and accepted for development
- [X] I have verified that these changes work locally on the following warehouses (Note: it's okay if you do not have access to all warehouses, this helps us understand what has been covered)
    - [ ] BigQuery
    - [ ] Postgres
    - [ ] Redshift
    - [X] Snowflake
- [X] I followed guidelines to ensure that my changes will work on "non-core" adapters by:
    - [ ] dispatching any new macro(s) so non-core adapters can also use them (e.g. [the `star()` source](https://github.com/dbt-labs/dbt-utils/blob/main/macros/sql/star.sql))
    - [ ] using the `limit_zero()` macro in place of the literal string: `limit 0`
    - [ ] using `dbt.type_*` macros instead of explicit datatypes (e.g. `dbt.type_timestamp()` instead of `TIMESTAMP`
- [X] I have updated the README.md (if applicable)
- [X] I have added tests & descriptions to my models (and macros if applicable)
- [ ] I have added an entry to CHANGELOG.md
