### PR TITLE
Remove column rename in mutually exclusive test.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@
 ## Contributors:
 --->
 
+# Unreleased
+## Quality of life
+* Remove column rename in mutually_exclusive_ranges test
+## Contributors:
+* @vvveracruz
 # dbt utils v1.1.1
 ## New features
 * Improve the performance of the `at_least_one` test by pruning early. This is especially helpful when running against external tables. By @joshuahuntley in https://github.com/dbt-labs/dbt-utils/pull/775

--- a/macros/generic_tests/mutually_exclusive_ranges.sql
+++ b/macros/generic_tests/mutually_exclusive_ranges.sql
@@ -35,7 +35,7 @@ with window_functions as (
 
     select
         {% if partition_by %}
-        {{ partition_by }} as partition_by_col,
+        {{ partition_by }},
         {% endif %}
         {{ lower_bound_column }} as lower_bound,
         {{ upper_bound_column }} as upper_bound,


### PR DESCRIPTION
resolves #

This is a:
- [ ] documentation update
- [x] bug fix with no breaking changes
- [ ] new functionality
- [ ] a breaking change

All pull requests from community contributors should target the `main` branch (default).

## Description & motivation
- The column rename here was renaming only the last grouping column, making it less clear what is happening

As an example:
```sql
with window_functions as (

    select
        
        brand_id,gsp_group_id,is_prepay,is_business as partition_by_col,
       ...
```
with this change:
```sql
with window_functions as (

    select
        
        brand_id,gsp_group_id,is_prepay,is_business,
       ...
```

## Checklist
- [ ] This code is associated with an Issue which has been triaged and [accepted for development](https://docs.getdbt.com/docs/contributing/oss-expectations#pull-requests). 
- [ ] I have verified that these changes work locally on the following warehouses (Note: it's okay if you do not have access to all warehouses, this helps us understand what has been covered)
    - [ ] BigQuery
    - [ ] Postgres
    - [ ] Redshift
    - [ ] Snowflake
    - [x] Databricks
- [ ] I followed guidelines to ensure that my changes will work on "non-core" adapters by:
    - [ ] dispatching any new macro(s) so non-core adapters can also use them (e.g. [the `star()` source](https://github.com/dbt-labs/dbt-utils/blob/main/macros/sql/star.sql))
    - [ ] using the `limit_zero()` macro in place of the literal string: `limit 0`
    - [ ] using `dbt.type_*` macros instead of explicit datatypes (e.g. `dbt.type_timestamp()` instead of `TIMESTAMP`
- [ ] I have updated the README.md (if applicable)
- [ ] I have added tests & descriptions to my models (and macros if applicable)
- [x] I have added an entry to CHANGELOG.md
