### PR TITLE
Update version on dbt_project

### DIFF
--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -1,5 +1,5 @@
 name: 'dbt_utils'
-version: '0.1.0'
+version: '1.1.1'
 
 require-dbt-version: [">=1.3.0", "<2.0.0"]
 


### PR DESCRIPTION
Version on dbt_project is not up to date with the real version 1.1.1

resolves #

This is a:
- [] documentation update
- [x] bug fix with no breaking changes
- [ ] new functionality
- [ ] a breaking change

All pull requests from community contributors should target the `main` branch (default).

## Description & motivation
<!---
I´ve developed a script that relies on the version of dbt_project.yml which is not up to date. This PR is addresing that issue so my script works fine.
-->

## Checklist
- [ ] This code is associated with an Issue which has been triaged and [accepted for development](https://docs.getdbt.com/docs/contributing/oss-expectations#pull-requests). 
- [x] I have verified that these changes work locally on the following warehouses (Note: it's okay if you do not have access to all warehouses, this helps us understand what has been covered)
    - [x ] BigQuery
    - [ x] Postgres
    - [ x] Redshift
    - [ x] Snowflake
- [ x] I followed guidelines to ensure that my changes will work on "non-core" adapters by:
    - [ x] dispatching any new macro(s) so non-core adapters can also use them (e.g. [the `star()` source](https://github.com/dbt-labs/dbt-utils/blob/main/macros/sql/star.sql))
    - [ ] using the `limit_zero()` macro in place of the literal string: `limit 0`
    - [ ] using `dbt.type_*` macros instead of explicit datatypes (e.g. `dbt.type_timestamp()` instead of `TIMESTAMP`
- [ ] I have updated the README.md (if applicable)
- [ ] I have added tests & descriptions to my models (and macros if applicable)
- [ ] I have added an entry to CHANGELOG.md
