### PR TITLE
Use QUALIFY clause in `deduplicate` macro for Redshift

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,9 +11,11 @@
 # Unreleased
 ## Fixes
 - deduplicate macro for Databricks now uses the QUALIFY clause, which fixes NULL columns issues from the default natural join logic
+- deduplicate macro for Redshift now uses the QUALIFY clause, which fixes NULL columns issues from the default natural join logic
 
 ## Contributors:
 [@graciegoheen](https://github.com/graciegoheen)
+[@yauhen-sobaleu](https://github.com/yauhen-sobaleu)
 
 # dbt utils v1.1.1
 ## New features

--- a/macros/sql/deduplicate.sql
+++ b/macros/sql/deduplicate.sql
@@ -29,10 +29,17 @@
 
 {%- endmacro -%}
 
-{# Redshift should use default instead of Postgres #}
+-- Redshift has the `QUALIFY` syntax:
+-- https://docs.aws.amazon.com/redshift/latest/dg/r_QUALIFY_clause.html
 {% macro redshift__deduplicate(relation, partition_by, order_by) -%}
 
-    {{ return(dbt_utils.default__deduplicate(relation, partition_by, order_by=order_by)) }}
+    select *
+    from {{ relation }} as tt
+    qualify
+        row_number() over (
+            partition by {{ partition_by }}
+            order by {{ order_by }}
+        ) = 1
 
 {% endmacro %}
 


### PR DESCRIPTION
resolves https://github.com/dbt-labs/dbt-utils/issues/713

This is a:
- [ ] documentation update
- [x] bug fix with no breaking changes
- [ ] new functionality
- [ ] a breaking change

All pull requests from community contributors should target the `main` branch (default).

## Description & motivation
In Redshift `deduplicate` macro causes rows with NULL values in any column to be discarded due to specifics of the natural join.

Since Redshift has added support for QUALIFY keyword (https://aws.amazon.com/about-aws/whats-new/2023/07/amazon-redshift-qualify-clause-select-sql-statement/) we can get rid of natural join in the macro and fix the problem in an elegant manner.

Compare inputs and outputs:

### Old version
```sql
with data as (

    select 
        '2021-04-03 23:00:26'::timestamp as ts,
        1 AS id,
        NULL AS null_field
    UNION ALL
    select 
        '2021-04-03 23:00:26'::timestamp as ts,
        1 AS id,
        NULL AS null_field
),

data_deduped AS (
    with row_numbered as (
        select
            _inner.*,
            row_number() over (
                partition by id
                order by ts desc
            ) as rn
        from data as _inner
    )

    select
        distinct data.*
    from data as data
    
    natural join row_numbered
    where row_numbered.rn = 1
)

select * from data_deduped
```

### Expected results
```
         ts          | id | null_field 
---------------------+----+------------
 2021-04-03 23:00:26 |  1 |          
(1 row)
```

### Actual results

```
 ts | id | null_field 
----+----+------------
(0 rows)
```

## New version

```sql
with data as (

    select 
        '2021-04-03 23:00:26'::timestamp as ts,
        1 AS id,
        NULL AS null_field
    UNION ALL
    select 
        '2021-04-03 23:00:26'::timestamp as ts,
        1 AS id,
        NULL AS null_field
),

data_deduped AS (
 
    select *
    from data as tt
    qualify
        row_number() over (
            partition by id
            order by ts
        ) = 1
)

select * from data_deduped
```

### Actual result
```
         ts          | id | null_field 
---------------------+----+------------
 2021-04-03 23:00:26 |  1 |          
(1 row)
```


## Checklist
- [x] This code is associated with an Issue which has been triaged and [accepted for development](https://docs.getdbt.com/docs/contributing/oss-expectations#pull-requests). 
- x ] I have verified that these changes work locally on the following warehouses (Note: it's okay if you do not have access to all warehouses, this helps us understand what has been covered)
    - [ ] BigQuery
    - [ ] Postgres
    - [x] Redshift
    - [ ] Snowflake
- [ ] I followed guidelines to ensure that my changes will work on "non-core" adapters by:
    - [ ] dispatching any new macro(s) so non-core adapters can also use them (e.g. [the `star()` source](https://github.com/dbt-labs/dbt-utils/blob/main/macros/sql/star.sql))
    - [ ] using the `limit_zero()` macro in place of the literal string: `limit 0`
    - [ ] using `dbt.type_*` macros instead of explicit datatypes (e.g. `dbt.type_timestamp()` instead of `TIMESTAMP`
- [ ] I have updated the README.md (if applicable)
- [ ] I have added tests & descriptions to my models (and macros if applicable)
- [x] I have added an entry to CHANGELOG.md
