### PR TITLE
Fixed fewer_rows_than and equal_rowcount macros

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,8 @@
-<!--- Copy, paste, and uncomment the following headers as-needed for unreleased features
 # Unreleased
-## New features
-- XXX ([#XXX](https://github.com/dbt-labs/dbt-utils/issues/XXX), [#XXX](https://github.com/dbt-labs/dbt-utils/pull/XXX))
 ## Fixes
-## Quality of life
-## Under the hood
-## Contributors:
---->
+- Fixed fewer_rows_than and equal_rowcount macros to work with warehouses which do not support lateral column aliasing ([#744](https://github.com/dbt-labs/dbt-utils/issues/744), [#746](https://github.com/dbt-labs/dbt-utils/pull/746))
+## Contributors: @damian3031
+
 
 # dbt utils v1.0
 

--- a/macros/generic_tests/equal_rowcount.sql
+++ b/macros/generic_tests/equal_rowcount.sql
@@ -26,7 +26,7 @@
 {#-- Redshift does not allow for dynamically created join conditions (e.g. full join on 1 = 1 --#}
 {#-- The same logic is used in fewer_rows_than. In case of changes, maintain consistent logic --#}
 {% set group_by_columns = ['id_dbtutils_test_equal_rowcount'] + group_by_columns %}
-{% set groupby_gb_cols = 'group by ' + group_by_columns|join(',') %}
+{% set groupby_gb_cols = dbt_utils.group_by(group_by_columns|length) %}
 
 with a as (
 

--- a/macros/generic_tests/fewer_rows_than.sql
+++ b/macros/generic_tests/fewer_rows_than.sql
@@ -20,7 +20,7 @@
 {#-- Redshift does not allow for dynamically created join conditions (e.g. full join on 1 = 1 --#}
 {#-- The same logic is used in equal_rowcount. In case of changes, maintain consistent logic --#}
 {% set group_by_columns = ['id_dbtutils_test_fewer_rows_than'] + group_by_columns %}
-{% set groupby_gb_cols = 'group by ' + group_by_columns|join(',') %}
+{% set groupby_gb_cols = dbt_utils.group_by(group_by_columns|length) %}
 
 
 with a as (


### PR DESCRIPTION
Fixed `fewer_rows_than` and `equal_rowcount` macros to work with warehouses which do not support lateral column aliasing

resolves #744 

This is a:
- bug fix with no breaking changes

## Checklist
- [x] I have verified that these changes work locally on the following warehouses:
    - Trino
- [x] I have added an entry to CHANGELOG.md
