### PR TITLE
Add fill_values arg to union_relations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@
 --->
 
 # Unreleased
+## New features
+- Optional `fill_values` parameter for `union_relations` macro. ([#772](https://github.com/dbt-labs/dbt-utils/issues/772), [#XXX](https://github.com/dbt-labs/dbt-utils/pull/XXX))
+
 ## Fixes
 - get_relations_by_pattern for Databricks connection with Unity catalog #768 ([#768](https://github.com/dbt-labs/dbt-utils/issues/768), [#769](https://github.com/dbt-labs/dbt-utils/pull/769))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 # Unreleased
 ## New features
-- Optional `fill_values` parameter for `union_relations` macro. ([#772](https://github.com/dbt-labs/dbt-utils/issues/772), [#XXX](https://github.com/dbt-labs/dbt-utils/pull/XXX))
+- Optional `fill_values` parameter for `union_relations` macro. ([#772](https://github.com/dbt-labs/dbt-utils/issues/772), [#783](https://github.com/dbt-labs/dbt-utils/pull/783))
 
 ## Fixes
 - get_relations_by_pattern for Databricks connection with Unity catalog #768 ([#768](https://github.com/dbt-labs/dbt-utils/issues/768), [#769](https://github.com/dbt-labs/dbt-utils/pull/769))

--- a/README.md
+++ b/README.md
@@ -1020,6 +1020,7 @@ e.g. `{"some_field": "varchar(100)"}`.``
 - `source_column_name` (optional, `default="_dbt_source_relation"`): The name of
 the column that records the source of this row. Pass `None` to omit this column from the results.
 - `where` (optional): Filter conditions to include in the `where` clause.
+- `fill_values` (optional): A dictionary specifying a value to use for each record for each column when that column is not present in the input relation (instead of the default `null`).  e.g. `{'column_name': 'fill_value'}`.
 
 ### generate_series ([source](macros/sql/generate_series.sql))
 

--- a/integration_tests/data/sql/data_union_fill_value_expected.csv
+++ b/integration_tests/data/sql/data_union_fill_value_expected.csv
@@ -1,0 +1,6 @@
+id,name,favorite_color,favorite_number
+1,drew,grey,pi
+2,bob,grey,e
+3,alice,grey,4
+1,gandalf,green,7
+2,gandalf,pink,13

--- a/integration_tests/data/sql/data_union_fill_value_int_expected.csv
+++ b/integration_tests/data/sql/data_union_fill_value_int_expected.csv
@@ -1,0 +1,6 @@
+id,name,favorite_number,favorite_color,high_score
+1,drew,pi,4,99
+2,bob,e,4,99
+3,alice,4,4,99
+1,gandalf,7,green,42
+2,gandalf,13,pink,50

--- a/integration_tests/data/sql/data_union_table_3.csv
+++ b/integration_tests/data/sql/data_union_table_3.csv
@@ -1,0 +1,3 @@
+id,favorite_color,favorite_number,high_score
+1,green,7,42
+2,pink,13,50

--- a/integration_tests/models/sql/schema.yml
+++ b/integration_tests/models/sql/schema.yml
@@ -229,6 +229,21 @@ models:
       - dbt_utils.equality:
           compare_model: ref('data_union_exclude_expected')
 
+  - name: test_union_fill_value
+    tests:
+      - dbt_utils.equality:
+          compare_model: ref('data_union_fill_value_expected')
+
+  - name: test_union_fill_value_case
+    tests:
+      - dbt_utils.equality:
+          compare_model: ref('data_union_fill_value_expected')
+
+  - name: test_union_fill_value_int
+    tests:
+      - dbt_utils.equality:
+          compare_model: ref('data_union_fill_value_int_expected')   
+
   - name: test_get_relations_by_pattern
     tests:
       - dbt_utils.equality:

--- a/integration_tests/models/sql/test_union_fill_value.sql
+++ b/integration_tests/models/sql/test_union_fill_value.sql
@@ -1,0 +1,6 @@
+select 
+    "id"
+    ,"name"
+    ,"favorite_number"
+    ,"favorite_color"
+from {{ ref('test_union_fill_value_base') }}

--- a/integration_tests/models/sql/test_union_fill_value_base.sql
+++ b/integration_tests/models/sql/test_union_fill_value_base.sql
@@ -1,0 +1,5 @@
+{{ dbt_utils.union_relations([
+        ref('data_union_table_1'),
+        ref('data_union_table_2')],
+        fill_values={'FavoRite_coloR': 'rainbow', 'name': 'gandalf'}
+) }}

--- a/integration_tests/models/sql/test_union_fill_value_base_case.sql
+++ b/integration_tests/models/sql/test_union_fill_value_base_case.sql
@@ -1,5 +1,5 @@
 {{ dbt_utils.union_relations([
         ref('data_union_table_1'),
         ref('data_union_table_2')],
-        fill_values={'name': 'gandalf', 'favorite_color': 'grey'}
+        fill_values={'name': 'gandalf', 'FavoRite_coloR': 'grey'}
 ) }}

--- a/integration_tests/models/sql/test_union_fill_value_base_int.sql
+++ b/integration_tests/models/sql/test_union_fill_value_base_int.sql
@@ -1,0 +1,5 @@
+{{ dbt_utils.union_relations([
+        ref('data_union_table_1'),
+        ref('data_union_table_3')],
+        fill_values={'name': 'gandalf', 'favorite_color': 4, 'high_score': 99}
+) }}

--- a/integration_tests/models/sql/test_union_fill_value_case.sql
+++ b/integration_tests/models/sql/test_union_fill_value_case.sql
@@ -1,0 +1,6 @@
+select 
+    "id"
+    ,"name"
+    ,"favorite_number"
+    ,"favorite_color"
+from {{ ref('test_union_fill_value_base_case') }}

--- a/integration_tests/models/sql/test_union_fill_value_int.sql
+++ b/integration_tests/models/sql/test_union_fill_value_int.sql
@@ -1,0 +1,7 @@
+select 
+    "id"
+    ,"name"
+    ,"favorite_number"
+    ,"favorite_color"
+    ,"high_score"
+from {{ ref('test_union_fill_value_base_int') }}


### PR DESCRIPTION
resolves #772

This is a:
- [ ] documentation update
- [ ] bug fix with no breaking changes
- [x] new functionality
- [ ] a breaking change

All pull requests from community contributors should target the `main` branch (default).

## Description & motivation
<!---
Describe your changes, and why you're making them.
-->
Add an optional `fill_values` arg to the `union_relations` macro to allow the user to specify a value that should be used instead of NULL if that column isn't in one of the input relations.

## Checklist
- [x] This code is associated with an Issue which has been triaged and [accepted for development](https://docs.getdbt.com/docs/contributing/oss-expectations#pull-requests). 
- [x] I have verified that these changes work locally on the following warehouses (Note: it's okay if you do not have access to all warehouses, this helps us understand what has been covered)
    - [ ] BigQuery
    - [x] Postgres
    - [ ] Redshift
    - [ ] Snowflake
- [x] I followed guidelines to ensure that my changes will work on "non-core" adapters by:
    - [x] dispatching any new macro(s) so non-core adapters can also use them (e.g. [the `star()` source](https://github.com/dbt-labs/dbt-utils/blob/main/macros/sql/star.sql))
    - [x] using the `limit_zero()` macro in place of the literal string: `limit 0`
    - [x] using `dbt.type_*` macros instead of explicit datatypes (e.g. `dbt.type_timestamp()` instead of `TIMESTAMP`
- [x] I have updated the README.md (if applicable)
- [x] I have added tests & descriptions to my models (and macros if applicable)
- [x] I have added an entry to CHANGELOG.md
