### PR TITLE
Equality exclude columns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@
 --->
 
 # Unreleased
+
+## Enhancements
+- Added an optional `exclude_columns` to the `equality` test. ([#828](https://github.com/dbt-labs/dbt-utils/issues/828))
+
 ## Fixes
 - deduplicate macro for Databricks now uses the QUALIFY clause, which fixes NULL columns issues from the default natural join logic
 - deduplicate macro for Redshift now uses the QUALIFY clause, which fixes NULL columns issues from the default natural join logic

--- a/README.md
+++ b/README.md
@@ -146,6 +146,8 @@ With `exclude_columns`:
             - fourth_column
 ```
 
+**Note:** The exclude columns are case-insensitive.
+
 
 ### expression_is_true ([source](macros/generic_tests/expression_is_true.sql))
 

--- a/README.md
+++ b/README.md
@@ -114,15 +114,20 @@ This test supports the `group_by_columns` parameter; see [Grouping in tests](#gr
 
 ### equality ([source](macros/generic_tests/equality.sql))
 
-Asserts the equality of two relations. Optionally specify a subset of columns to compare.
+Asserts the equality of two relations. Optionally specify a subset of columns to compare or to exclude.
 
 **Usage:**
 
 ```yaml
-version: 2
-
 models:
   - name: model_name
+    tests:
+      - dbt_utils.equality:
+          compare_model: ref('other_table_name')
+```
+
+With `compare_columns`:
+```yaml
     tests:
       - dbt_utils.equality:
           compare_model: ref('other_table_name')
@@ -130,6 +135,17 @@ models:
             - first_column
             - second_column
 ```
+
+With `exclude_columns`:
+```yaml
+    tests:
+      - dbt_utils.equality:
+          compare_model: ref('other_table_name')
+          exclude_columns:
+            - third_column
+            - fourth_column
+```
+
 
 ### expression_is_true ([source](macros/generic_tests/expression_is_true.sql))
 

--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ models:
           compare_model: ref('other_table_name')
 ```
 
-With `compare_columns`:
+**With `compare_columns` (optional):**
 ```yaml
     tests:
       - dbt_utils.equality:
@@ -136,7 +136,16 @@ With `compare_columns`:
             - second_column
 ```
 
-With `exclude_columns`:
+*Note:* The compare columns are case-insensitive (input uppercase or lowercase and it will work!).
+If your adapter is Snowflake and the columns of your model are quoted (bad idea!), you should quote the compare columns like so:
+```yaml
+          compare_columns:
+            - '"first_column"'
+            - '"second_column"'
+```
+
+
+**With `exclude_columns` (optional):**
 ```yaml
     tests:
       - dbt_utils.equality:
@@ -146,7 +155,7 @@ With `exclude_columns`:
             - fourth_column
 ```
 
-**Note:** The exclude columns are case-insensitive.
+*Note:* The exclude columns are case-insensitive (input uppercase or lowercase and it will work!).
 
 
 ### expression_is_true ([source](macros/generic_tests/expression_is_true.sql))

--- a/integration_tests/models/generic_tests/schema.yml
+++ b/integration_tests/models/generic_tests/schema.yml
@@ -192,6 +192,14 @@ models:
             - last_name
             - email
 
+  - name: test_equal_column_exclude
+    tests:
+      - dbt_utils.equality:
+          compare_model: ref('data_people')
+          exclude_columns:
+            - first_name
+            - last_name
+
   - name: test_fewer_rows_than
     tests:
       - dbt_utils.fewer_rows_than:

--- a/integration_tests/models/generic_tests/test_equal_column_exclude.sql
+++ b/integration_tests/models/generic_tests/test_equal_column_exclude.sql
@@ -1,0 +1,13 @@
+{{ config(materialized='table') }}
+
+select
+
+  id,
+  'incorrect_name' as first_name,
+  last_name,
+  email,
+  ip_address,
+  created_at,
+  is_active
+
+from {{ ref('data_people') }}

--- a/macros/generic_tests/equality.sql
+++ b/macros/generic_tests/equality.sql
@@ -33,10 +33,16 @@ information schema — this allows the model to be an ephemeral model
 {%- endif -%}
 
 {%- if exclude_columns -%}
-    {%- set compare_columns = compare_columns | reject('in', exclude_columns) | list -%}
+    {%- set final_columns = [] -%}
+    {%- for column_name in compare_columns -%}
+        {%- if column_name | lower not in exclude_columns | map('lower') -%}
+            {%- do final_columns.append(column_name) -%}
+        {%- endif -%}
+    {%- endfor -%}
+    {%- set compare_columns = final_columns -%}
 {%- endif -%}
 
-{% set compare_cols_csv = compare_columns | join(', ') %}
+{% set compare_cols_csv = get_quoted_csv(compare_columns) %}
 
 with a as (
 

--- a/macros/generic_tests/equality.sql
+++ b/macros/generic_tests/equality.sql
@@ -1,8 +1,8 @@
-{% test equality(model, compare_model, compare_columns=None) %}
-  {{ return(adapter.dispatch('test_equality', 'dbt_utils')(model, compare_model, compare_columns)) }}
+{% test equality(model, compare_model, compare_columns=None, exclude_columns=None) %}
+  {{ return(adapter.dispatch('test_equality', 'dbt_utils')(model, compare_model, compare_columns, exclude_columns)) }}
 {% endtest %}
 
-{% macro default__test_equality(model, compare_model, compare_columns=None) %}
+{% macro default__test_equality(model, compare_model, compare_columns=None, exclude_columns=None) %}
 
 {% set set_diff %}
     count(*) + coalesce(abs(
@@ -29,7 +29,11 @@ information schema — this allows the model to be an ephemeral model
 
 {%- if not compare_columns -%}
     {%- do dbt_utils._is_ephemeral(model, 'test_equality') -%}
-    {%- set compare_columns = adapter.get_columns_in_relation(model) | map(attribute='quoted') -%}
+    {%- set compare_columns = adapter.get_columns_in_relation(model) | map(attribute='name') | list -%}
+{%- endif -%}
+
+{%- if exclude_columns -%}
+    {%- set compare_columns = compare_columns | reject('in', exclude_columns) | list -%}
 {%- endif -%}
 
 {% set compare_cols_csv = compare_columns | join(', ') %}


### PR DESCRIPTION
resolves #828 

This is a:
- [ ] documentation update
- [ ] bug fix with no breaking changes
- [x] new functionality
- [ ] a breaking change

All pull requests from community contributors should target the `main` branch (default).

## Description & motivation

This PR adds an optional `exclude_columns` to the `equality` test (similar to `compare_columns`).


## Checklist
- [ ] This code is associated with an Issue which has been triaged and [accepted for development](https://docs.getdbt.com/docs/contributing/oss-expectations#pull-requests). 
- [x] I have verified that these changes work locally on the following warehouses (Note: it's okay if you do not have access to all warehouses, this helps us understand what has been covered)
    - [ ] BigQuery
    - [x] Postgres
    - [ ] Redshift
    - [x] Snowflake
- [x] I followed guidelines to ensure that my changes will work on "non-core" adapters by:
    - [ ] dispatching any new macro(s) so non-core adapters can also use them (e.g. [the `star()` source](https://github.com/dbt-labs/dbt-utils/blob/main/macros/sql/star.sql))
    - [ ] using the `limit_zero()` macro in place of the literal string: `limit 0`
    - [ ] using `dbt.type_*` macros instead of explicit datatypes (e.g. `dbt.type_timestamp()` instead of `TIMESTAMP`
- [x] I have updated the README.md (if applicable)
- [x] I have added tests & descriptions to my models (and macros if applicable)
- [x] I have added an entry to CHANGELOG.md
