### PR TITLE
Parameterize `union_relations` macro to support deduplication with `UNION DISTINCT` #816

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,9 +13,13 @@
 - deduplicate macro for Databricks now uses the QUALIFY clause, which fixes NULL columns issues from the default natural join logic
 - deduplicate macro for Redshift now uses the QUALIFY clause, which fixes NULL columns issues from the default natural join logic
 
+## Quality of life
+- parameterize union_relations() macro to support deduplication with UNION
+
 ## Contributors:
 [@graciegoheen](https://github.com/graciegoheen)
 [@yauhen-sobaleu](https://github.com/yauhen-sobaleu)
+[@will-hou](https://github.com/will-hou)
 
 # dbt utils v1.1.1
 ## New features

--- a/README.md
+++ b/README.md
@@ -993,7 +993,7 @@ from {{ ref('my_model') }}
 
 ### union_relations ([source](macros/sql/union.sql))
 
-This macro combines via `union all` (default) or `union` (when `dedupe=True`) an array of [Relations](https://docs.getdbt.com/docs/writing-code-in-dbt/class-reference/#relation),
+This macro combines via `union all` (default) or `union distinct` (when `dedupe=True`) an array of [Relations](https://docs.getdbt.com/docs/writing-code-in-dbt/class-reference/#relation),
 even when columns have differing orders in each Relation, and/or some columns are
 missing from some relations. Any columns exclusive to a subset of these
 relations will be filled with `null` where not present. A new column
@@ -1020,7 +1020,7 @@ e.g. `{"some_field": "varchar(100)"}`.``
 - `source_column_name` (optional, `default="_dbt_source_relation"`): The name of
 the column that records the source of this row. Pass `None` to omit this column from the results.
 - `where` (optional): Filter conditions to include in the `where` clause.
-- `dedupe` (optional): Whether to perform a `UNION` or `UNION ALL`; defaults to false (i.e. `UNION ALL`)
+- `dedupe` (optional): Whether to perform a `UNION DISTINCT` or `UNION ALL`; defaults to false (i.e. `UNION ALL`)
 
 
 ### generate_series ([source](macros/sql/generate_series.sql))

--- a/README.md
+++ b/README.md
@@ -993,7 +993,7 @@ from {{ ref('my_model') }}
 
 ### union_relations ([source](macros/sql/union.sql))
 
-This macro combines via `union all` an array of [Relations](https://docs.getdbt.com/docs/writing-code-in-dbt/class-reference/#relation),
+This macro combines via `union all` (default) or `union` (when `dedupe=True`) an array of [Relations](https://docs.getdbt.com/docs/writing-code-in-dbt/class-reference/#relation),
 even when columns have differing orders in each Relation, and/or some columns are
 missing from some relations. Any columns exclusive to a subset of these
 relations will be filled with `null` where not present. A new column
@@ -1020,6 +1020,8 @@ e.g. `{"some_field": "varchar(100)"}`.``
 - `source_column_name` (optional, `default="_dbt_source_relation"`): The name of
 the column that records the source of this row. Pass `None` to omit this column from the results.
 - `where` (optional): Filter conditions to include in the `where` clause.
+- `dedupe` (optional): Whether to perform a `UNION` or `UNION ALL`; defaults to false (i.e. `UNION ALL`)
+
 
 ### generate_series ([source](macros/sql/generate_series.sql))
 

--- a/integration_tests/data/sql/data_union_dedupe_false_expected.csv
+++ b/integration_tests/data/sql/data_union_dedupe_false_expected.csv
@@ -1,0 +1,5 @@
+id,favorite_color
+1,purple
+1,purple
+1,purple
+1,purple

--- a/integration_tests/data/sql/data_union_dedupe_true_expected.csv
+++ b/integration_tests/data/sql/data_union_dedupe_true_expected.csv
@@ -1,0 +1,2 @@
+id,favorite_color
+1,purple

--- a/integration_tests/data/sql/data_union_table_dedupe.csv
+++ b/integration_tests/data/sql/data_union_table_dedupe.csv
@@ -1,0 +1,3 @@
+id,favorite_color
+1,purple
+1,purple

--- a/integration_tests/models/sql/schema.yml
+++ b/integration_tests/models/sql/schema.yml
@@ -233,6 +233,16 @@ models:
     tests:
       - dbt_utils.equality:
           compare_model: ref('data_union_events_expected')
+  
+  - name: test_union_dedupe_true
+    tests:
+      - dbt_utils.equal_rowcount:
+          compare_model: ref('data_union_dedupe_true_expected')
+
+  - name: test_union_dedupe_false
+    tests:
+      - dbt_utils.equal_rowcount:
+          compare_model: ref('data_union_dedupe_false_expected')
 
   - name: test_deduplicate
     tests:

--- a/integration_tests/models/sql/test_union_dedupe_false.sql
+++ b/integration_tests/models/sql/test_union_dedupe_false.sql
@@ -1,0 +1,10 @@
+select
+    id,
+    favorite_color
+from 
+(
+{{ dbt_utils.union_relations([
+        ref('data_union_table_dedupe'),
+        ref('data_union_table_dedupe')]
+) }} 
+) as unioned

--- a/integration_tests/models/sql/test_union_dedupe_true.sql
+++ b/integration_tests/models/sql/test_union_dedupe_true.sql
@@ -1,0 +1,11 @@
+select
+    id,
+    favorite_color
+from 
+(
+{{ dbt_utils.union_relations([
+        ref('data_union_table_dedupe'),
+        ref('data_union_table_dedupe')],
+        dedupe=True
+) }} 
+) as unioned

--- a/macros/sql/union.sql
+++ b/macros/sql/union.sql
@@ -1,8 +1,8 @@
-{%- macro union_relations(relations, column_override=none, include=[], exclude=[], source_column_name='_dbt_source_relation', where=none) -%}
-    {{ return(adapter.dispatch('union_relations', 'dbt_utils')(relations, column_override, include, exclude, source_column_name, where)) }}
+{%- macro union_relations(relations, column_override=none, include=[], exclude=[], source_column_name='_dbt_source_relation', where=none, dedupe=false) -%}
+    {{ return(adapter.dispatch('union_relations', 'dbt_utils')(relations, column_override, include, exclude, source_column_name, where, dedupe)) }}
 {% endmacro %}
 
-{%- macro default__union_relations(relations, column_override=none, include=[], exclude=[], source_column_name='_dbt_source_relation', where=none) -%}
+{%- macro default__union_relations(relations, column_override=none, include=[], exclude=[], source_column_name='_dbt_source_relation', where=none, dedupe=false) -%}
 
     {%- if exclude and include -%}
         {{ exceptions.raise_compiler_error("Both an exclude and include list were provided to the `union` macro. Only one is allowed") }}
@@ -120,7 +120,11 @@
         )
 
         {% if not loop.last -%}
-            union all
+            {% if dedupe %}
+                union
+            {% else %}
+                union all
+            {% endif %}
         {% endif -%}
 
     {%- endfor -%}

--- a/macros/sql/union.sql
+++ b/macros/sql/union.sql
@@ -121,7 +121,7 @@
 
         {% if not loop.last -%}
             {% if dedupe %}
-                union
+                union distinct
             {% else %}
                 union all
             {% endif %}


### PR DESCRIPTION
resolves #816 

This is a:
- [ ] documentation update
- [ ] bug fix with no breaking changes
- [X] new functionality
- [ ] a breaking change

All pull requests from community contributors should target the `main` branch (default).

## Description & motivation
The current implementation of `union_relations()` performs a `UNION ALL` which does not de-duplicate rows #760. Changing the `UNION ALL` to a `UNION DISTINCT` would perform this deduplication smoothly and it makes sense to support the operation.

## Checklist
- [X] This code is associated with an Issue which has been triaged (https://docs.getdbt.com/docs/contributing/oss-expectations#pull-requests). 
- [X] I have verified that these changes work locally on the following warehouses (Note: it's okay if you do not have access to all warehouses, this helps us understand what has been covered)
    - [ ] BigQuery
    - [X] Postgres
    - [ ] Redshift
    - [ ] Snowflake
- [X] I followed guidelines to ensure that my changes will work on "non-core" adapters by:
    - [X] dispatching any new macro(s) so non-core adapters can also use them (e.g. [the `star()` source](https://github.com/dbt-labs/dbt-utils/blob/main/macros/sql/star.sql))
    - [X] using the `limit_zero()` macro in place of the literal string: `limit 0`
    - [X] using `dbt.type_*` macros instead of explicit datatypes (e.g. `dbt.type_timestamp()` instead of `TIMESTAMP`
- [X] I have updated the README.md (if applicable)
- [X] I have added tests & descriptions to my models (and macros if applicable)
- [X] I have added an entry to CHANGELOG.md
