### PR TITLE
Slugify for snowflake

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 # Unreleased
 
 ## New features
+- Added Snowflake rules to the `slugify` macro to preserve column names beginning with a number.
 - Implemented an optional `group_by_columns` argument across many of the generic testing macros to test for properties that only pertain to group-level or are can be more rigorously conducted at the group level. Property available in `recency`, `at_least_one`, `equal_row_count`, `fewer_rows_than`, `not_constant`, `not_null_proportion`, and `sequential` tests [#633](https://github.com/dbt-labs/dbt-utils/pull/633)
 - New feature to omit the `source_column_name` column on the `union_relations` macro ([#331](https://github.com/dbt-labs/dbt-utils/issues/331), [#624](https://github.com/dbt-labs/dbt-utils/pull/624))
 - New feature to select fewer columns in `expression_is_true` ([#683](https://github.com/dbt-labs/dbt-utils/issues/683), [#686](https://github.com/dbt-labs/dbt-utils/pull/686))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,8 @@
 - Fix to utilize dbt Core version of `escape_single_quotes` instead of version from dbt Utils ([[#689](https://github.com/dbt-labs/dbt-utils/issues/689)], [#692](https://github.com/dbt-labs/dbt-utils/pull/692))
 
 ## Contributors:
+- [@fivetran-catfritz](https://github.com/fivetran-catfritz)
+- [@crowemi](https://github.com/crowemi)
 - [@christineberger](https://github.com/christineberger) (#624)
 - [@epapineau](https://github.com/epapineau) (#634)
 - [@courentin](https://github.com/courentin) (#651)

--- a/macros/jinja_helpers/slugify.sql
+++ b/macros/jinja_helpers/slugify.sql
@@ -1,4 +1,8 @@
 {% macro slugify(string) %}
+  {{ return(adapter.dispatch('slugify', 'dbt_utils')(string)) }}
+{% endmacro %}
+
+{% macro default__slugify(string) %}
 
 {#- Lower case the string -#}
 {% set string = string | lower %}
@@ -6,6 +10,22 @@
 {% set string = modules.re.sub('[ -]+', '_', string) %}
 {#- Only take letters, numbers, and underscores -#}
 {% set string = modules.re.sub('[^a-z0-9_]+', '', string) %}
+
+{{ return(string) }}
+
+{% endmacro %}
+
+{#- For Snowflake naming requirements -#}
+{% macro snowflake__slugify(string) %}
+
+{#- Lower case the string -#}
+{% set string = string | lower %}
+{#- Replace spaces and dashes with underscores -#}
+{% set string = modules.re.sub('[ -]+', '_', string) %}
+{#- Only take letters, numbers, and underscores -#}
+{% set string = modules.re.sub('[^a-z0-9_]+', '', string) %}
+{#- For Snowflake rules, will prepend "_" if col begins with a number -#}
+{% set string = modules.re.sub('^[0-9]', '_' + string[0], string) %}
 
 {{ return(string) }}
 


### PR DESCRIPTION
resolves #

This is a:
- [ ] documentation update
- [ ] bug fix with no breaking changes
- [x] new functionality
- [ ] a breaking change

All pull requests from community contributors should target the `main` branch (default).

## Description & motivation
<!---
Describe your changes, and why you're making them.
-->
Snowflake does not allow columns to begin with a number, so to preserve the number, the changes adds an underscore to the beginning of the string if the target is Snowflake. 

## Checklist
- [ ] This code is associated with an Issue which has been triaged and [accepted for development](https://docs.getdbt.com/docs/contributing/oss-expectations#pull-requests). 
- [x] I have verified that these changes work locally on the following warehouses (Note: it's okay if you do not have access to all warehouses, this helps us understand what has been covered)
    - [ ] BigQuery
    - [ ] Postgres
    - [ ] Redshift
    - [x] Snowflake
- [x] I followed guidelines to ensure that my changes will work on "non-core" adapters by:
    - [x] dispatching any new macro(s) so non-core adapters can also use them (e.g. [the `star()` source](https://github.com/dbt-labs/dbt-utils/blob/main/macros/sql/star.sql))
    - [x] using the `limit_zero()` macro in place of the literal string: `limit 0`
    - [x] using `dbt.type_*` macros instead of explicit datatypes (e.g. `dbt.type_timestamp()` instead of `TIMESTAMP`
- [ ] I have updated the README.md (if applicable)
- [ ] I have added tests & descriptions to my models (and macros if applicable)
- [x] I have added an entry to CHANGELOG.md

Cc: @crowemi thanks so much for collaborating with us on this. I would love to have your feedback!