### PR TITLE
chore: Add MySql support to get_tables_by_pattern_sql

### DIFF
--- a/macros/sql/get_tables_by_pattern_sql.sql
+++ b/macros/sql/get_tables_by_pattern_sql.sql
@@ -17,6 +17,20 @@
 {% endmacro %}
 
 
+{% macro mysql__get_tables_by_pattern_sql(schema_pattern, table_pattern, exclude='', database=target.database) %}
+
+        select distinct
+            table_schema as {{ adapter.quote('table_schema') }},
+            table_name as {{ adapter.quote('table_name') }},
+            {{ dbt_utils.get_table_types_sql() }}
+        from {{ database }}.information_schema.tables
+        where table_schema LIKE '{{ schema_pattern }}'
+        and table_name LIKE '{{ table_pattern }}'
+        and table_name not LIKE '{{ exclude }}'
+
+{% endmacro %}
+
+
 {% macro bigquery__get_tables_by_pattern_sql(schema_pattern, table_pattern, exclude='', database=target.database) %}
 
     {% if '%' in schema_pattern %}


### PR DESCRIPTION
resolves #

This is a:
- [ ] documentation update
- [ ] bug fix with no breaking changes
- [X] new functionality
- [ ] a breaking change

All pull requests from community contributors should target the `main` branch (default).

## Description & motivation
Adding support for MySql in `get_tables_by_pattern_sql`

Motivation: Our source databases are MySql which is underrepresented in the DBT ecosystem. 


## Checklist
- [ ] This code is associated with an Issue which has been triaged and [accepted for development](https://docs.getdbt.com/docs/contributing/oss-expectations#pull-requests). 
- [ ] I have verified that these changes work locally on the following warehouses (Note: it's okay if you do not have access to all warehouses, this helps us understand what has been covered)
    - [ ] BigQuery
    - [ ] Postgres
    - [ ] Redshift
    - [ ] Snowflake
    - [X] MySql
- [ ] I followed guidelines to ensure that my changes will work on "non-core" adapters by:
    - [ ] dispatching any new macro(s) so non-core adapters can also use them (e.g. [the `star()` source](https://github.com/dbt-labs/dbt-utils/blob/main/macros/sql/star.sql))
    - [ ] using the `limit_zero()` macro in place of the literal string: `limit 0`
    - [ ] using `dbt.type_*` macros instead of explicit datatypes (e.g. `dbt.type_timestamp()` instead of `TIMESTAMP`
- [ ] I have updated the README.md (if applicable)
- [ ] I have added tests & descriptions to my models (and macros if applicable)
- [ ] I have added an entry to CHANGELOG.md
