### PR TITLE
Typo of `not_null_proportion` in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -607,7 +607,7 @@ This feature is currently available for the following tests:
 - at_least_one()
 - not_constant()
 - sequential_values()
-- non_null_proportion()
+- not_null_proportion()
 
 To use this feature, the names of grouping variables can be passed as a list. For example, to test for at least one valid value by group, the `group_by_columns` argument could be used as follows:
 


### PR DESCRIPTION
This is a:
- [x] documentation update

## Description & motivation
I was looking if `not_null_proportion` supported grouping and noticed this inconsistency in the README which confused me about which was the correct spelling. It is a small change, but hopefully avoids confusion for people looking at it in the future.

## Checklist
- [ ] This code is associated with an Issue which has been triaged and [accepted for development](https://docs.getdbt.com/docs/contributing/oss-expectations#pull-requests). 
- [ ] I have verified that these changes work locally on the following warehouses (Note: it's okay if you do not have access to all warehouses, this helps us understand what has been covered)
    - [ ] BigQuery
    - [ ] Postgres
    - [ ] Redshift
    - [ ] Snowflake
- [ ] I followed guidelines to ensure that my changes will work on "non-core" adapters by:
    - [ ] dispatching any new macro(s) so non-core adapters can also use them (e.g. [the `star()` source](https://github.com/dbt-labs/dbt-utils/blob/main/macros/sql/star.sql))
    - [ ] using the `limit_zero()` macro in place of the literal string: `limit 0`
    - [ ] using `dbt.type_*` macros instead of explicit datatypes (e.g. `dbt.type_timestamp()` instead of `TIMESTAMP`
- [x] I have updated the README.md (if applicable)
- [ ] I have added tests & descriptions to my models (and macros if applicable)
- [ ] I have added an entry to CHANGELOG.md

