### PR TITLE
Output a warning when star finds no columns, not '*'

### DIFF
--- a/integration_tests/models/sql/schema.yml
+++ b/integration_tests/models/sql/schema.yml
@@ -180,7 +180,7 @@ models:
 
   - name: test_star_no_columns
     columns: 
-      - name: outcome_msg #don't want to check for the specific error message, but do want to check that the error column is there
+      - name: canary_column #If the no-columns state isn't hit, this table won't be queryable because there will be a missing comma
         tests: 
           - not_null
 

--- a/integration_tests/models/sql/schema.yml
+++ b/integration_tests/models/sql/schema.yml
@@ -178,6 +178,12 @@ models:
       - dbt_utils.equality:
           compare_model: ref('data_star_expected')
 
+  - name: test_star_no_columns
+    columns: 
+      - name: outcome_msg #don't want to check for the specific error message, but do want to check that the error column is there
+        tests: 
+          - not_null
+
   - name: test_generate_surrogate_key
     tests:
       - assert_equal:

--- a/integration_tests/models/sql/test_star_no_columns.sql
+++ b/integration_tests/models/sql/test_star_no_columns.sql
@@ -2,7 +2,8 @@ with data as (
 
     select
         {{ dbt_utils.star(from=ref('data_star'), except=['field_1', 'field_2', 'field_3']) }}
-
+        -- if star() returns `*` or a list of columns, this query will fail because there's no comma between the columns
+        1 as canary_column
     from {{ ref('data_star') }}
 
 )

--- a/integration_tests/models/sql/test_star_no_columns.sql
+++ b/integration_tests/models/sql/test_star_no_columns.sql
@@ -1,0 +1,10 @@
+with data as (
+
+    select
+        {{ dbt_utils.star(from=ref('data_star'), except=['field_1', 'field_2', 'field_3']) }}
+
+    from {{ ref('data_star') }}
+
+)
+
+select * from data

--- a/macros/sql/star.sql
+++ b/macros/sql/star.sql
@@ -14,7 +14,7 @@
     {% set cols = dbt_utils.get_filtered_columns_in_relation(from, except) %}
 
     {%- if cols|length <= 0 -%}
-      {{- return('*') -}}
+      {{- return(dbt.string_literal("no columns returned from star() macro") ~ " as outcome_msg") -}}
     {%- else -%}
         {%- for col in cols %}
             {%- if relation_alias %}{{ relation_alias }}.{% else %}{%- endif -%}


### PR DESCRIPTION
resolves #681 

This is a:
- [ ] documentation update
- [ ] bug fix with no breaking changes
- [ ] new functionality
- [x] a breaking change

All pull requests from community contributors should target the `main` branch (default).

## Description & motivation
#561 solved a SQLFluff linting error where the `star()` macro returned an empty string if there were no columns found (either because the model doesn't exist or because all columns were excluded). 

The side effect of this is that if someone excludes all columns, they get `'*'` (every column) back instead, which is the exact opposite of what you'd expect. 

This change means that if no columns are found, it returns `'no columns returned from star() macro' as outcome_msg` instead. 

This is still valid SQL, so SQLFluff won't complain about it, but it better represents the outcome that got us here than a `*`. 

## Checklist
- [x] This code is associated with an Issue which has been triaged and [accepted for development](https://docs.getdbt.com/docs/contributing/oss-expectations#pull-requests). 
- [ ] I have verified that these changes work locally on the following warehouses (Note: it's okay if you do not have access to all warehouses, this helps us understand what has been covered)
    - [ ] BigQuery
    - [ ] Postgres
    - [ ] Redshift
    - [x] Snowflake
- [x] I followed guidelines to ensure that my changes will work on "non-core" adapters by:
    - [ ] dispatching any new macro(s) so non-core adapters can also use them (e.g. [the `star()` source](https://github.com/dbt-labs/dbt-utils/blob/main/macros/sql/star.sql))
    - [ ] using the `limit_zero()` macro in place of the literal string: `limit 0`
    - [ ] using `dbt.type_*` macros instead of explicit datatypes (e.g. `dbt.type_timestamp()` instead of `TIMESTAMP`
- [ ] I have updated the README.md (if applicable)
- [x] I have added tests & descriptions to my models (and macros if applicable)
- [ ] I have added an entry to CHANGELOG.md
