### PR TITLE
Add optional override arg for behavior of generate_surrogate_key()

### DIFF
--- a/macros/sql/generate_surrogate_key.sql
+++ b/macros/sql/generate_surrogate_key.sql
@@ -1,11 +1,19 @@
-{%- macro generate_surrogate_key(field_list) -%}
-    {{ return(adapter.dispatch('generate_surrogate_key', 'dbt_utils')(field_list)) }}
+{%- macro generate_surrogate_key(field_list, treat_nulls_as_empty_strings=None) -%}
+    {{ return(adapter.dispatch('generate_surrogate_key', 'dbt_utils')(field_list, treat_nulls_as_empty_strings=None)) }}
 {% endmacro %}
 
-{%- macro default__generate_surrogate_key(field_list) -%}
+{%- macro default__generate_surrogate_key(field_list, treat_nulls_as_empty_strings=None) -%}
 
-{%- if var('surrogate_key_treat_nulls_as_empty_strings', False) -%}
+
+{# check for the override variable #}
+{%- if treat_nulls_as_empty_strings -%}
     {%- set default_null_value = "" -%}
+{%- elif not treat_nulls_as_empty_strings -%}
+    {%- set default_null_value = '_dbt_utils_surrogate_key_null_' -%}
+{# Check project config variable #}
+{%- elif var('surrogate_key_treat_nulls_as_empty_strings', False) -%}
+    {%- set default_null_value = "" -%}
+{# fallback to default behavior #}
 {%- else -%}
     {%- set default_null_value = '_dbt_utils_surrogate_key_null_' -%}
 {%- endif -%}


### PR DESCRIPTION
resolves #777

This is a:
- [ ] documentation update
- [ ] bug fix with no breaking changes
- [x] new functionality
- [ ] a breaking change

All pull requests from community contributors should target the `main` branch (default).

## Description & motivation
See issue

## Checklist
- [ ] This code is associated with an Issue which has been triaged and [accepted for development](https://docs.getdbt.com/docs/contributing/oss-expectations#pull-requests). 
- [ ] I have verified that these changes work locally on the following warehouses (Note: it's okay if you do not have access to all warehouses, this helps us understand what has been covered)
    - [ ] BigQuery
    - [ ] Postgres
    - [ ] Redshift
    - [ ] Snowflake
- [ ] I followed guidelines to ensure that my changes will work on "non-core" adapters by:
    - [ ] dispatching any new macro(s) so non-core adapters can also use them (e.g. [the `star()` source](https://github.com/dbt-labs/dbt-utils/blob/main/macros/sql/star.sql))
    - [ ] using the `limit_zero()` macro in place of the literal string: `limit 0`
    - [ ] using `dbt.type_*` macros instead of explicit datatypes (e.g. `dbt.type_timestamp()` instead of `TIMESTAMP`
- [ ] I have updated the README.md (if applicable)
- [ ] I have added tests & descriptions to my models (and macros if applicable)
- [ ] I have added an entry to CHANGELOG.md
