### PR TITLE
Add comment on using `EXCLUDE`/`EXCEPT` instead of the `star` macro in Snowflake and BigQuery

### DIFF
--- a/README.md
+++ b/README.md
@@ -944,6 +944,8 @@ group by 1,2,3
 
 ### star ([source](macros/sql/star.sql))
 
+💡 In [Snowflake](https://docs.snowflake.com/en/sql-reference/sql/select) you can use the `EXCLUDE` keyword and in [BigQuery](https://cloud.google.com/bigquery/docs/reference/standard-sql/query-syntax#select_except) you have the `EXCEPT` keyword to exclude columns from a `SELECT *` statement. This macro is not needed in those databases.
+
 This macro generates a comma-separated list of all fields that exist in the `from` relation, excluding any fields
 listed in the `except` argument. The construction is identical to `select * from {{ref('my_model')}}`, replacing star (`*`) with
 the star macro.


### PR DESCRIPTION
This is a:
- [x] documentation update
- [ ] bug fix with no breaking changes
- [ ] new functionality
- [ ] a breaking change

All pull requests from community contributors should target the `main` branch (default).

## Description & motivation
<!---
Describe your changes, and why you're making them.
-->

Snowflake and BigQuery have the EXCLUDE and EXCEPT keywords to exclude columns from `SELECT *` statement. This PR adds this as a  comment to the `star` macro docs in README to encourage users to use those built-in SQL functionalities instead of the `star` macro.

## Checklist
- [ ] This code is associated with an Issue which has been triaged and [accepted for development](https://docs.getdbt.com/docs/contributing/oss-expectations#pull-requests). 
- [ ] I have verified that these changes work locally on the following warehouses (Note: it's okay if you do not have access to all warehouses, this helps us understand what has been covered)
    - [ ] BigQuery
    - [ ] Postgres
    - [ ] Redshift
    - [ ] Snowflake
- [ ] I followed guidelines to ensure that my changes will work on "non-core" adapters by:
    - [ ] dispatching any new macro(s) so non-core adapters can also use them (e.g. [the `star()` source](https://github.com/dbt-labs/dbt-utils/blob/main/macros/sql/star.sql))
    - [ ] using the `limit_zero()` macro in place of the literal string: `limit 0`
    - [ ] using `dbt.type_*` macros instead of explicit datatypes (e.g. `dbt.type_timestamp()` instead of `TIMESTAMP`
- [x] I have updated the README.md (if applicable)
- [ ] I have added tests & descriptions to my models (and macros if applicable)
- [ ] I have added an entry to CHANGELOG.md
