### PR TITLE
Restore dbt. prefix for all migrated cross-db macros

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,18 +23,20 @@
 - Fully remove varargs usage in surrogate_key and safe_add ([#674](https://github.com/dbt-labs/dbt-utils/pull/674))
 
 ## Fixes
+- Explicitly stating the namespace for cross-db macros so that the dispatch logic works correctly by restoring the dbt. prefix for all migrated cross-db macros ([#701](https://github.com/dbt-labs/dbt-utils/pull/701))
 - Better handling of whitespaces in the star macro ([#651](https://github.com/dbt-labs/dbt-utils/pull/651))
 - Fix to correct behavior in `mutually_exclusive_ranges` test in certain situations when `zero_length_range_allowed: true` and multiple ranges in a partition have the same value for `lower_bound_column`. ([[#659](https://github.com/dbt-labs/dbt-utils/issues/659)], [#660](https://github.com/dbt-labs/dbt-utils/pull/660))
 - Fix to utilize dbt Core version of `escape_single_quotes` instead of version from dbt Utils ([[#689](https://github.com/dbt-labs/dbt-utils/issues/689)], [#692](https://github.com/dbt-labs/dbt-utils/pull/692))
 
 ## Contributors:
+- [@SimonQuvang](https://github.com/SimonQuvang) (#701)
 - [@christineberger](https://github.com/christineberger) (#624)
 - [@epapineau](https://github.com/epapineau) (#634)
 - [@courentin](https://github.com/courentin) (#651)
 - [@sfc-gh-ancoleman](https://github.com/sfc-gh-ancoleman) (#660)
 - [@zachoj10](https://github.com/zachoj10) (#692)
 - [@miles170](https://github.com/miles170)
-- [@emilyriederer](https://github.com/emilyriederer) 
+- [@emilyriederer](https://github.com/emilyriederer)
 
 # dbt-utils v0.8.6
 

--- a/integration_tests/data/sql/data_safe_divide_numerator_expressions.csv
+++ b/integration_tests/data/sql/data_safe_divide_numerator_expressions.csv
@@ -5,4 +5,3 @@ numerator_1,numerator_2,denominator,output
 3,4,,
 ,6,14,
 2,5,2,5
-

--- a/integration_tests/models/sql/test_safe_divide.sql
+++ b/integration_tests/models/sql/test_safe_divide.sql
@@ -1,16 +1,16 @@
-
+ 
 with data_safe_divide as (
 
     select * from {{ ref('data_safe_divide') }}
 
 ),
 
-data_safe_divide_numerator_expressions (
+data_safe_divide_numerator_expressions as (
 
     select * from {{ ref('data_safe_divide_numerator_expressions') }}
 ),
 
-data_safe_divide_denominator_expressions (
+data_safe_divide_denominator_expressions as (
 
     select * from {{ ref('data_safe_divide_denominator_expressions') }}
 )
@@ -26,6 +26,7 @@ union all
 select 
     {{ dbt_utils.safe_divide('numerator_1 * numerator_2', 'denominator') }} as actual,
     output as expected
+
 from data_safe_divide_numerator_expressions
 
 union all
@@ -33,4 +34,5 @@ union all
 select 
     {{ dbt_utils.safe_divide('numerator', 'denominator_1 * denominator_2') }} as actual,
     output as expected
+
 from data_safe_divide_denominator_expressions

--- a/macros/generic_tests/cardinality_equality.sql
+++ b/macros/generic_tests/cardinality_equality.sql
@@ -26,7 +26,7 @@ group by {{ field }}
 except_a as (
   select *
   from table_a
-  {{ except() }}
+  {{ dbt.except() }}
   select *
   from table_b
 ),
@@ -34,7 +34,7 @@ except_a as (
 except_b as (
   select *
   from table_b
-  {{ except() }}
+  {{ dbt.except() }}
   select *
   from table_a
 ),

--- a/macros/generic_tests/equality.sql
+++ b/macros/generic_tests/equality.sql
@@ -49,7 +49,7 @@ b as (
 a_minus_b as (
 
     select {{compare_cols_csv}} from a
-    {{ except() }}
+    {{ dbt.except() }}
     select {{compare_cols_csv}} from b
 
 ),
@@ -57,7 +57,7 @@ a_minus_b as (
 b_minus_a as (
 
     select {{compare_cols_csv}} from b
-    {{ except() }}
+    {{ dbt.except() }}
     select {{compare_cols_csv}} from a
 
 ),

--- a/macros/generic_tests/recency.sql
+++ b/macros/generic_tests/recency.sql
@@ -4,7 +4,7 @@
 
 {% macro default__test_recency(model, field, datepart, interval, group_by_columns) %}
 
-{% set threshold = dateadd(datepart, interval * -1, current_timestamp()) %}
+{% set threshold = dbt.dateadd(datepart, interval * -1, current_timestamp()) %}
 {% if group_by_columns|length() > 0 %}
   {% set select_gb_cols = group_by_columns|join(' ,') + ', ' %}
   {% set groupby_gb_cols = 'group by ' + group_by_columns|join(',') %}

--- a/macros/generic_tests/sequential_values.sql
+++ b/macros/generic_tests/sequential_values.sql
@@ -30,7 +30,7 @@ validation_errors as (
         *
     from windowed
     {% if datepart %}
-    where not(cast({{ column_name }} as {{ type_timestamp() }})= cast({{ dateadd(datepart, interval, previous_column_name) }} as {{ type_timestamp() }}))
+    where not(cast({{ column_name }} as {{ dbt.type_timestamp() }})= cast({{ dbt.dateadd(datepart, interval, previous_column_name) }} as {{ dbt.type_timestamp() }}))
     {% else %}
     where not({{ column_name }} = {{ previous_column_name }} + {{ interval }})
     {% endif %}

--- a/macros/sql/date_spine.sql
+++ b/macros/sql/date_spine.sql
@@ -5,7 +5,7 @@
 {% macro default__get_intervals_between(start_date, end_date, datepart) -%}
     {%- call statement('get_intervals_between', fetch_result=True) %}
 
-        select {{ datediff(start_date, end_date, datepart) }}
+        select {{ dbt.datediff(start_date, end_date, datepart) }}
 
     {%- endcall -%}
 
@@ -35,7 +35,7 @@
 date_spine(
     "day",
     "to_date('01/01/2016', 'mm/dd/yyyy')",
-    "dateadd(week, 1, current_date)"
+    "dbt.dateadd(week, 1, current_date)"
 ) #}
 
 
@@ -51,7 +51,7 @@ all_periods as (
 
     select (
         {{
-            dateadd(
+            dbt.dateadd(
                 datepart,
                 "row_number() over (order by 1) - 1",
                 start_date

--- a/macros/sql/generate_surrogate_key.sql
+++ b/macros/sql/generate_surrogate_key.sql
@@ -15,7 +15,7 @@
 {%- for field in field_list -%}
 
     {%- do fields.append(
-        "coalesce(cast(" ~ field ~ " as " ~ type_string() ~ "), '" ~ default_null_value  ~"')"
+        "coalesce(cast(" ~ field ~ " as " ~ dbt.type_string() ~ "), '" ~ default_null_value  ~"')"
     ) -%}
 
     {%- if not loop.last %}
@@ -24,6 +24,6 @@
 
 {%- endfor -%}
 
-{{ hash(concat(fields)) }}
+{{ dbt.hash(dbt.concat(fields)) }}
 
 {%- endmacro -%}

--- a/macros/sql/pivot.sql
+++ b/macros/sql/pivot.sql
@@ -69,7 +69,7 @@ Arguments:
     {{ agg }}(
       {% if distinct %} distinct {% endif %}
       case
-      when {{ column }} {{ cmp }} '{{ escape_single_quotes(value) }}'
+      when {{ column }} {{ cmp }} '{{ dbt.escape_single_quotes(value) }}'
         then {{ then_value }}
       else {{ else_value }}
       end

--- a/macros/sql/union.sql
+++ b/macros/sql/union.sql
@@ -100,7 +100,7 @@
             select
 
                 {%- if source_column_name is not none %}
-                cast({{ string_literal(relation) }} as {{ type_string() }}) as {{ source_column_name }},
+                cast({{ dbt.string_literal(relation) }} as {{ dbt.type_string() }}) as {{ source_column_name }},
                 {%- endif %}
 
                 {% for col_name in ordered_column_names -%}

--- a/macros/sql/unpivot.sql
+++ b/macros/sql/unpivot.sql
@@ -48,9 +48,9 @@ Arguments:
         {{ exclude_col }},
       {%- endfor %}
 
-      cast('{{ col.column }}' as {{ type_string() }}) as {{ field_name }},
+      cast('{{ col.column }}' as {{ dbt.type_string() }}) as {{ field_name }},
       cast(  {% if col.data_type == 'boolean' %}
-           {{ cast_bool_to_text(col.column) }}
+           {{ dbt.cast_bool_to_text(col.column) }}
              {% else %}
            {{ col.column }}
              {% endif %}

--- a/macros/sql/width_bucket.sql
+++ b/macros/sql/width_bucket.sql
@@ -13,8 +13,8 @@
         case
             when
                 mod(
-                    {{ dbt.safe_cast(expr, type_numeric() ) }},
-                    {{ dbt.safe_cast(bin_size, type_numeric() ) }}
+                    {{ dbt.safe_cast(expr, dbt.type_numeric() ) }},
+                    {{ dbt.safe_cast(bin_size, dbt.type_numeric() ) }}
                 ) = 0
             then 1
             else 0
@@ -38,8 +38,8 @@
         -- to break ties when the amount is exactly at the bucket edge
         case
             when
-                {{ dbt.safe_cast(expr, type_numeric() ) }} %
-                {{ dbt.safe_cast(bin_size, type_numeric() ) }}
+                {{ dbt.safe_cast(expr, dbt.type_numeric() ) }} %
+                {{ dbt.safe_cast(bin_size, dbt.type_numeric() ) }}
                  = 0
             then 1
             else 0

--- a/macros/web/get_url_host.sql
+++ b/macros/web/get_url_host.sql
@@ -5,11 +5,11 @@
 {% macro default__get_url_host(field) -%}
 
 {%- set parsed =
-    split_part(
-        split_part(
-            replace(
-                replace(
-                    replace(field, "'android-app://'", "''"
+    dbt.split_part(
+        dbt.split_part(
+            dbt.replace(
+                dbt.replace(
+                    dbt.replace(field, "'android-app://'", "''"
                     ), "'http://'", "''"
                 ), "'https://'", "''"
             ), "'/'", 1
@@ -21,7 +21,7 @@
 
     {{ dbt.safe_cast(
         parsed,
-        type_string()
+        dbt.type_string()
         )}}
 
 {%- endmacro %}

--- a/macros/web/get_url_parameter.sql
+++ b/macros/web/get_url_parameter.sql
@@ -6,7 +6,7 @@
 
 {%- set formatted_url_parameter = "'" + url_parameter + "='" -%}
 
-{%- set split = split_part(split_part(field, formatted_url_parameter, 2), "'&'", 1) -%}
+{%- set split = dbt.split_part(dbt.split_part(field, formatted_url_parameter, 2), "'&'", 1) -%}
 
 nullif({{ split }},'')
 

--- a/macros/web/get_url_path.sql
+++ b/macros/web/get_url_path.sql
@@ -5,30 +5,30 @@
 {% macro default__get_url_path(field) -%}
 
     {%- set stripped_url =
-        replace(
-            replace(field, "'http://'", "''"), "'https://'", "''")
+        dbt.replace(
+            dbt.replace(field, "'http://'", "''"), "'https://'", "''")
     -%}
 
     {%- set first_slash_pos -%}
         coalesce(
-            nullif({{ position("'/'", stripped_url) }}, 0),
-            {{ position("'?'", stripped_url) }} - 1
+            nullif({{ dbt.position("'/'", stripped_url) }}, 0),
+            {{ dbt.position("'?'", stripped_url) }} - 1
             )
     {%- endset -%}
 
     {%- set parsed_path =
-        split_part(
-            right(
+        dbt.split_part(
+            dbt.right(
                 stripped_url,
-                length(stripped_url) ~ "-" ~ first_slash_pos
+                dbt.length(stripped_url) ~ "-" ~ first_slash_pos
                 ),
             "'?'", 1
             )
     -%}
 
-    {{ safe_cast(
+    {{ dbt.safe_cast(
         parsed_path,
-        type_string()
+        dbt.type_string()
     )}}
 
 {%- endmacro %}


### PR DESCRIPTION
resolves #690 

This is a:
- [ ] documentation update
- [x] bug fix with no breaking changes
- [ ] new functionality
- [ ] a breaking change

All pull requests from community contributors should target the `main` branch (default).

## Description & motivation

Adding dbt. prefix(namespace) to all the migrated cross database macros to solve the bug that caused unexpected behavior when a project already had a macro named the same as one of the migrated cross-db macros.

I did not touch the macro call in the test folders (they still call dbt_utils

## Checklist
- [x] This code is associated with an Issue which has been triaged and [accepted for development](https://docs.getdbt.com/docs/contributing/oss-expectations#pull-requests). 
- [ ] I have verified that these changes work locally on the following warehouses (Note: it's okay if you do not have access to all warehouses, this helps us understand what has been covered)
    - [ ] BigQuery
    - [x] Postgres
    - [ ] Redshift
    - [ ] Snowflake
- [ ] I followed guidelines to ensure that my changes will work on "non-core" adapters by:
    - [ ] dispatching any new macro(s) so non-core adapters can also use them (e.g. [the `star()` source](https://github.com/dbt-labs/dbt-utils/blob/main/macros/sql/star.sql))
    - [ ] using the `limit_zero()` macro in place of the literal string: `limit 0`
    - [x] using `dbt.type_*` macros instead of explicit datatypes (e.g. `dbt.type_timestamp()` instead of `TIMESTAMP`
- [ ] I have updated the README.md (if applicable)
- [ ] I have added tests & descriptions to my models (and macros if applicable)
- [x] I have added an entry to CHANGELOG.md
