### PR TITLE
Safe subtract

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ Check [dbt Hub](https://hub.getdbt.com/dbt-labs/dbt_utils/latest/) for the lates
   - [generate_surrogate_key](#generate_surrogate_key-source)
   - [safe_add](#safe_add-source)
   - [safe_divide](#safe_divide-source)
+  - [safe_subtract](#safe_subtract-source)
   - [pivot](#pivot-source)
   - [unpivot](#unpivot-source)
   - [width_bucket](#width_bucket-source)
@@ -1069,6 +1070,16 @@ This macro performs division but returns null if the denominator is 0.
 
 ```
 {{ dbt_utils.safe_divide('numerator', 'denominator') }}
+```
+
+#### safe_subtract ([source](macros/sql/safe_subtract.sql))
+
+This macro implements a cross-database way to take the difference of nullable fields using the fields specified.
+
+**Usage:**
+
+```
+{{ dbt_utils.safe_subtract('field_a', 'field_b'[,...]) }}
 ```
 
 #### pivot ([source](macros/sql/pivot.sql))

--- a/README.md
+++ b/README.md
@@ -1054,7 +1054,7 @@ This macro implements a cross-database way to sum nullable fields using the fiel
 **Usage:**
 
 ```
-{{ dbt_utils.safe_add('field_a', 'field_b'[,...]) }}
+{{ dbt_utils.safe_add(['field_a', 'field_b', ...]) }}
 ```
 
 #### safe_divide ([source](macros/cross_db_utils/safe_divide.sql))
@@ -1079,7 +1079,7 @@ This macro implements a cross-database way to take the difference of nullable fi
 **Usage:**
 
 ```
-{{ dbt_utils.safe_subtract('field_a', 'field_b'[,...]) }}
+{{ dbt_utils.safe_subtract(['field_a', 'field_b', ...]) }}
 ```
 
 #### pivot ([source](macros/sql/pivot.sql))

--- a/integration_tests/data/sql/data_safe_subtract.csv
+++ b/integration_tests/data/sql/data_safe_subtract.csv
@@ -1,0 +1,5 @@
+field_1,field_2,field_3,expected
+3,2,1,0
+4,,3,1
+,,2,-2
+,,,0

--- a/integration_tests/models/sql/schema.yml
+++ b/integration_tests/models/sql/schema.yml
@@ -120,6 +120,12 @@ models:
       - assert_equal:
           actual: actual
           expected: expected
+  
+  - name: test_safe_subtract
+    tests:
+      - assert_equal:
+          actual: actual
+          expected: expected
 
   - name: test_safe_divide
     tests:

--- a/integration_tests/models/sql/test_safe_subtract.sql
+++ b/integration_tests/models/sql/test_safe_subtract.sql
@@ -1,0 +1,12 @@
+
+with data as (
+
+    select * from {{ ref('data_safe_subtract') }}
+
+)
+
+select
+    {{ dbt_utils.safe_subtract(['field_1', 'field_2', 'field_3']) }} as actual,
+    expected
+
+from data

--- a/macros/sql/safe_subtract.sql
+++ b/macros/sql/safe_subtract.sql
@@ -1,0 +1,28 @@
+{%- macro safe_subtract(field_list) -%}
+    {{ return(adapter.dispatch('safe_subtract', 'dbt_utils')(field_list)) }}
+{% endmacro %}
+
+{%- macro default__safe_subtract(field_list) -%}
+
+{%- if field_list is not iterable or field_list is string or field_list is mapping -%}
+
+{%- set error_message = '
+Warning: the `safe_subtract` macro now takes a single list argument instead of \
+string arguments. The {}.{} model triggered this warning. \
+'.format(model.package_name, model.name) -%}
+
+{%- do exceptions.warn(error_message) -%}
+
+{%- endif -%}
+
+{% set fields = [] %}
+
+{%- for field in field_list -%}
+
+    {% do fields.append("coalesce(" ~ field ~ ", 0)") %}
+
+{%- endfor -%}
+
+{{ fields|join(' -\n  ') }}
+
+{%- endmacro -%}

--- a/macros/sql/safe_subtract.sql
+++ b/macros/sql/safe_subtract.sql
@@ -7,11 +7,11 @@
 {%- if field_list is not iterable or field_list is string or field_list is mapping -%}
 
 {%- set error_message = '
-Warning: the `safe_subtract` macro now takes a single list argument instead of \
+Warning: the `safe_subtract` macro takes a single list argument instead of \
 string arguments. The {}.{} model triggered this warning. \
 '.format(model.package_name, model.name) -%}
 
-{%- do exceptions.warn(error_message) -%}
+{%- do exceptions.raise_compiler_error(error_message) -%}
 
 {%- endif -%}
 


### PR DESCRIPTION
resolves #745

This is a:
- [ ] documentation update
- [ ] bug fix with no breaking changes
- [x] new functionality
- [ ] a breaking change

All pull requests from community contributors should target the `main` branch (default).

## Description & motivation
As discussed in #745, this new macro will provide a method for taking the difference across nullable fields similar in functionality to `safe_add()`. Currently it is necessary to multiply fields by -1 with the `safe_add()` macro or use coalesce statements in sql directly to achieve the same result.

## Checklist
- [x] This code is associated with an Issue which has been triaged and [accepted for development](https://docs.getdbt.com/docs/contributing/oss-expectations#pull-requests). 
- [x] I have verified that these changes work locally on the following warehouses (Note: it's okay if you do not have access to all warehouses, this helps us understand what has been covered)
    - [ ] BigQuery
    - [x] Postgres
    - [ ] Redshift
    - [ ] Snowflake
- [x] I followed guidelines to ensure that my changes will work on "non-core" adapters by:
    - [x] dispatching any new macro(s) so non-core adapters can also use them (e.g. [the `star()` source](https://github.com/dbt-labs/dbt-utils/blob/main/macros/sql/star.sql))
    - [ ] using the `limit_zero()` macro in place of the literal string: `limit 0`
    - [ ] using `dbt.type_*` macros instead of explicit datatypes (e.g. `dbt.type_timestamp()` instead of `TIMESTAMP`
- [x] I have updated the README.md (if applicable)
- [x] I have added tests & descriptions to my models (and macros if applicable)
- [ ] I have added an entry to CHANGELOG.md
