### PR TITLE
Add optional `condition` to `not_null_proportion` test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 ## New features
 - New feature to omit the `source_column_name` column on the `union_relations` macro ([#331](https://github.com/dbt-labs/dbt-utils/issues/331), [#624](https://github.com/dbt-labs/dbt-utils/pull/624))
+- New feature to allow a `condition` option to `not_null_proportion` tests ([#691](https://github.com/dbt-labs/dbt-utils/pull/691))
 
 ## Fixes
 - Better handling of whitespaces in the star macro ([#651](https://github.com/dbt-labs/dbt-utils/pull/651))

--- a/README.md
+++ b/README.md
@@ -317,6 +317,23 @@ models:
               at_least: 0.95
 ```
 
+The macro accepts an optional argument `condition` that allows for asserting the proportion is not null on a subset of all records.
+
+**Usage:**
+
+```yaml
+version: 2
+
+models:
+  - name: my_model
+    columns:
+      - name: id
+        tests:
+          - dbt_utils.not_null_proportion:
+              at_least: 0.95
+              condition: "created_at > '2018-12-31'"
+```
+
 #### not_accepted_values ([source](macros/generic_tests/not_accepted_values.sql))
 
 Asserts that there are no rows that match the given values.

--- a/integration_tests/models/generic_tests/schema.yml
+++ b/integration_tests/models/generic_tests/schema.yml
@@ -146,6 +146,10 @@ seeds:
         tests:
           - dbt_utils.not_null_proportion:
               at_least: 0.9
+          - dbt_utils.not_null_proportion:
+              at_least: 1
+              at_most: 1
+              condition: "point_9 IS NOT NULL"
 
 models:
   - name: test_recency

--- a/macros/generic_tests/not_null_proportion.sql
+++ b/macros/generic_tests/not_null_proportion.sql
@@ -7,11 +7,13 @@
 {% set column_name = kwargs.get('column_name', kwargs.get('arg')) %}
 {% set at_least = kwargs.get('at_least', kwargs.get('arg')) %}
 {% set at_most = kwargs.get('at_most', kwargs.get('arg', 1)) %}
+{% set condition = kwargs.get('condition', kwargs.get('arg', '1=1')) %}
 
 with validation as (
   select
     sum(case when {{ column_name }} is null then 0 else 1 end) / cast(count(*) as numeric) as not_null_proportion
   from {{ model }}
+  where {{ condition }}
 ),
 validation_errors as (
   select


### PR DESCRIPTION
This is a:
- [ ] documentation update
- [ ] bug fix with no breaking changes
- [x] new functionality
- [ ] a breaking change

All pull requests from community contributors should target the `main` branch (default).

## Description & motivation
The dbt core `not_null` test allows a `where` parameter and the dbt utils `expression_is_true` allows a `condition` parameter, both of which allow the test to operate on a subset of rows.

This adds a similar functoinality to the `not_null_proportion` test, sticking with the `condition` convention from `expression_is_true.


## Checklist
- [ ] This code is associated with an Issue which has been triaged and [accepted for development](https://docs.getdbt.com/docs/contributing/oss-expectations#pull-requests). 
- [x] I have verified that these changes work locally on the following warehouses (Note: it's okay if you do not have access to all warehouses, this helps us understand what has been covered)
    - [ ] BigQuery
    - [x] Postgres
    - [ ] Redshift
    - [ ] Snowflake
- [ ] I followed guidelines to ensure that my changes will work on "non-core" adapters by:
    - [ ] dispatching any new macro(s) so non-core adapters can also use them (e.g. [the `star()` source](https://github.com/dbt-labs/dbt-utils/blob/main/macros/sql/star.sql))
    - [ ] using the `limit_zero()` macro in place of the literal string: `limit 0`
    - [ ] using `dbt.type_*` macros instead of explicit datatypes (e.g. `dbt.type_timestamp()` instead of `TIMESTAMP`
- [x] I have updated the README.md (if applicable)
- [x] I have added tests & descriptions to my models (and macros if applicable)
- [x] I have added an entry to CHANGELOG.md
