### PR TITLE
FIX: Failing example for dbt_utils.deduplicate() in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -892,7 +892,7 @@ with my_cte as (
 deduplicated_cte as (
   {{ dbt_utils.deduplicate(
       relation='my_cte',
-      partition_by='user_id, cast(timestamp as day)',
+      partition_by='user_id, cast(timestamp as date)',
       order_by='timestamp desc',
      )
   }}

--- a/README.md
+++ b/README.md
@@ -888,14 +888,16 @@ with my_cte as (
     select *
     from {{ source('my_source', 'my_table') }}
     where user_id = 1
+),
+deduplicated_cte as (
+  {{ dbt_utils.deduplicate(
+      relation='my_cte',
+      partition_by='user_id, cast(timestamp as day)',
+      order_by='timestamp desc',
+     )
+  }}
 )
-
-{{ dbt_utils.deduplicate(
-    relation='my_cte',
-    partition_by='user_id, cast(timestamp as day)',
-    order_by='timestamp desc',
-   )
-}}
+select * from deduplicated_cte
 ```
 
 ### haversine_distance ([source](macros/sql/haversine_distance.sql))


### PR DESCRIPTION
resolves #

This is a:
- [x] documentation update
- [ ] bug fix with no breaking changes
- [ ] new functionality
- [ ] a breaking change

All pull requests from community contributors should target the `main` branch (default).

## Description & motivation
<!---
Currently, the third example of dbt_utils.deduplicate fails due to a second WITH statement. The example can easily be adapted to create a second CTE.
-->

## Checklist
- [ ] This code is associated with an Issue which has been triaged and [accepted for development](https://docs.getdbt.com/docs/contributing/oss-expectations#pull-requests). 
- [ ] I have verified that these changes work locally on the following warehouses (Note: it's okay if you do not have access to all warehouses, this helps us understand what has been covered)
    - [ ] BigQuery
    - [ ] Postgres
    - [ ] Redshift
    - [ ] Snowflake
- [ ] I followed guidelines to ensure that my changes will work on "non-core" adapters by:
    - [ ] dispatching any new macro(s) so non-core adapters can also use them (e.g. [the `star()` source](https://github.com/dbt-labs/dbt-utils/blob/main/macros/sql/star.sql))
    - [ ] using the `limit_zero()` macro in place of the literal string: `limit 0`
    - [ ] using `dbt.type_*` macros instead of explicit datatypes (e.g. `dbt.type_timestamp()` instead of `TIMESTAMP`
- [x] I have updated the README.md (if applicable)
- [ ] I have added tests & descriptions to my models (and macros if applicable)
- [ ] I have added an entry to CHANGELOG.md
