### PR TITLE
Add argument to allow rename columns in star (#798)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 # Unreleased
 ## New features
 * ZZZ by @YYY in https://github.com/dbt-labs/dbt-utils/pull/XXX
+* Add rename argument to `star` by @haluunn in https://github.com/dbt-labs/dbt-utils/pull/799
 ## Fixes
 * Fix legacy links in README by @dbeatty10 in https://github.com/dbt-labs/dbt-utils/pull/796
 ## Quality of life

--- a/README.md
+++ b/README.md
@@ -950,6 +950,7 @@ the star macro.
 This macro also has an optional `relation_alias` argument that will prefix all generated fields with an alias (`relation_alias`.`field_name`).
 The macro also has optional `prefix` and `suffix` arguments. When one or both are provided, they will be concatenated onto each field's alias
 in the output (`prefix` ~ `field_name` ~ `suffix`). NB: This prevents the output from being used in any context other than a select statement.
+The macro also has an optional `rename` argument that will rename the columns based on
 This macro also has an optional `quote_identifiers` argument that will encase the selected columns and their aliases in double quotes.
 
 **Args:**
@@ -959,6 +960,7 @@ This macro also has an optional `quote_identifiers` argument that will encase th
 - `relation_alias` (optional, default=`''`): will prefix all generated fields with an alias (`relation_alias`.`field_name`).
 - `prefix` (optional, default=`''`): will prefix the output `field_name` (`field_name as prefix_field_name`).
 - `suffix` (optional, default=`''`): will suffix the output `field_name` (`field_name as field_name_suffix`).
+- `rename` (optional, default=`{}`): will rename the output `field_name` if existing in the keys (`field_name as new_name`) (case-insensitive)
 - `quote_identifiers` (optional, default=`True`): will encase selected columns and aliases in double quotes (`"field_name" as "field_name"`).
 
 **Usage:**
@@ -987,6 +989,13 @@ from {{ ref('my_model') }}
 ```sql
 select
 {{ dbt_utils.star(from=ref('my_model'), except=["exclude_field_1", "exclude_field_2"], prefix="max_") }}
+from {{ ref('my_model') }}
+
+```
+
+```sql
+select
+  {{ dbt_utils.star(from=ref('my_model'), rename={"field_name_1":"new_name_1","few_name_2":"new_name_2"}) }}
 from {{ ref('my_model') }}
 
 ```

--- a/macros/sql/star.sql
+++ b/macros/sql/star.sql
@@ -16,7 +16,7 @@
     {% set lower_rename = {} %}
     {%- if rename and rename is mapping %}
         {%- for key, value in rename.items() %}
-            {%- do lower_rename.update({key.lower():value.lower()})}
+            {%- do lower_rename.update({key | lower: value | lower}) -%}
         {%- endfor -%}
     {%- endif -%}
 

--- a/macros/sql/star.sql
+++ b/macros/sql/star.sql
@@ -1,8 +1,8 @@
 {% macro star(from, relation_alias=False, except=[], prefix='', suffix='', rename={}, quote_identifiers=True) -%}
-    {{ return(adapter.dispatch('star', 'dbt_utils')(from, relation_alias, except, prefix, suffix, quote_identifiers)) }}
+    {{ return(adapter.dispatch('star', 'dbt_utils')(from, relation_alias, except, prefix, suffix, rename, quote_identifiers)) }}
 {% endmacro %}
 
-{% macro default__star(from, relation_alias=False, except=[], prefix='', suffix='', quote_identifiers=True) -%}
+{% macro default__star(from, relation_alias=False, except=[], prefix='', suffix='', rename={}, quote_identifiers=True) -%}
     {%- do dbt_utils._is_relation(from, 'star') -%}
     {%- do dbt_utils._is_ephemeral(from, 'star') -%}
 

--- a/macros/sql/star.sql
+++ b/macros/sql/star.sql
@@ -13,7 +13,7 @@
 
     {% set cols = dbt_utils.get_filtered_columns_in_relation(from, except) %}
 
-    {% set lower_rename = rename | map(key=lambda x: x.lower(), value=lambda x: x.lower()) if rename else {} %}
+    {% set lower_rename = dict((k.lower(), v.lower()) for k, v in rename.items()) %}
 
     {%- if cols|length <= 0 -%}
         {% if flags.WHICH == 'compile' %}

--- a/macros/sql/star.sql
+++ b/macros/sql/star.sql
@@ -6,20 +6,19 @@
     {%- do dbt_utils._is_relation(from, 'star') -%}
     {%- do dbt_utils._is_ephemeral(from, 'star') -%}
 
-    {#-- Prevent querying of db in parsing mode. This works because this macro does not create any new refs. #}
+    {# /* Prevent querying of db in parsing mode. This works because this macro does not create any new refs. */ #}
     {%- if not execute -%}
         {% do return('*') %}
     {%- endif -%}
 
-    {% set cols = dbt_utils.get_filtered_columns_in_relation(from, except) %}
-
-    {% set lower_rename = {} %}
+    {%- set lower_rename = {} %}
     {%- if rename and rename is mapping %}
         {%- for key, value in rename.items() %}
             {%- do lower_rename.update({key | lower: value | lower}) -%}
         {%- endfor -%}
     {%- endif -%}
 
+    {% set cols = dbt_utils.get_filtered_columns_in_relation(from, except) %}
 
     {%- if cols|length <= 0 -%}
         {% if flags.WHICH == 'compile' %}

--- a/macros/sql/star.sql
+++ b/macros/sql/star.sql
@@ -31,9 +31,9 @@ dbt compile, and exists to keep SQLFluff happy. */
         {%- for col in cols %}
             {%- if relation_alias %}{{ relation_alias }}.{% else %}{%- endif -%}
                 {%- if quote_identifiers -%}
-                    {{ adapter.quote(col)|trim }} {%- if prefix!='' or suffix!='' %} as {{ adapter.quote(prefix ~ col ~ suffix)|trim }} {%- else -%} {%- if col in lower_rename.keys() %} as {{ adapter.quote(lower_rename.get(col))|trim }} {%- endif -%}
+                    {{ adapter.quote(col)|trim }} {%- if prefix!='' or suffix!='' %} as {{ adapter.quote(prefix ~ col ~ suffix)|trim }} {%- elif col in lower_rename.keys() %} as {{ adapter.quote(lower_rename.get(col))|trim }} {%- endif -%}
                 {%- else -%}
-                    {{ col|trim }} {%- if prefix!='' or suffix!='' %} as {{ (prefix ~ col ~ suffix)|trim }} {%- else -%} {%- if col in lower_rename.keys() %} as {{ lower_rename.get(col)|trim }} {%- endif -%}
+                    {{ col|trim }} {%- if prefix!='' or suffix!='' %} as {{ (prefix ~ col ~ suffix)|trim }} {%- elif col in lower_rename.keys() %} as {{ lower_rename.get(col)|trim }} {%- endif -%}
                 {% endif %}
             {%- if not loop.last %},{{ '\n  ' }}{%- endif -%}
         {%- endfor -%}

--- a/macros/sql/star.sql
+++ b/macros/sql/star.sql
@@ -13,7 +13,13 @@
 
     {% set cols = dbt_utils.get_filtered_columns_in_relation(from, except) %}
 
-    {% set lower_rename = dict((k.lower(), v.lower()) for k, v in rename.items()) %}
+    {% set lower_rename = {} %}
+    {%- if rename and rename is mapping %}
+        {%- for key, value in rename.items() %}
+            {%- do lower_rename.update({key.lower():value.lower()})}
+        {%- endfor -%}
+    {%- endif -%}
+
 
     {%- if cols|length <= 0 -%}
         {% if flags.WHICH == 'compile' %}


### PR DESCRIPTION
resolves #

This is a:
- [ ] documentation update
- [ ] bug fix with no breaking changes
- [x] new functionality
- [ ] a breaking change

All pull requests from community contributors should target the `main` branch (default).

## Description & motivation
<!---
The change is made to `star` function, to allow renaming columns based on a dictionary as input.
The change enables more flexibility in renaming columns instead of following a fixed prefix or suffix.
-->

## Checklist
- [x] This code is associated with an Issue which has been triaged and [accepted for development](https://docs.getdbt.com/docs/contributing/oss-expectations#pull-requests). 
- [ ] I have verified that these changes work locally on the following warehouses (Note: it's okay if you do not have access to all warehouses, this helps us understand what has been covered)
    - [ ] BigQuery
    - [ ] Postgres
    - [v] Redshift
    - [ ] Snowflake
- [x] I followed guidelines to ensure that my changes will work on "non-core" adapters by:
    - [x] dispatching any new macro(s) so non-core adapters can also use them (e.g. [the `star()` source](https://github.com/dbt-labs/dbt-utils/blob/main/macros/sql/star.sql))
    - [x] using the `limit_zero()` macro in place of the literal string: `limit 0`
    - [x] using `dbt.type_*` macros instead of explicit datatypes (e.g. `dbt.type_timestamp()` instead of `TIMESTAMP`
- [x] I have updated the README.md (if applicable)
- [x] I have added tests & descriptions to my models (and macros if applicable)
- [x] I have added an entry to CHANGELOG.md
