### PR TITLE
get redshift external tables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,16 @@
 ## Contributors:
 --->
 
+# Unreleased
+## Fixes
+- get_tables_by_pattern_sql will now:
+  - return redshift external tables ([#752](https://github.com/dbt-labs/dbt-utils/issues/752)
+  - work with valid redshift database names that contain dashes
+## Under the hood
+- created a new dispatch redshift__get_tables_by_pattern which unions the result of the default macro
+and querying svv_external_tables for the same conditions (schema name, pattern, exclude pattern).
+## Contributors: [@brendan-cook-87](https://github.com/brendan-cook-87)
+
 # dbt utils v1.0
 
 ## Migration Guide 

--- a/macros/sql/get_tables_by_pattern_sql.sql
+++ b/macros/sql/get_tables_by_pattern_sql.sql
@@ -9,7 +9,7 @@
             table_schema as {{ adapter.quote('table_schema') }},
             table_name as {{ adapter.quote('table_name') }},
             {{ dbt_utils.get_table_types_sql() }}
-        from "{{ database }}"."information_schema"."tables"
+        from {{ database }}.information_schema.tables
         where table_schema ilike '{{ schema_pattern }}'
         and table_name ilike '{{ table_pattern }}'
         and table_name not ilike '{{ exclude }}'
@@ -19,7 +19,14 @@
 {% macro redshift__get_tables_by_pattern_sql(schema_pattern, table_pattern, exclude='', database=target.database) %}
 
     {% set sql %}
-        {{ dbt_utils.default__get_tables_by_pattern_sql(schema_pattern, table_pattern, exclude, database) }}
+        select distinct
+            table_schema as {{ adapter.quote('table_schema') }},
+            table_name as {{ adapter.quote('table_name') }},
+            {{ dbt_utils.get_table_types_sql() }}
+        from "{{ database }}"."information_schema"."tables"
+        where table_schema ilike '{{ schema_pattern }}'
+        and table_name ilike '{{ table_pattern }}'
+        and table_name not ilike '{{ exclude }}'
         union all
         select distinct
             schemaname as {{ adapter.quote('table_schema') }},


### PR DESCRIPTION
redshift external tables are not listed in information_schema.tables  but we can extract the same info from svv_external tables and union the results. also quote database name as redshift allows dashes which require quotes

resolves #752 

This is a:
- [ ] documentation update
- [x] bug fix with no breaking changes
- [ ] new functionality
- [ ] a breaking change

All pull requests from community contributors should target the `main` branch (default).

## Description & motivation
external tables in redshift are not listed in information_schema.tables
they are listed in svv_external_tables

so that this macro works as expected (lists all tables in the specified schema, whether external or not)
there is a new dispatch for redshift__get_tables_by_pattern_sql which calls the default macro
and unions the result with the same information (with the same pattern matching) from svv_external_tables.

redshift also allows dashes in database names, which the macro does not quote, so can generate invalid sql.

## Checklist
- [x] This code is associated with an Issue which has been triaged and [accepted for development](https://docs.getdbt.com/docs/contributing/oss-expectations#pull-requests). 
- [ ] I have verified that these changes work locally on the following warehouses (Note: it's okay if you do not have access to all warehouses, this helps us understand what has been covered)
    - [ ] BigQuery
    - [ ] Postgres
    - [x] Redshift
    - [ ] Snowflake
- [x] I followed guidelines to ensure that my changes will work on "non-core" adapters by:
    - [x] dispatching any new macro(s) so non-core adapters can also use them (e.g. [the `star()` source](https://github.com/dbt-labs/dbt-utils/blob/main/macros/sql/star.sql))
    - [x] using the `limit_zero()` macro in place of the literal string: `limit 0`
    - [x] using `dbt.type_*` macros instead of explicit datatypes (e.g. `dbt.type_timestamp()` instead of `TIMESTAMP`
- [] I have updated the README.md (if applicable)
- [x] I have added tests & descriptions to my models (and macros if applicable)
- [x] I have added an entry to CHANGELOG.md
