### PR TITLE
Fix: Verb conj and macro descs

### DIFF
--- a/README.md
+++ b/README.md
@@ -910,7 +910,7 @@ Optionally takes a `unit` string argument ('km' or 'mi') which defaults to miles
 
 #### group_by ([source](macros/sql/groupby.sql))
 
-This macro build a group by statement for fields 1...N
+This macro builds a group by statement for fields 1...N
 
 **Usage:**
 
@@ -1006,7 +1006,7 @@ This macro implements a cross-database mechanism to generate an arbitrarily long
 
 #### surrogate_key ([source](macros/sql/surrogate_key.sql))
 
-Implements a cross-database way to generate a hashed surrogate key using the fields specified.
+This macro implements a cross-database way to generate a hashed surrogate key using the fields specified.
 
 **Usage:**
 
@@ -1016,7 +1016,7 @@ Implements a cross-database way to generate a hashed surrogate key using the fie
 
 #### safe_add ([source](macros/sql/safe_add.sql))
 
-Implements a cross-database way to sum nullable fields using the fields specified.
+This macro implements a cross-database way to sum nullable fields using the fields specified.
 
 **Usage:**
 


### PR DESCRIPTION
I was doing some studying on these and spotted some stuff. One verb conjugation and a consistency in macro description

resolves #

This is a:
- [x] documentation update
- [ ] bug fix with no breaking changes
- [ ] new functionality
- [ ] a breaking change

All pull requests from community contributors should target the `main` branch (default).

## Description & motivation
<!---
Describe your changes, and why you're making them.
-->
I was studying the macros for my own development and spotted a typo and a macro description inconsistency we could fix. 

## Checklist
- [ ] This code is associated with an Issue which has been triaged and [accepted for development](https://docs.getdbt.com/docs/contributing/oss-expectations#pull-requests). 
- [ ] I have verified that these changes work locally on the following warehouses (Note: it's okay if you do not have access to all warehouses, this helps us understand what has been covered)
    - [ ] BigQuery
    - [ ] Postgres
    - [ ] Redshift
    - [ ] Snowflake
- [ ] I followed guidelines to ensure that my changes will work on "non-core" adapters by:
    - [ ] dispatching any new macro(s) so non-core adapters can also use them (e.g. [the `star()` source](https://github.com/dbt-labs/dbt-utils/blob/main/macros/sql/star.sql))
    - [ ] using the `limit_zero()` macro in place of the literal string: `limit 0`
    - [ ] using `dbt.type_*` macros instead of explicit datatypes (e.g. `dbt.type_timestamp()` instead of `TIMESTAMP`
- [x] I have updated the README.md (if applicable)
- [ ] I have added tests & descriptions to my models (and macros if applicable)
- [ ] I have added an entry to CHANGELOG.md
