### PR TITLE
Add none option of order_by in "get_column_values"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,9 +12,12 @@
 ## Fixes
 - get_relations_by_pattern for Databricks connection with Unity catalog #768 ([#768](https://github.com/dbt-labs/dbt-utils/issues/768), [#769](https://github.com/dbt-labs/dbt-utils/pull/769))
 
+## Enhancements
+- Disable order by if not necessary in "get_column_values" #787 ([#787](https://github.com/dbt-labs/dbt-utils/pull/787))
+
 ## Contributors:
 @Harmuth94, [#768](https://github.com/dbt-labs/dbt-utils/issues/768)
-
+- [@billyio] (https://github.com/billyio) (#787)
 
 # dbt utils v1.0
 

--- a/integration_tests/data/sql/data_get_column_values_none_order_expected.csv
+++ b/integration_tests/data/sql/data_get_column_values_none_order_expected.csv
@@ -1,0 +1,8 @@
+field
+a
+b
+c
+d
+e
+f
+g

--- a/integration_tests/models/sql/schema.yml
+++ b/integration_tests/models/sql/schema.yml
@@ -85,6 +85,11 @@ models:
       - dbt_utils.equality:
           compare_model: ref('data_get_column_values_where_expected')
 
+  - name: test_get_column_values_none_order
+    tests:
+      - dbt_utils.equality:
+          compare_model: ref('test_get_column_values_none_order_expected')
+
   - name: test_get_filtered_columns_in_relation
     tests:
       - dbt_utils.equality:

--- a/integration_tests/models/sql/test_get_column_values_none_order.sql
+++ b/integration_tests/models/sql/test_get_column_values_none_order.sql
@@ -1,0 +1,6 @@
+{% set column_values = dbt_utils.get_column_values(ref('data_get_column_values'), 'field', order_by=none) %}
+
+-- Create a relation using the values
+{% for val in column_values -%}
+select {{ string_literal(val) }} as field {% if not loop.last %}union all{% endif %} 
+{% endfor %}

--- a/macros/sql/get_column_values.sql
+++ b/macros/sql/get_column_values.sql
@@ -43,7 +43,10 @@
             {% endif %}
 
             group by {{ column }}
+
+            {% if order_by is not none %}
             order by {{ order_by }}
+            {% endif %}
 
             {% if max_records is not none %}
             limit {{ max_records }}


### PR DESCRIPTION
resolves 
https://github.com/dbt-labs/dbt-utils/issues/288 is related

This is a:
- [ ] documentation update
- [ ] bug fix with no breaking changes
- [x] new functionality
- [ ] a breaking change

All pull requests from community contributors should target the `main` branch (default).

## Description & motivation
<!---
Describe your changes, and why you're making them.
-->
I have some tables with specific order and don't want to use "order by"

## Checklist
- [x] This code is associated with an Issue which has been triaged and [accepted for development](https://docs.getdbt.com/docs/contributing/oss-expectations#pull-requests). 
- [x] I have verified that these changes work locally on the following warehouses (Note: it's okay if you do not have access to all warehouses, this helps us understand what has been covered)
    - [ ] BigQuery
    - [ ] Postgres
    - [ ] Redshift
    - [x] Snowflake
- [ ] I followed guidelines to ensure that my changes will work on "non-core" adapters by:
    - [ ] dispatching any new macro(s) so non-core adapters can also use them (e.g. [the `star()` source](https://github.com/dbt-labs/dbt-utils/blob/main/macros/sql/star.sql))
    - [ ] using the `limit_zero()` macro in place of the literal string: `limit 0`
    - [ ] using `dbt.type_*` macros instead of explicit datatypes (e.g. `dbt.type_timestamp()` instead of `TIMESTAMP`
- [ ] I have updated the README.md (if applicable)
- [x] I have added tests & descriptions to my models (and macros if applicable)
- [x] I have added an entry to CHANGELOG.md
