### PR TITLE
Point to the GitHub issue for re-enabling this test

### DIFF
--- a/integration_tests/tests/sql/test_get_column_values_use_default.sql
+++ b/integration_tests/tests/sql/test_get_column_values_use_default.sql
@@ -1,5 +1,9 @@
 
-{# This keeps succeeding locally and failing in CI. Disabling it to get everything else out, but it should still be tested. #}
+{#
+This keeps succeeding locally and failing in CI. Disabling it to get everything else out, but it should still be tested.
+https://github.com/dbt-labs/dbt-utils/issues/788
+#}
+
 {{ config(enabled = false)}}
 
 {% set column_values = dbt_utils.get_column_values(ref('data_get_column_values_dropped'), 'field', default=['y', 'z'], order_by="field") %}


### PR DESCRIPTION
resolves N/A

This is a:
- [x] documentation update

## Description & motivation

Please reformat the Jinja comment however desired.

Context: merge queue auto-merged prior to [this](https://github.com/dbt-labs/dbt-utils/pull/771/files/51d883ad7dfcb9f1dee2a4fcc43dc41482c8d42d#diff-ff359ddba6bdd617553825ded6e10db24b4305a79f3490ca965b1c43d7d88324) suggestion being committed that adds a link to https://github.com/dbt-labs/dbt-utils/issues/788 as an inline comment.

## Checklist
N/A