### PR TITLE
fix: support clickhouse dialect in deduplicate

### DIFF
--- a/macros/sql/deduplicate.sql
+++ b/macros/sql/deduplicate.sql
@@ -108,3 +108,16 @@
     )
 
 {%- endmacro -%}
+
+{#
+-- Clickhouse supports the `DISTINCT ON` syntax:
+-- https://clickhouse.com/docs/en/sql-reference/statements/select/distinct
+#}
+{%- macro clickhouse__deduplicate(relation, partition_by, order_by) -%}
+
+    select
+        distinct on ({{ partition_by }}) *
+    from {{ relation }}
+    order by {{ partition_by }}{{ ',' ~ order_by }}
+
+{%- endmacro -%}


### PR DESCRIPTION
This is a:
- [ ] documentation update
- [X] bug fix with no breaking changes
- [ ] new functionality
- [ ] a breaking change

All pull requests from community contributors should target the `main` branch (default).

## Description & motivation
There is no specific clickhouse dispatch for the `deduplicate` macro, and so the default implementation is used. However, Clickhouse does not support the `natural join` clause, so the macro fails.

This adds a Clickhouse specific implementation that uses the `distinct on` clause (in the same way as Postgres).

Not sure about a few things:
- Do I need to create a related issue for this?
- Do I need to verify that this works on the warehouses below given that it doesn't target them?
- Do I need to add an entry to CHANGELOG.md?
- Is Clickhouse supported at all by dbt-utils?? I can't seem to find any mention of it, but figured I'd chuck this PR out there anyway

## Checklist
- [ ] This code is associated with an Issue which has been triaged and [accepted for development](https://docs.getdbt.com/docs/contributing/oss-expectations#pull-requests). 
- [ ] I have verified that these changes work locally on the following warehouses (Note: it's okay if you do not have access to all warehouses, this helps us understand what has been covered)
    - [ ] BigQuery
    - [ ] Postgres
    - [ ] Redshift
    - [ ] Snowflake
- [X] I followed guidelines to ensure that my changes will work on "non-core" adapters by:
    - [X] dispatching any new macro(s) so non-core adapters can also use them (e.g. [the `star()` source](https://github.com/dbt-labs/dbt-utils/blob/main/macros/sql/star.sql))
    - [X] using the `limit_zero()` macro in place of the literal string: `limit 0`
    - [X] using `dbt.type_*` macros instead of explicit datatypes (e.g. `dbt.type_timestamp()` instead of `TIMESTAMP`
- [X] I have updated the README.md (if applicable)
- [X] I have added tests & descriptions to my models (and macros if applicable)
- [ ] I have added an entry to CHANGELOG.md
