### PR TITLE
Add ClickHouse support to get_tables_by_pattern_sql

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,12 +17,14 @@
 - Better handling of whitespaces in the star macro ([#651](https://github.com/dbt-labs/dbt-utils/pull/651))
 - Fix to correct behavior in `mutually_exclusive_ranges` test in certain situations when `zero_length_range_allowed: true` and multiple ranges in a partition have the same value for `lower_bound_column`. ([[#659](https://github.com/dbt-labs/dbt-utils/issues/659)], [#660](https://github.com/dbt-labs/dbt-utils/pull/660))
 - Fix to utilize dbt Core version of `escape_single_quotes` instead of version from dbt Utils ([[#689](https://github.com/dbt-labs/dbt-utils/issues/689)], [#692](https://github.com/dbt-labs/dbt-utils/pull/692))
+- Make `get_tables_by_pattern_sql` work with ClickHouse ([#698](https://github.com/dbt-labs/dbt-utils/pull/698))
 
 ## Contributors:
 - [@christineberger](https://github.com/christineberger) (#624)
 - [@courentin](https://github.com/courentin) (#651)
 - [@sfc-gh-ancoleman](https://github.com/sfc-gh-ancoleman) (#660)
 - [@zachoj10](https://github.com/zachoj10) (#692)
+- [@mlazowik](https://github.com/mlazowik) (#698)
 
 # dbt-utils v0.8.6
 

--- a/macros/sql/get_tables_by_pattern_sql.sql
+++ b/macros/sql/get_tables_by_pattern_sql.sql
@@ -68,3 +68,16 @@
 
 
 {% endmacro %}
+
+{% macro clickhouse__get_tables_by_pattern_sql(schema_pattern, table_pattern, exclude='', database=target.database) %}
+
+        select
+            database as "table_schema",
+            name as "table_name",
+            'table' as "table_type"
+        from system.tables
+        where database ilike '{{ schema_pattern }}'
+        and name ilike '{{ table_pattern }}'
+        and name not ilike '{{ exclude }}'
+
+{% endmacro %}


### PR DESCRIPTION
This is a:
- [ ] documentation update
- [x] bug fix with no breaking changes
- [ ] new functionality
- [ ] a breaking change

All pull requests from community contributors should target the `main` branch (default).

## Description & motivation
The generic code does not work with ClickHouse. The main motivation is to make the source generation macro from `dbt--codegen` work.

Note that ClickHouse has no concept of schemas, only databases. The schema name from dbt is used as a database name. See https://docs.getdbt.com/reference/warehouse-profiles/clickhouse-profile#description-of-clickhouse-profile-fields

## Checklist
- [ ] This code is associated with an Issue which has been triaged and [accepted for development](https://docs.getdbt.com/docs/contributing/oss-expectations#pull-requests). 
- [x] I have verified that these changes work locally on the following warehouses (Note: it's okay if you do not have access to all warehouses, this helps us understand what has been covered)
    - [ ] BigQuery
    - [ ] Postgres
    - [ ] Redshift
    - [ ] Snowflake
    - [x] ClickHouse 
- [ ] I followed guidelines to ensure that my changes will work on "non-core" adapters by:
    - [ ] dispatching any new macro(s) so non-core adapters can also use them (e.g. [the `star()` source](https://github.com/dbt-labs/dbt-utils/blob/main/macros/sql/star.sql))
    - [ ] using the `limit_zero()` macro in place of the literal string: `limit 0`
    - [ ] using `dbt.type_*` macros instead of explicit datatypes (e.g. `dbt.type_timestamp()` instead of `TIMESTAMP`
    - [x] appending db-specific code to an existing macro
- [ ] I have updated the README.md (if applicable)
- [ ] I have added tests & descriptions to my models (and macros if applicable)
- [x] I have added an entry to CHANGELOG.md
