### PR TITLE
fix syntax errors 

### DIFF
--- a/integration_tests/data/sql/data_safe_divide_numerator_expressions.csv
+++ b/integration_tests/data/sql/data_safe_divide_numerator_expressions.csv
@@ -5,4 +5,3 @@ numerator_1,numerator_2,denominator,output
 3,4,,
 ,6,14,
 2,5,2,5
-

--- a/integration_tests/models/sql/test_safe_divide.sql
+++ b/integration_tests/models/sql/test_safe_divide.sql
@@ -1,16 +1,16 @@
-
+ 
 with data_safe_divide as (
 
     select * from {{ ref('data_safe_divide') }}
 
 ),
 
-data_safe_divide_numerator_expressions (
+data_safe_divide_numerator_expressions as (
 
     select * from {{ ref('data_safe_divide_numerator_expressions') }}
 ),
 
-data_safe_divide_denominator_expressions (
+data_safe_divide_denominator_expressions as (
 
     select * from {{ ref('data_safe_divide_denominator_expressions') }}
 )
@@ -26,6 +26,7 @@ union all
 select 
     {{ dbt_utils.safe_divide('numerator_1 * numerator_2', 'denominator') }} as actual,
     output as expected
+
 from data_safe_divide_numerator_expressions
 
 union all
@@ -33,4 +34,5 @@ union all
 select 
     {{ dbt_utils.safe_divide('numerator', 'denominator_1 * denominator_2') }} as actual,
     output as expected
+
 from data_safe_divide_denominator_expressions


### PR DESCRIPTION
resolves safe_divide integration test errors

This is a:
- [ ] documentation update
- [x] bug fix with no breaking changes
- [ ] new functionality
- [ ] a breaking change

All pull requests from community contributors should target the `main` branch (default).

## Description & motivation
<!---
Fixed syntax errors in safe_divide_test file.
-->

## Checklist
- [ ] This code is associated with an Issue which has been triaged and [accepted for development](https://docs.getdbt.com/docs/contributing/oss-expectations#pull-requests). 
- [ ] I have verified that these changes work locally on the following warehouses (Note: it's okay if you do not have access to all warehouses, this helps us understand what has been covered)
    - [ ] BigQuery
    - [ ] Postgres
    - [ ] Redshift
    - [x] Snowflake
- [ ] I followed guidelines to ensure that my changes will work on "non-core" adapters by:
    - [ ] dispatching any new macro(s) so non-core adapters can also use them (e.g. [the `star()` source](https://github.com/dbt-labs/dbt-utils/blob/main/macros/sql/star.sql))
    - [ ] using the `limit_zero()` macro in place of the literal string: `limit 0`
    - [ ] using `dbt.type_*` macros instead of explicit datatypes (e.g. `dbt.type_timestamp()` instead of `TIMESTAMP`
- [ ] I have updated the README.md (if applicable)
- [ ] I have added tests & descriptions to my models (and macros if applicable)
- [ ] I have added an entry to CHANGELOG.md
