### PR TITLE
make column name to be fully qualified to prevent BQ confusion

### DIFF
--- a/macros/sql/union.sql
+++ b/macros/sql/union.sql
@@ -107,7 +107,8 @@
 
                     {%- set col = column_superset[col_name] %}
                     {%- set col_type = column_override.get(col.column, col.data_type) %}
-                    {%- set col_name = adapter.quote(col_name) if col_name in relation_columns[relation] else 'null' %}
+                    {%- set column_exists = col_name in relation_columns[relation] %}
+                    {%- set col_name = adapter.quote(table.name) ~ '.' ~ adapter.quote(col_name) if column_exists else 'null' %}
                     cast({{ col_name }} as {{ col_type }}) as {{ col.quoted }} {% if not loop.last %},{% endif -%}
 
                 {%- endfor %}


### PR DESCRIPTION
resolves #173 

This is a:
- [ ] documentation update
- [x] bug fix with no breaking changes
- [ ] new functionality
- [ ] a breaking change

All pull requests from community contributors should target the `main` branch (default).

## Description & motivation
For better support for an edge case in Bigquery, which gets confused by casting a column with the same name as its table name. 

## Checklist
- [x] This code is associated with an Issue that has been triaged and [accepted for development](https://docs.getdbt.com/docs/contributing/oss-expectations#pull-requests). 
- [x] I have verified that these changes work locally on the following warehouses (Note: it's okay if you do not have access to all warehouses, this helps us understand what has been covered)
    - [x] BigQuery
    - [ ] Postgres
    - [ ] Redshift
    - [ ] Snowflake
- [x] I followed guidelines to ensure that my changes will work on "non-core" adapters by:
    - [x] dispatching any new macro(s) so non-core adapters can also use them (e.g. [the `star()` source](https://github.com/dbt-labs/dbt-utils/blob/main/macros/sql/star.sql))
    - [x] using the `limit_zero()` macro in place of the literal string: `limit 0`
    - [x] using `dbt.type_*` macros instead of explicit datatypes (e.g. `dbt.type_timestamp()` instead of `TIMESTAMP`
- [x] I have updated the README.md (if applicable)
- [x] I have added tests & descriptions to my models (and macros if applicable)
- [x] I have added an entry to CHANGELOG.md
