### PR TITLE
Handle empty strings in slugify macro

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,10 +11,11 @@
 # Unreleased
 ## Fixes
 - get_relations_by_pattern for Databricks connection with Unity catalog #768 ([#768](https://github.com/dbt-labs/dbt-utils/issues/768), [#769](https://github.com/dbt-labs/dbt-utils/pull/769))
+- Handle empty strings in slugify macro #773 ([#773](https://github.com/dbt-labs/dbt-utils/issues/773), [#XXX](https://github.com/dbt-labs/dbt-utils/pull/XXX))
 
 ## Contributors:
 @Harmuth94, [#768](https://github.com/dbt-labs/dbt-utils/issues/768)
-
+@atvaccaro, [#773](https://github.com/dbt-labs/dbt-utils/issues/773)
 
 # dbt utils v1.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@
 # Unreleased
 ## Fixes
 - get_relations_by_pattern for Databricks connection with Unity catalog #768 ([#768](https://github.com/dbt-labs/dbt-utils/issues/768), [#769](https://github.com/dbt-labs/dbt-utils/pull/769))
-- Handle empty strings in slugify macro #773 ([#773](https://github.com/dbt-labs/dbt-utils/issues/773), [#XXX](https://github.com/dbt-labs/dbt-utils/pull/XXX))
+- Handle empty strings in slugify macro #773 ([#773](https://github.com/dbt-labs/dbt-utils/issues/773), [#774](https://github.com/dbt-labs/dbt-utils/pull/774))
 
 ## Contributors:
 @Harmuth94, [#768](https://github.com/dbt-labs/dbt-utils/issues/768)

--- a/integration_tests/tests/jinja_helpers/test_slugify.sql
+++ b/integration_tests/tests/jinja_helpers/test_slugify.sql
@@ -1,6 +1,8 @@
 with comparisons as (
   select '{{ dbt_utils.slugify("") }}' as output, '' as expected
   union all
+  select '{{ dbt_utils.slugify(None) }}' as output, '' as expected
+  union all
   select '{{ dbt_utils.slugify("!Hell0 world-hi") }}' as output, 'hell0_world_hi' as expected
   union all
   select '{{ dbt_utils.slugify("0Hell0 world-hi") }}' as output, '_0hell0_world_hi' as expected

--- a/integration_tests/tests/jinja_helpers/test_slugify.sql
+++ b/integration_tests/tests/jinja_helpers/test_slugify.sql
@@ -1,4 +1,5 @@
 with comparisons as (
+  select '{{ dbt_utils.slugify("") }}' as output, '' as expected
   select '{{ dbt_utils.slugify("!Hell0 world-hi") }}' as output, 'hell0_world_hi' as expected
   union all
   select '{{ dbt_utils.slugify("0Hell0 world-hi") }}' as output, '_0hell0_world_hi' as expected

--- a/integration_tests/tests/jinja_helpers/test_slugify.sql
+++ b/integration_tests/tests/jinja_helpers/test_slugify.sql
@@ -1,5 +1,6 @@
 with comparisons as (
   select '{{ dbt_utils.slugify("") }}' as output, '' as expected
+  union all
   select '{{ dbt_utils.slugify("!Hell0 world-hi") }}' as output, 'hell0_world_hi' as expected
   union all
   select '{{ dbt_utils.slugify("0Hell0 world-hi") }}' as output, '_0hell0_world_hi' as expected

--- a/macros/jinja_helpers/slugify.sql
+++ b/macros/jinja_helpers/slugify.sql
@@ -1,7 +1,7 @@
 {% macro slugify(string) %}
 
 {% if not string %}
-{{ return(string) }}
+{{ return('') }}
 {% endif %}
 
 {#- Lower case the string -#}

--- a/macros/jinja_helpers/slugify.sql
+++ b/macros/jinja_helpers/slugify.sql
@@ -1,5 +1,9 @@
 {% macro slugify(string) %}
 
+{% if not string %}
+{{ return(string) }}
+{% endif %}
+
 {#- Lower case the string -#}
 {% set string = string | lower %}
 {#- Replace spaces and dashes with underscores -#}


### PR DESCRIPTION
resolves #773

This is a:
- [ ] documentation update
- [x] bug fix with no breaking changes
- [ ] new functionality
- [ ] a breaking change

All pull requests from community contributors should target the `main` branch (default).

## Description & motivation
As of the 1.0 release, slugify now [prepends an underscore](https://github.com/dbt-labs/dbt-utils/pull/707) in the case of leading numbers. This throws an exception if the string is empty, but we can just return falsy strings without any modification.

Another option would be using a capture group or positive lookahead.

## Checklist
- [x] This code is associated with an Issue which has been triaged and [accepted for development](https://docs.getdbt.com/docs/contributing/oss-expectations#pull-requests). 
- [x] I have verified that these changes work locally on the following warehouses (Note: it's okay if you do not have access to all warehouses, this helps us understand what has been covered)
    - [x] BigQuery
    - [ ] Postgres
    - [ ] Redshift
    - [ ] Snowflake
- [x] I followed guidelines to ensure that my changes will work on "non-core" adapters by:
    - [ ] dispatching any new macro(s) so non-core adapters can also use them (e.g. [the `star()` source](https://github.com/dbt-labs/dbt-utils/blob/main/macros/sql/star.sql))
    - [ ] using the `limit_zero()` macro in place of the literal string: `limit 0`
    - [ ] using `dbt.type_*` macros instead of explicit datatypes (e.g. `dbt.type_timestamp()` instead of `TIMESTAMP`
- [ ] I have updated the README.md (if applicable)
- [x] I have added tests & descriptions to my models (and macros if applicable)
- [x] I have added an entry to CHANGELOG.md
