### PR TITLE
[DOCS] Add missing entry in the summary of README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Check [dbt Hub](https://hub.getdbt.com/dbt-labs/dbt_utils/latest/) for the lates
   - [not_accepted_values](#not_accepted_values-source)
   - [relationships_where](#relationships_where-source)
   - [mutually_exclusive_ranges](#mutually_exclusive_ranges-source)
+  - [sequential_values](#sequential_values-source)
   - [unique_combination_of_columns](#unique_combination_of_columns-source)
   - [accepted_range](#accepted_range-source)
 


### PR DESCRIPTION
Missing sequential_values generic test entry in the top summary.

This is a:
- [X] documentation update
- [ ] bug fix with no breaking changes
- [ ] new functionality
- [ ] a breaking change

## Description & motivation
Just fixing the README summary. I almost missed the test was already implemented because it was not there.

## Checklist
- [ ] This code is associated with an Issue which has been triaged and [accepted for development](https://docs.getdbt.com/docs/contributing/oss-expectations#pull-requests). 
- [ ] I have verified that these changes work locally on the following warehouses (Note: it's okay if you do not have access to all warehouses, this helps us understand what has been covered)
    - [ ] BigQuery
    - [ ] Postgres
    - [ ] Redshift
    - [ ] Snowflake
- [ ] I followed guidelines to ensure that my changes will work on "non-core" adapters by:
    - [ ] dispatching any new macro(s) so non-core adapters can also use them (e.g. [the `star()` source](https://github.com/dbt-labs/dbt-utils/blob/main/macros/sql/star.sql))
    - [ ] using the `limit_zero()` macro in place of the literal string: `limit 0`
    - [ ] using `dbt.type_*` macros instead of explicit datatypes (e.g. `dbt.type_timestamp()` instead of `TIMESTAMP`
- [X] I have updated the README.md (if applicable)
- [ ] I have added tests & descriptions to my models (and macros if applicable)
- [ ] I have added an entry to CHANGELOG.md
