### PR TITLE
Remove obsolete condition argument from expression_is_true

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,10 +17,11 @@
 - Add `not_empty_string` generic test that asserts column values are not an empty string. ([#632](https://github.com/dbt-labs/dbt-utils/issues/632), [#634](https://github.com/dbt-labs/dbt-utils/pull/634))
 
 ## Under the hood
-- Remove deprecated table argument from unpivot ([#671](https://github.com/dbt-labs/dbt-utils/pull/671))
+- Remove deprecated table argument from `unpivot` ([#671](https://github.com/dbt-labs/dbt-utils/pull/671))
 - Delete the deprecated identifier macro ([#672](https://github.com/dbt-labs/dbt-utils/pull/672))
 - Handle deprecations in deduplicate macro ([#673](https://github.com/dbt-labs/dbt-utils/pull/673))
-- Fully remove varargs usage in surrogate_key and safe_add ([#674](https://github.com/dbt-labs/dbt-utils/pull/674))
+- Fully remove varargs usage in `surrogate_key` and `safe_add` ([#674](https://github.com/dbt-labs/dbt-utils/pull/674))
+- Remove obsolete condition argument from `expression_is_true` ([#699](https://github.com/dbt-labs/dbt-utils/pull/699))
 
 ## Fixes
 - Better handling of whitespaces in the star macro ([#651](https://github.com/dbt-labs/dbt-utils/pull/651))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,33 @@
 - Fully remove varargs usage in `surrogate_key` and `safe_add` ([#674](https://github.com/dbt-labs/dbt-utils/pull/674))
 - Remove obsolete condition argument from `expression_is_true` ([#699](https://github.com/dbt-labs/dbt-utils/pull/699))
 
+## Migration instructions
+- If your project uses the `expression_is_true` macro, replace `condition` argument with `where`. 
+
+Before:
+```yaml
+version: 2
+
+models:
+  - name: model_name
+    tests:
+      - dbt_utils.expression_is_true:
+          expression: "col_a + col_b = total"
+          condition: "created_at > '2018-12-31'"
+```
+After:
+```yaml
+version: 2
+
+models:
+  - name: model_name
+    tests:
+      - dbt_utils.expression_is_true:
+          expression: "col_a + col_b = total"
+          config:
+            where: "created_at > '2018-12-31'"
+```
+
 ## Fixes
 - Better handling of whitespaces in the star macro ([#651](https://github.com/dbt-labs/dbt-utils/pull/651))
 - Fix to correct behavior in `mutually_exclusive_ranges` test in certain situations when `zero_length_range_allowed: true` and multiple ranges in a partition have the same value for `lower_bound_column`. ([[#659](https://github.com/dbt-labs/dbt-utils/issues/659)], [#660](https://github.com/dbt-labs/dbt-utils/pull/660))

--- a/README.md
+++ b/README.md
@@ -173,8 +173,6 @@ models:
             where: "created_at > '2018-12-31'"
 ```
 
-This macro can also be used at the column level. When this is done, the `expression` is evaluated against the column.
-
 ```yaml
 version: 2
 models:

--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ models:
           expression: "col_a + col_b = total"
 ```
 
-The macro accepts an optional argument `condition` that allows for asserting
+The macro accepts an optional argument `where` that allows for asserting
 the `expression` on a subset of all records.
 
 **Usage:**
@@ -169,7 +169,8 @@ models:
     tests:
       - dbt_utils.expression_is_true:
           expression: "col_a + col_b = total"
-          condition: "created_at > '2018-12-31'"
+          config:
+            where: "created_at > '2018-12-31'"
 ```
 
 This macro can also be used at the column level. When this is done, the `expression` is evaluated against the column.
@@ -187,7 +188,8 @@ models:
         tests:
           - dbt_utils.expression_is_true:
               expression: '= 1'
-              condition: col_a = 1
+              config:
+                where: col_a = 1
 ```
 
 #### recency ([source](macros/generic_tests/recency.sql))

--- a/integration_tests/models/generic_tests/schema.yml
+++ b/integration_tests/models/generic_tests/schema.yml
@@ -23,7 +23,8 @@ seeds:
           expression: col_a + col_b = 1
       - dbt_utils.expression_is_true:
           expression: col_a = 0.5
-          condition: col_b = 0.5
+          config:
+            where: col_b = 0.5
     columns:
       - name: col_a
         tests:
@@ -33,7 +34,8 @@ seeds:
         tests:
           - dbt_utils.expression_is_true:
               expression: = 0.5
-              condition: col_a = 0.5
+              config:
+                where: col_a = 0.5
 
   - name: data_people
     columns:

--- a/macros/generic_tests/expression_is_true.sql
+++ b/macros/generic_tests/expression_is_true.sql
@@ -1,20 +1,16 @@
-{% test expression_is_true(model, expression, column_name=None, condition='1=1') %}
+{% test expression_is_true(model, expression, column_name=None) %}
 {# T-SQL has no boolean data type so we use 1=1 which returns TRUE #}
 {# ref https://stackoverflow.com/a/7170753/3842610 #}
-  {{ return(adapter.dispatch('test_expression_is_true', 'dbt_utils')(model, expression, column_name, condition)) }}
+  {{ return(adapter.dispatch('test_expression_is_true', 'dbt_utils')(model, expression, column_name)) }}
 {% endtest %}
 
-{% macro default__test_expression_is_true(model, expression, column_name, condition) %}
+{% macro default__test_expression_is_true(model, expression, column_name) %}
 
 {% set column_list = '*' if should_store_failures() else "1" %}
 
-with meet_condition as (
-    select * from {{ model }} where {{ condition }}
-)
-
 select
     {{ column_list }}
-from meet_condition
+from {{ model }}
 {% if column_name is none %}
 where not({{ expression }})
 {%- else %}

--- a/macros/generic_tests/expression_is_true.sql
+++ b/macros/generic_tests/expression_is_true.sql
@@ -1,6 +1,4 @@
 {% test expression_is_true(model, expression, column_name=None) %}
-{# T-SQL has no boolean data type so we use 1=1 which returns TRUE #}
-{# ref https://stackoverflow.com/a/7170753/3842610 #}
   {{ return(adapter.dispatch('test_expression_is_true', 'dbt_utils')(model, expression, column_name)) }}
 {% endtest %}
 


### PR DESCRIPTION
Closes #695 

This is a:
- [ ] documentation update
- [ ] bug fix with no breaking changes
- [ ] new functionality
- [x] a breaking change

All pull requests from community contributors should target the `main` branch (default).

## Description & motivation
<!---
Describe your changes, and why you're making them.
-->

Remove `condition` argument since it can be replaced by `where`.

## Checklist
- [x] This code is associated with an Issue which has been triaged and [accepted for development](https://docs.getdbt.com/docs/contributing/oss-expectations#pull-requests). 
- [x] I have verified that these changes work locally on the following warehouses (Note: it's okay if you do not have access to all warehouses, this helps us understand what has been covered)
    - [ ] BigQuery
    - [x] Postgres
    - [ ] Redshift
    - [ ] Snowflake
- [ ] I followed guidelines to ensure that my changes will work on "non-core" adapters by:
    - [ ] dispatching any new macro(s) so non-core adapters can also use them (e.g. [the `star()` source](https://github.com/dbt-labs/dbt-utils/blob/main/macros/sql/star.sql))
    - [ ] using the `limit_zero()` macro in place of the literal string: `limit 0`
    - [ ] using `dbt.type_*` macros instead of explicit datatypes (e.g. `dbt.type_timestamp()` instead of `TIMESTAMP`
- [ ] I have updated the README.md (if applicable)
- [ ] I have added tests & descriptions to my models (and macros if applicable)
- [x] I have added an entry to CHANGELOG.md
