### PR TITLE
Removed remark about Dbt 0.9.6 as utils 1.0.0 is now the the default …

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,11 +6,6 @@ Check [dbt Hub](https://hub.getdbt.com/dbt-labs/dbt_utils/latest/) for the lates
 
 ----
 
-> **Note**
-> This readme reflects dbt utils 1.0, currently in release candidate status. The currently shipping version of dbt utils is [0.9.6](https://github.com/dbt-labs/dbt-utils/tree/0.9.6).
-
----
-
 ## Contents
 
 **[Generic tests](#generic-tests)**


### PR DESCRIPTION
…version

 in hub.getdbt.com/dbt-labs/dbt_utils/latest/ the lattest version in 1.0.0 so no need for the note

resolves #

This is a:
- [x] documentation update

## Description & motivation
<!---
Removed remark about Dbt 0.9.6 as utils 1.0.0 is now the the default …
-->

## Checklist
- [ ] This code is associated with an Issue which has been triaged and [accepted for development](https://docs.getdbt.com/docs/contributing/oss-expectations#pull-requests). 
- [x] I have verified that these changes work locally on the following warehouses (Note: it's okay if you do not have access to all warehouses, this helps us understand what has been covered)
    - [x] BigQuery
    - [x] Postgres
    - [x] Redshift
    - [x] Snowflake
- [x] I followed guidelines to ensure that my changes will work on "non-core" adapters by:
    - [x] dispatching any new macro(s) so non-core adapters can also use them (e.g. [the `star()` source](https://github.com/dbt-labs/dbt-utils/blob/main/macros/sql/star.sql))
    - [x] using the `limit_zero()` macro in place of the literal string: `limit 0`
    - [x] using `dbt.type_*` macros instead of explicit datatypes (e.g. `dbt.type_timestamp()` instead of `TIMESTAMP`
- [x] I have updated the README.md (if applicable)
- [x] I have added tests & descriptions to my models (and macros if applicable)
- [ ] I have added an entry to CHANGELOG.md
