### PR TITLE
Improve the performance of the at_least_one test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,12 +14,13 @@
 
 ## Contributors:
 @Harmuth94, [#768](https://github.com/dbt-labs/dbt-utils/issues/768)
+@joshuahuntley, [#775](https://github.com/dbt-labs/dbt-utils/issues/775)
 
 
 # dbt utils v1.0
 
-## Migration Guide 
-The full migration guide is at https://docs.getdbt.com/guides/migration/versions/upgrading-to-dbt-utils-v1.0 
+## Migration Guide
+The full migration guide is at https://docs.getdbt.com/guides/migration/versions/upgrading-to-dbt-utils-v1.0
 
 ## New features
 - New macro `get_single_value` ([#696](https://github.com/dbt-labs/dbt-utils/pull/696))
@@ -29,11 +30,12 @@ The full migration guide is at https://docs.getdbt.com/guides/migration/versions
 ## Enhancements
 - Implemented an optional `group_by_columns` argument across many of the generic testing macros to test for properties that only pertain to group-level or are can be more rigorously conducted at the group level. Property available in `recency`, `at_least_one`, `equal_row_count`, `fewer_rows_than`, `not_constant`, `not_null_proportion`, and `sequential` tests [#633](https://github.com/dbt-labs/dbt-utils/pull/633)
 - With the addition of an on-by-default quote_identifiers flag in the star() macro, you can now disable quoting if necessary. ([#706](https://github.com/dbt-labs/dbt-utils/pull/706))
+- Improve the performance of the `at_least_one` test by pruning early. This is especially helpful when running against external tables.([#775](https://github.com/dbt-labs/dbt-utils/pull/775))
 
 ## Fixes
 - `union()` now includes/excludes columns case-insensitively
 - The `expression_is_true test` doesn’t output * unless storing failures, a cost improvement for BigQuery ([#683](https://github.com/dbt-labs/dbt-utils/issues/683), [#686](https://github.com/dbt-labs/dbt-utils/pull/686))
-- Updated the `slugify` macro to prepend "_" to column names beginning with a number since most databases do not allow names to begin with numbers. 
+- Updated the `slugify` macro to prepend "_" to column names beginning with a number since most databases do not allow names to begin with numbers.
 
 ## Under the hood
 - Remove deprecated table argument from `unpivot` ([#671](https://github.com/dbt-labs/dbt-utils/pull/671))
@@ -54,6 +56,7 @@ The full migration guide is at https://docs.getdbt.com/guides/migration/versions
 - [@zachoj10](https://github.com/zachoj10) (#692)
 - [@miles170](https://github.com/miles170)
 - [@emilyriederer](https://github.com/emilyriederer)
+- [@joshuahuntley](https://github.com/JoshuaHuntley)
 # 0.9.5
 ## Fixes
 - Stop showing cross-db deprecation warnings for macros who have already been migrated ([#725](https://github.com/dbt-labs/dbt-utils/pull/725))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,14 +10,41 @@
 
 # Unreleased
 ## New features
-* ZZZ by @YYY in https://github.com/dbt-labs/dbt-utils/pull/XXX
+* Improve the performance of the `at_least_one` test by pruning early. This is especially helpful when running against external tables. By @joshuahuntley in https://github.com/dbt-labs/dbt-utils/pull/775
 ## Fixes
 * Fix legacy links in README by @dbeatty10 in https://github.com/dbt-labs/dbt-utils/pull/796
 ## Quality of life
 ## Under the hood
 ## Contributors:
-@Harmuth94, [#768](https://github.com/dbt-labs/dbt-utils/issues/768)
-@joshuahuntley, [#775](https://github.com/dbt-labs/dbt-utils/issues/775)
+
+# dbt utils v1.1.0
+## What's Changed
+### New functionality
+* Safe subtract by @dchess in https://github.com/dbt-labs/dbt-utils/pull/748
+* Add Databricks handler for get_table_types_sql.sql by @Harmuth94 in https://github.com/dbt-labs/dbt-utils/pull/769
+
+### Documentation
+* Typo fix by @AndrewLane in https://github.com/dbt-labs/dbt-utils/pull/738
+* Removed remark about Dbt 0.9.6 as utils 1.0.0 is now the the default by @ilanbenb in https://github.com/dbt-labs/dbt-utils/pull/740
+* Fix link in README by @b-per in https://github.com/dbt-labs/dbt-utils/pull/743
+* Update README.md about use `where` with `accepted_range` tests by @eitsupi in https://github.com/dbt-labs/dbt-utils/pull/739
+* doc: clarify that `union_relations()` uses `union all` by @owenprough-sift in https://github.com/dbt-labs/dbt-utils/pull/760
+* Automatically generate TOC for utils readme by @joellabes in https://github.com/dbt-labs/dbt-utils/pull/486
+
+### Behind the scenes
+* Use CircleCI contexts for environment variables by @dbeatty10 in https://github.com/dbt-labs/dbt-utils/pull/754
+* fix: #755 - add whitespace control to generate_surrogate_key macro by @akv-akv in https://github.com/dbt-labs/dbt-utils/pull/756
+* Fix CI by @joellabes in https://github.com/dbt-labs/dbt-utils/pull/771
+
+## New Contributors
+* @AndrewLane made their first contribution in https://github.com/dbt-labs/dbt-utils/pull/738
+* @ilanbenb made their first contribution in https://github.com/dbt-labs/dbt-utils/pull/740
+* @eitsupi made their first contribution in https://github.com/dbt-labs/dbt-utils/pull/739
+* @owenprough-sift made their first contribution in https://github.com/dbt-labs/dbt-utils/pull/760
+* @akv-akv made their first contribution in https://github.com/dbt-labs/dbt-utils/pull/756
+* @dchess made their first contribution in https://github.com/dbt-labs/dbt-utils/pull/748
+* @Harmuth94 made their first contribution in https://github.com/dbt-labs/dbt-utils/pull/769
+
 
 # dbt utils v1.0
 
@@ -32,7 +59,6 @@ The full migration guide is at https://docs.getdbt.com/guides/migration/versions
 ## Enhancements
 - Implemented an optional `group_by_columns` argument across many of the generic testing macros to test for properties that only pertain to group-level or are can be more rigorously conducted at the group level. Property available in `recency`, `at_least_one`, `equal_row_count`, `fewer_rows_than`, `not_constant`, `not_null_proportion`, and `sequential` tests [#633](https://github.com/dbt-labs/dbt-utils/pull/633)
 - With the addition of an on-by-default quote_identifiers flag in the star() macro, you can now disable quoting if necessary. ([#706](https://github.com/dbt-labs/dbt-utils/pull/706))
-- Improve the performance of the `at_least_one` test by pruning early. This is especially helpful when running against external tables.([#775](https://github.com/dbt-labs/dbt-utils/pull/775))
 
 ## Fixes
 - `union()` now includes/excludes columns case-insensitively
@@ -58,7 +84,6 @@ The full migration guide is at https://docs.getdbt.com/guides/migration/versions
 - [@zachoj10](https://github.com/zachoj10) (#692)
 - [@miles170](https://github.com/miles170)
 - [@emilyriederer](https://github.com/emilyriederer)
-- [@joshuahuntley](https://github.com/JoshuaHuntley)
 # 0.9.5
 ## Fixes
 - Stop showing cross-db deprecation warnings for macros who have already been migrated ([#725](https://github.com/dbt-labs/dbt-utils/pull/725))

--- a/integration_tests/models/generic_tests/schema.yml
+++ b/integration_tests/models/generic_tests/schema.yml
@@ -14,6 +14,8 @@ seeds:
       - name: field
         tests:
           - dbt_utils.at_least_one
+          - dbt_utils.at_least_one:
+              group_by_columns: ['field']
 
   - name: data_test_expression_is_true
     tests:

--- a/integration_tests/models/generic_tests/schema.yml
+++ b/integration_tests/models/generic_tests/schema.yml
@@ -14,8 +14,6 @@ seeds:
       - name: field
         tests:
           - dbt_utils.at_least_one
-          - dbt_utils.at_least_one:
-              group_by_columns: ['field']
 
   - name: data_test_expression_is_true
     tests:
@@ -89,14 +87,14 @@ seeds:
           upper_bound_column: valid_to
           partition_by: subscription_id
           zero_length_range_allowed: true
- 
+
   - name: data_unique_combination_of_columns
     tests:
       - dbt_utils.unique_combination_of_columns:
           combination_of_columns:
             - month
             - product
-  
+
   - name: data_cardinality_equality_a
     columns:
       - name: same_name
@@ -191,7 +189,7 @@ models:
             - first_name
             - last_name
             - email
-  
+
   - name: test_fewer_rows_than
     tests:
       - dbt_utils.fewer_rows_than:

--- a/macros/generic_tests/at_least_one.sql
+++ b/macros/generic_tests/at_least_one.sql
@@ -4,9 +4,17 @@
 
 {% macro default__test_at_least_one(model, column_name, group_by_columns) %}
 
-{% if group_by_columns|length() > 0 %}
-  {% set select_gb_cols = group_by_columns|join(' ,') + ', ' %}
-  {% set groupby_gb_cols = 'group by ' + group_by_columns|join(',') %}
+{#- Ensure that column_name is not in the group by list or the database will throw an ambiguous column error #}
+{%- set group_by_cols_filtered = [] %}
+{% for column in group_by_columns %}
+  {%- if column != column_name %}
+      {%- do group_by_cols_filtered.append(column) %}
+  {% endif -%}
+{% endfor %}
+
+{% if group_by_cols_filtered|length() > 0 %}
+  {% set select_gb_cols = group_by_cols_filtered|join(' ,') + ', ' %}
+  {% set groupby_gb_cols = 'group by ' + group_by_cols_filtered|join(',') %}
 {% endif %}
 
 select *

--- a/macros/generic_tests/at_least_one.sql
+++ b/macros/generic_tests/at_least_one.sql
@@ -17,7 +17,14 @@ from (
       {{select_gb_cols}}
       count({{ column_name }}) as filler_column
 
-    from {{ model }}
+    from (
+          select
+            {{select_gb_cols}}
+            {{ column_name }}
+          from {{ model }}
+          where {{ column_name }} is not null
+          limit 1
+          )
 
     {{groupby_gb_cols}}
 

--- a/macros/generic_tests/at_least_one.sql
+++ b/macros/generic_tests/at_least_one.sql
@@ -4,17 +4,27 @@
 
 {% macro default__test_at_least_one(model, column_name, group_by_columns) %}
 
+{% set pruned_cols = [column_name] %}
+
 {% if group_by_columns|length() > 0 %}
+
   {% set select_gb_cols = group_by_columns|join(' ,') + ', ' %}
   {% set groupby_gb_cols = 'group by ' + group_by_columns|join(',') %}
+  {% set pruned_cols = group_by_columns %}
+
+  {% if column_name not in pruned_cols %}
+    {% do pruned_cols.append(column_name) %}
+  {% endif %}
+
 {% endif %}
+
+{% set select_pruned_cols = pruned_cols|join(' ,') %}
 
 select *
 from (
     with pruned_rows as (
       select
-        {{select_gb_cols}}
-        {{ column_name }}
+        {{ select_pruned_cols }}
       from {{ model }}
       where {{ column_name }} is not null
       limit 1

--- a/macros/generic_tests/at_least_one.sql
+++ b/macros/generic_tests/at_least_one.sql
@@ -24,7 +24,7 @@ from (
           from {{ model }}
           where {{ column_name }} is not null
           limit 1
-          )
+          ) pruned_rows
 
     {{groupby_gb_cols}}
 

--- a/macros/generic_tests/at_least_one.sql
+++ b/macros/generic_tests/at_least_one.sql
@@ -7,7 +7,7 @@
 {#- Ensure that column_name is not in the group by list or the database will throw an ambiguous column error #}
 {%- set group_by_cols_filtered = [] %}
 {% for column in group_by_columns %}
-  {%- if column != column_name %}
+  {%- if column|upper != column_name|upper %}
       {%- do group_by_cols_filtered.append(column) %}
   {% endif -%}
 {% endfor %}

--- a/macros/generic_tests/at_least_one.sql
+++ b/macros/generic_tests/at_least_one.sql
@@ -4,35 +4,28 @@
 
 {% macro default__test_at_least_one(model, column_name, group_by_columns) %}
 
-{#- Ensure that column_name is not in the group by list or the database will throw an ambiguous column error #}
-{%- set group_by_cols_filtered = [] %}
-{% for column in group_by_columns %}
-  {%- if column|upper != column_name|upper %}
-      {%- do group_by_cols_filtered.append(column) %}
-  {% endif -%}
-{% endfor %}
-
-{% if group_by_cols_filtered|length() > 0 %}
-  {% set select_gb_cols = group_by_cols_filtered|join(' ,') + ', ' %}
-  {% set groupby_gb_cols = 'group by ' + group_by_cols_filtered|join(',') %}
+{% if group_by_columns|length() > 0 %}
+  {% set select_gb_cols = group_by_columns|join(' ,') + ', ' %}
+  {% set groupby_gb_cols = 'group by ' + group_by_columns|join(',') %}
 {% endif %}
 
 select *
 from (
+    with pruned_rows as (
+      select
+        {{select_gb_cols}}
+        {{ column_name }}
+      from {{ model }}
+      where {{ column_name }} is not null
+      limit 1
+    )
     select
         {# In TSQL, subquery aggregate columns need aliases #}
         {# thus: a filler col name, 'filler_column' #}
       {{select_gb_cols}}
       count({{ column_name }}) as filler_column
 
-    from (
-          select
-            {{select_gb_cols}}
-            {{ column_name }}
-          from {{ model }}
-          where {{ column_name }} is not null
-          limit 1
-          ) pruned_rows
+    from pruned_rows
 
     {{groupby_gb_cols}}
 


### PR DESCRIPTION
resolves #775 

[This is a:
- [ ] documentation update
- [ ] bug fix with no breaking changes
- [x] new functionality
- [ ] a breaking change

All pull requests from community contributors should target the `main` branch (default).

## Description & motivation
<!---
We frequently use this test to check that a data source exists. Sometimes to monitor our external S3 sources to ensure they haven't been incorrectly archived. The performance of the at_least_one test in this case is inefficient as it currently exists because it tries to do a count over the entire external source. The specific task for this test is to find a single, non-null instance rather than a full count of rows. I'm proposing that the test should be modified to prune first.
-->

## Checklist
- [ ] This code is associated with an Issue which has been triaged and [accepted for development](https://docs.getdbt.com/docs/contributing/oss-expectations#pull-requests). 
- [x] I have verified that these changes work locally on the following warehouses (Note: it's okay if you do not have access to all warehouses, this helps us understand what has been covered)
    - [ ] BigQuery
    - [ ] Postgres
    - [ ] Redshift
    - [x] Snowflake
- [ ] I followed guidelines to ensure that my changes will work on "non-core" adapters by:
    - [ ] dispatching any new macro(s) so non-core adapters can also use them (e.g. [the `star()` source](https://github.com/dbt-labs/dbt-utils/blob/main/macros/sql/star.sql))
    - [ ] using the `limit_zero()` macro in place of the literal string: `limit 0`
    - [ ] using `dbt.type_*` macros instead of explicit datatypes (e.g. `dbt.type_timestamp()` instead of `TIMESTAMP`
- [x] I have updated the README.md (if applicable)
- [x] I have added tests & descriptions to my models (and macros if applicable)
- [x] I have added an entry to CHANGELOG.md
](https://github.com/JoshuaHuntley)