### PR TITLE
Update dev-requirements for new pip syntax

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,9 +1,9 @@
 pytest
 pytest-dotenv
-git+https://github.com/dbt-labs/dbt-core.git#egg=dbt-core&subdirectory=core
-git+https://github.com/dbt-labs/dbt-core.git#egg=dbt-tests-adapter&subdirectory=tests/adapter
-git+https://github.com/dbt-labs/dbt-core.git#egg=dbt-postgres&subdirectory=plugins/postgres
-git+https://github.com/dbt-labs/dbt-redshift.git
-git+https://github.com/dbt-labs/dbt-snowflake.git
-git+https://github.com/dbt-labs/dbt-bigquery.git
+dbt-core@git+https://github.com/dbt-labs/dbt-core.git#subdirectory=core
+dbt-tests-adapter@git+https://github.com/dbt-labs/dbt-adapters.git#subdirectory=dbt-tests-adapter
+dbt-postgres@git+https://github.com/dbt-labs/dbt-postgres.git
+dbt-redshift@git+https://github.com/dbt-labs/dbt-redshift.git
+dbt-snowflake@git+https://github.com/dbt-labs/dbt-snowflake.git
+dbt-bigquery@git+https://github.com/dbt-labs/dbt-bigquery.git
 pytest-xdist

--- a/integration_tests/package-lock.yml
+++ b/integration_tests/package-lock.yml
@@ -1,0 +1,3 @@
+packages:
+- local: ../
+sha1_hash: de2deba3d66ce03d8c02949013650cc9b94f6030


### PR DESCRIPTION
Our CI is broken because pip syntax has changed for direct git references of packages

This is a:
- [ ] documentation update
- [x] bug fix with no breaking changes
- [ ] new functionality
- [ ] a breaking change

All pull requests from community contributors should target the `main` branch (default).

## Description & motivation
We want the package to work.

## Checklist
- [ ] This code is associated with an Issue which has been triaged and [accepted for development](https://docs.getdbt.com/docs/contributing/oss-expectations#pull-requests). 
- [x] I have verified that these changes work locally on the following warehouses (Note: it's okay if you do not have access to all warehouses, this helps us understand what has been covered)
    - [ ] BigQuery
    - [x] Postgres
    - [ ] Redshift
    - [ ] Snowflake
- [ ] I followed guidelines to ensure that my changes will work on "non-core" adapters by:
    - [ ] dispatching any new macro(s) so non-core adapters can also use them (e.g. [the `star()` source](https://github.com/dbt-labs/dbt-utils/blob/main/macros/sql/star.sql))
    - [ ] using the `limit_zero()` macro in place of the literal string: `limit 0`
    - [ ] using `dbt.type_*` macros instead of explicit datatypes (e.g. `dbt.type_timestamp()` instead of `TIMESTAMP`
- [ ] I have updated the README.md (if applicable)
- [ ] I have added tests & descriptions to my models (and macros if applicable)
- [ ] I have added an entry to CHANGELOG.md
