### PR TITLE
Fix for #848 (not_constant fails within groups with 1 element)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 * Improve the performance of the `at_least_one` test by pruning early. This is especially helpful when running against external tables. By @joshuahuntley in https://github.com/dbt-labs/dbt-utils/pull/775
 ## Fixes
 * Fix legacy links in README by @dbeatty10 in https://github.com/dbt-labs/dbt-utils/pull/796
+* Fixed false positive in not_constant test when using groupings and a grouping has only one row by @igor-lobanov-maersk https://github.com/dbt-labs/dbt-utils/issues/848
 
 # dbt utils v1.1.0
 ## What's Changed

--- a/macros/generic_tests/not_constant.sql
+++ b/macros/generic_tests/not_constant.sql
@@ -22,6 +22,6 @@ from {{ model }}
   {{groupby_gb_cols}}
 
 having count(distinct {{ column_name }}) = 1
-
+  and count(1) > 1
 
 {% endmacro %}


### PR DESCRIPTION
resolves #848

This is a:
- [ ] documentation update
- [x] bug fix with no breaking changes
- [ ] new functionality
- [ ] a breaking change

All pull requests from community contributors should target the `main` branch (default).

## Description & motivation
As described in the bug report for #848, not_constant generic test fails when grouping is used and one of the groups has only one element. The implementation considers the value of this one element constant and fails the test. Whilst such interpretation is technically correct, the context where such test is used a different interpretation arguably would be preferable. I provided additional details in the bug report.

## Checklist
- [ ] This code is associated with an Issue which has been triaged and [accepted for development](https://docs.getdbt.com/docs/contributing/oss-expectations#pull-requests). **Not really, I just filed a bug report, but found it's trivial to fix**
- [ ] I have verified that these changes work locally on the following warehouses (Note: it's okay if you do not have access to all warehouses, this helps us understand what has been covered) **I only have access to Dremio environment, and I tested it there**
    - [ ] BigQuery
    - [ ] Postgres
    - [ ] Redshift
    - [ ] Snowflake
- [ ] I followed guidelines to ensure that my changes will work on "non-core" adapters by:
    - [ ] dispatching any new macro(s) so non-core adapters can also use them (e.g. [the `star()` source](https://github.com/dbt-labs/dbt-utils/blob/main/macros/sql/star.sql)) **N/A**
    - [ ] using the `limit_zero()` macro in place of the literal string: `limit 0` **N/A**
    - [ ] using `dbt.type_*` macros instead of explicit datatypes (e.g. `dbt.type_timestamp()` instead of `TIMESTAMP` **N/A**
- [ ] I have updated the README.md (if applicable) **N/A**
- [ ] I have added tests & descriptions to my models (and macros if applicable) **No, see below**
- [x] I have added an entry to CHANGELOG.md

I did not add a test, because it's not clear to me how such tests are written. There is no prior test for not_constant macro to extend. That said, I'm happy to write one with some guidance from the core team.
