### PR TITLE
Output '*' in union_relations when no columns are found in compile mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,10 +12,12 @@
 ## Fixes
 - deduplicate macro for Databricks now uses the QUALIFY clause, which fixes NULL columns issues from the default natural join logic
 - deduplicate macro for Redshift now uses the QUALIFY clause, which fixes NULL columns issues from the default natural join logic
+- union_relations macro outputs '*' in compile mode when the upstream relations haven't been built, such as when running SQLFluff on new models
 
 ## Contributors:
 [@graciegoheen](https://github.com/graciegoheen)
 [@yauhen-sobaleu](https://github.com/yauhen-sobaleu)
+[@martinshjung](https://github.com/martinshjung)
 
 # dbt utils v1.1.1
 ## New features

--- a/macros/sql/union.sql
+++ b/macros/sql/union.sql
@@ -103,6 +103,12 @@
                 cast({{ dbt.string_literal(relation) }} as {{ dbt.type_string() }}) as {{ source_column_name }},
                 {%- endif %}
 
+                /* No columns from any of the relations.
+                   This star is only output during dbt compile, and exists to keep SQLFluff happy. */
+                {% if dbt_command == 'compile' and ordered_column_names|length == 0 %}
+                    *
+                {% endif %}
+
                 {% for col_name in ordered_column_names -%}
 
                     {%- set col = column_superset[col_name] %}


### PR DESCRIPTION
This is to handle the scenario with the `union_relations` macro where the upstream relations haven't been run, and you run SQLFluff against a model using it, with `source_column_name=None`. Currently the macro outputs nothing after the SELECT statement, resulting in parsing errors with SQLFluff.

Resolves https://github.com/dbt-labs/dbt-utils/issues/831.

This is a:
- [ ] documentation update
- [x] bug fix with no breaking changes
- [ ] new functionality
- [ ] a breaking change

All pull requests from community contributors should target the `main` branch (default).

## Description & motivation
<!---
Describe your changes, and why you're making them.
-->

As described in https://github.com/dbt-labs/dbt-utils/issues/831, I want to be able to run SQLFluff against models that use `union_relation`, where their upstream dbt models haven't been built yet, without getting a parser error. This is useful in development/CI workflows, where you want to run linting against newly created models without building them first.

This is essentially the same fix as with the `star` macro.

## Checklist
- [ ] This code is associated with an Issue which has been triaged and [accepted for development](https://docs.getdbt.com/docs/contributing/oss-expectations#pull-requests). 
- [x] I have verified that these changes work locally on the following warehouses (Note: it's okay if you do not have access to all warehouses, this helps us understand what has been covered)
    - [x] BigQuery
    - [ ] Postgres
    - [ ] Redshift
    - [ ] Snowflake
- [ ] I followed guidelines to ensure that my changes will work on "non-core" adapters by:
    - [ ] dispatching any new macro(s) so non-core adapters can also use them (e.g. [the `star()` source](https://github.com/dbt-labs/dbt-utils/blob/main/macros/sql/star.sql))
    - [ ] using the `limit_zero()` macro in place of the literal string: `limit 0`
    - [ ] using `dbt.type_*` macros instead of explicit datatypes (e.g. `dbt.type_timestamp()` instead of `TIMESTAMP`
- [ ] I have updated the README.md (if applicable)
- [ ] I have added tests & descriptions to my models (and macros if applicable)
- [x] I have added an entry to CHANGELOG.md
