### PR TITLE
Fix legacy links in README

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 <!--- Copy, paste, and uncomment the following headers as-needed for unreleased features
 # Unreleased
 ## New features
-- XXX ([#XXX](https://github.com/dbt-labs/dbt-utils/issues/XXX), [#XXX](https://github.com/dbt-labs/dbt-utils/pull/XXX))
+* ZZZ by @YYY in https://github.com/dbt-labs/dbt-utils/pull/XXX
 ## Fixes
 ## Quality of life
 ## Under the hood
@@ -10,8 +10,9 @@
 
 # Unreleased
 ## New features
-- XXX ([#XXX](https://github.com/dbt-labs/dbt-utils/issues/XXX), [#XXX](https://github.com/dbt-labs/dbt-utils/pull/XXX))
+* ZZZ by @YYY in https://github.com/dbt-labs/dbt-utils/pull/XXX
 ## Fixes
+* Fix legacy links in README by @dbeatty10 in https://github.com/dbt-labs/dbt-utils/pull/796
 ## Quality of life
 ## Under the hood
 ## Contributors:

--- a/README.md
+++ b/README.md
@@ -45,11 +45,11 @@ Check [dbt Hub](https://hub.getdbt.com/dbt-labs/dbt_utils/latest/) for the lates
       * [generate_series (<a href="macros/sql/generate_series.sql">source</a>)](#generate_series-source)
       * [generate_surrogate_key (<a href="macros/sql/generate_surrogate_key.sql">source</a>)](#generate_surrogate_key-source)
       * [safe_add (<a href="macros/sql/safe_add.sql">source</a>)](#safe_add-source)
-      * [safe_divide (<a href="macros/cross_db_utils/safe_divide.sql">source</a>)](#safe_divide-source)
+      * [safe_divide (<a href="macros/sql/safe_divide.sql">source</a>)](#safe_divide-source)
       * [safe_subtract (<a href="macros/sql/safe_subtract.sql">source</a>)](#safe_subtract-source)
       * [pivot (<a href="macros/sql/pivot.sql">source</a>)](#pivot-source)
       * [unpivot (<a href="macros/sql/unpivot.sql">source</a>)](#unpivot-source)
-      * [width_bucket (<a href="macros/cross_db_utils/width_bucket.sql">source</a>)](#width_bucket-source)
+      * [width_bucket (<a href="macros/sql/width_bucket.sql">source</a>)](#width_bucket-source)
    * [Web macros](#web-macros)
       * [get_url_parameter (<a href="macros/web/get_url_parameter.sql">source</a>)](#get_url_parameter-source)
       * [get_url_host (<a href="macros/web/get_url_host.sql">source</a>)](#get_url_host-source)
@@ -1059,7 +1059,7 @@ This macro implements a cross-database way to sum nullable fields using the fiel
 {{ dbt_utils.safe_add(['field_a', 'field_b', ...]) }}
 ```
 
-### safe_divide ([source](macros/cross_db_utils/safe_divide.sql))
+### safe_divide ([source](macros/sql/safe_divide.sql))
 
 This macro performs division but returns null if the denominator is 0. 
 
@@ -1211,7 +1211,7 @@ Boolean values are replaced with the strings 'true'|'false'
 - `field_name`: column name in the resulting table for field
 - `value_name`: column name in the resulting table for value
 
-### width_bucket ([source](macros/cross_db_utils/width_bucket.sql))
+### width_bucket ([source](macros/sql/width_bucket.sql))
 
 This macro is modeled after the `width_bucket` function natively available in Snowflake.
 


### PR DESCRIPTION
resolves #790

This is a:
- [x] documentation update
- [ ] bug fix with no breaking changes
- [ ] new functionality
- [ ] a breaking change

All pull requests from community contributors should target the `main` branch (default).

## Description & motivation

`safe_divide` and `width_bucket ` didn't get their source code URLs updated when they changed source code directories, so clicking on links in the readme gives 404 like this:

<img width="450" alt="image" src="https://github.com/dbt-labs/dbt-utils/assets/44704949/85b1cd5e-e4b6-4b47-883e-9a60d18cacc7">

## Checklist
- [x] This code is associated with an issue ~which has been triaged and [accepted for development](https://docs.getdbt.com/docs/contributing/oss-expectations#pull-requests)~. 
- [x] I have updated the README.md (if applicable)
- [x] I have added an entry to CHANGELOG.md