### PR TITLE
Updated union.sql to add special handling for GEOGRAPHY datatype

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@
 ## Contributors:
 --->
 
+# Unreleased
+## New features
+## Fixes
+* Fix for GEOGRAPHY datatype in Snowflake - issue #793 by @paperlinguist in https://github.com/dbt-labs/dbt-utils/pull/807
+## Quality of life
+## Under the hood
+## Contributors:
+
 # dbt utils v1.1.1
 ## New features
 * Improve the performance of the `at_least_one` test by pruning early. This is especially helpful when running against external tables. By @joshuahuntley in https://github.com/dbt-labs/dbt-utils/pull/775

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 # Unreleased
 ## Fixes
-* Fix for GEOGRAPHY datatype in Snowflake - issue #793 by @paperlinguist in https://github.com/dbt-labs/dbt-utils/pull/807
+* Fix for GEOGRAPHY datatype handling in union.sql - issue #793 by @paperlinguist in https://github.com/dbt-labs/dbt-utils/pull/807
 ## Contributors:
 * @paperlinguist
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,12 +9,10 @@
 --->
 
 # Unreleased
-## New features
 ## Fixes
 * Fix for GEOGRAPHY datatype in Snowflake - issue #793 by @paperlinguist in https://github.com/dbt-labs/dbt-utils/pull/807
-## Quality of life
-## Under the hood
 ## Contributors:
+* @paperlinguist
 
 # dbt utils v1.1.1
 ## New features

--- a/macros/sql/union.sql
+++ b/macros/sql/union.sql
@@ -108,8 +108,14 @@
                     {%- set col = column_superset[col_name] %}
                     {%- set col_type = column_override.get(col.column, col.data_type) %}
                     {%- set col_name = adapter.quote(col_name) if col_name in relation_columns[relation] else 'null' %}
-                    cast({{ col_name }} as {{ col_type }}) as {{ col.quoted }} {% if not loop.last %},{% endif -%}
 
+                    {#-- Special handling for GEOGRAPHY columns in Snowflake. -#}
+                    {%- if col_type == 'GEOGRAPHY'%}
+                    to_geography({{ col_name }}) as {{ col.quoted }} {% if not loop.last %},{% endif -%}
+                    {% else %}
+                    cast({{ col_name }} as {{ col_type }}) as {{ col.quoted }} {% if not loop.last %},{% endif -%}
+                    {%- endif %}
+    
                 {%- endfor %}
 
             from {{ relation }}


### PR DESCRIPTION
Resolves # 793

This is a:
- [ ] documentation update
- [x] bug fix with no breaking changes
- [ ] new functionality
- [ ] a breaking change

All pull requests from community contributors should target the `main` branch (default).

## Description & motivation
Related to issue #793: https://github.com/dbt-labs/dbt-utils/issues/793

Union.sql:
Added tests for col_type == 'GEOGRAPHY' and using st_geogfromtext rather than cast due to Snowflake not supporting geography data types in cast() functions. Should have good cross-db compatibility due to support for st_geogfromtext() in PostGIS, Snowflake, BigQuery, and Redshift.

Tested and working in DBT 1.5 & Snowflake

## Checklist
- [x] This code is associated with an Issue which has been triaged and [accepted for development](https://docs.getdbt.com/docs/contributing/oss-expectations#pull-requests). 
- [x] I have verified that these changes work locally on the following warehouses (Note: it's okay if you do not have access to all warehouses, this helps us understand what has been covered)
    - [ ] BigQuery
    - [ ] Postgres
    - [ ] Redshift
    - [x] Snowflake
- [x] I followed guidelines to ensure that my changes will work on "non-core" adapters by:
    - [x] dispatching any new macro(s) so non-core adapters can also use them (e.g. [the `star()` source](https://github.com/dbt-labs/dbt-utils/blob/main/macros/sql/star.sql))
    - [x] using the `limit_zero()` macro in place of the literal string: `limit 0`
    - [x] using `dbt.type_*` macros instead of explicit datatypes (e.g. `dbt.type_timestamp()` instead of `TIMESTAMP`
- [x] I have updated the README.md (if applicable)
- [x] I have added tests & descriptions to my models (and macros if applicable)
- [x] I have added an entry to CHANGELOG.md
