### PR TITLE
Add Databricks handler for get_table_types_sql.sql

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 # Unreleased
 ## Fixes
-- get_relations_by_pattern for Databricks connection with Unity catalog #768 ([#768](https://github.com/dbt-labs/dbt-utils/issues/768), [#XXX](https://github.com/dbt-labs/dbt-utils/pull/XXX))
+- get_relations_by_pattern for Databricks connection with Unity catalog #768 ([#768](https://github.com/dbt-labs/dbt-utils/issues/768), [#769](https://github.com/dbt-labs/dbt-utils/pull/769))
 
 ## Contributors:
 @Harmuth94, [#768](https://github.com/dbt-labs/dbt-utils/issues/768)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@
 ## Contributors:
 --->
 
+# Unreleased
+## Fixes
+- get_relations_by_pattern for Databricks connection with Unity catalog #768 ([#768](https://github.com/dbt-labs/dbt-utils/issues/768), [#XXX](https://github.com/dbt-labs/dbt-utils/pull/XXX))
+
+## Contributors:
+@Harmuth94, [#768](https://github.com/dbt-labs/dbt-utils/issues/768)
+
+
 # dbt utils v1.0
 
 ## Migration Guide 

--- a/macros/sql/get_table_types_sql.sql
+++ b/macros/sql/get_table_types_sql.sql
@@ -20,3 +20,13 @@
                 else lower(table_type)
             end as {{ adapter.quote('table_type') }}
 {% endmacro %}
+
+
+{% macro databricks__get_table_types_sql() %}
+            case table_type
+                when 'MANAGED' then 'table'
+                when 'BASE TABLE' then 'table'
+                when 'MATERIALIZED VIEW' then 'materializedview'
+                else lower(table_type)
+            end as {{ adapter.quote('table_type') }}
+{% endmacro %}


### PR DESCRIPTION
resolves [#768](https://github.com/dbt-labs/dbt-utils/issues/768)

This is a:
- [ ] documentation update
- [x] bug fix with no breaking changes
- [ ] new functionality
- [ ] a breaking change

All pull requests from community contributors should target the `main` branch (default).

## Description & motivation
`get_relations_by_pattern` throws an error when using the databricks adapter on schemas in a Unity catalog. The error comes from the table having the `table_type` `MANAGED` in the `information_schema.tables` table.
Adding a handler for databricks allows the macro to as expected with data in a Unity catalog.

## Checklist
- [ ] This code is associated with an Issue which has been triaged and [accepted for development](https://docs.getdbt.com/docs/contributing/oss-expectations#pull-requests). 
- [x] I have verified that these changes work locally on the following warehouses (Note: it's okay if you do not have access to all warehouses, this helps us understand what has been covered)
    - [ ] BigQuery
    - [ ] Postgres
    - [ ] Redshift
    - [ ] Snowflake
    - [x] Databricks
- [x] I followed guidelines to ensure that my changes will work on "non-core" adapters by:
    - [x] dispatching any new macro(s) so non-core adapters can also use them (e.g. [the `star()` source](https://github.com/dbt-labs/dbt-utils/blob/main/macros/sql/star.sql))
    - [ ] using the `limit_zero()` macro in place of the literal string: `limit 0`
    - [ ] using `dbt.type_*` macros instead of explicit datatypes (e.g. `dbt.type_timestamp()` instead of `TIMESTAMP`
- [ ] I have updated the README.md (if applicable)
- [ ] I have added tests & descriptions to my models (and macros if applicable)
- [x] I have added an entry to CHANGELOG.md
