### PR TITLE
update tests: -> data_tests:

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ version: 2
 
 models:
   - name: model_name
-    tests:
+    data_tests:
       - dbt_utils.equal_rowcount:
           compare_model: ref('other_table_name')
 
@@ -105,7 +105,7 @@ version: 2
 
 models:
   - name: model_name
-    tests:
+    data_tests:
       - dbt_utils.fewer_rows_than:
           compare_model: ref('other_table_name')
 ```
@@ -124,13 +124,13 @@ version: 2
 models:
   # compare the entire table 
   - name: model_name
-    tests:
+    data_tests:
       - dbt_utils.equality:
           compare_model: ref('other_table_name')
 
   # only compare some of the columns
   - name: model_name_compare_columns
-    tests:
+    data_tests:
       - dbt_utils.equality:
           compare_model: ref('other_table_name')
           compare_columns:
@@ -140,7 +140,7 @@ models:
 
   # compare all columns except the ones on the ignore list
   - name: model_name_exclude_columns
-    tests:
+    data_tests:
       - dbt_utils.equality:
           compare_model: ref('other_table_name')
           exclude_columns:
@@ -163,7 +163,7 @@ version: 2
 
 models:
   - name: model_name
-    tests:
+    data_tests:
       - dbt_utils.expression_is_true:
           expression: "col_a + col_b = total"
 ```
@@ -178,7 +178,7 @@ version: 2
 
 models:
   - name: model_name
-    tests:
+    data_tests:
       - dbt_utils.expression_is_true:
           expression: "col_a + col_b = total"
           config:
@@ -191,11 +191,11 @@ models:
   - name: model_name
     columns:
       - name: col_a
-        tests:
+        data_tests:
           - dbt_utils.expression_is_true:
               expression: '>= 1'
       - name: col_b
-        tests:
+        data_tests:
           - dbt_utils.expression_is_true:
               expression: '= 1'
               config:
@@ -213,7 +213,7 @@ version: 2
 
 models:
   - name: model_name
-    tests:
+    data_tests:
       - dbt_utils.recency:
           datepart: day
           field: created_at
@@ -234,7 +234,7 @@ models:
   - name: model_name
     columns:
       - name: col_name
-        tests:
+        data_tests:
           - dbt_utils.at_least_one
 ```
 
@@ -253,7 +253,7 @@ models:
   - name: model_name
     columns:
       - name: column_name
-        tests:
+        data_tests:
           - dbt_utils.not_constant
 ```
 
@@ -270,7 +270,7 @@ models:
   - name: model_name
     columns:
       - name: column_name
-        tests:
+        data_tests:
           - dbt_utils.not_empty_string
 ```
 
@@ -284,7 +284,7 @@ models:
   - name: model_name
     columns:
       - name: column_name
-        tests:
+        data_tests:
           - dbt_utils.not_empty_string:
               trim_whitespace: false
               
@@ -303,7 +303,7 @@ models:
   - name: model_name
     columns:
       - name: from_column
-        tests:
+        data_tests:
           - dbt_utils.cardinality_equality:
               field: other_column_name
               to: ref('other_model_name')
@@ -323,7 +323,7 @@ models:
   - name: my_model
     columns:
       - name: id
-        tests:
+        data_tests:
           - dbt_utils.not_null_proportion:
               at_least: 0.95
 ```
@@ -343,7 +343,7 @@ models:
   - name: my_model
     columns:
       - name: city
-        tests:
+        data_tests:
           - dbt_utils.not_accepted_values:
               values: ['Barcelona', 'New York']
 ```
@@ -361,7 +361,7 @@ models:
   - name: model_name
     columns:
       - name: id
-        tests:
+        data_tests:
           - dbt_utils.relationships_where:
               to: ref('other_model_name')
               field: client_id
@@ -383,7 +383,7 @@ version: 2
 models:
   # test that age ranges do not overlap
   - name: age_brackets
-    tests:
+    data_tests:
       - dbt_utils.mutually_exclusive_ranges:
           lower_bound_column: min_age
           upper_bound_column: max_age
@@ -391,7 +391,7 @@ models:
 
   # test that each customer can only have one subscription at a time
   - name: subscriptions
-    tests:
+    data_tests:
       - dbt_utils.mutually_exclusive_ranges:
           lower_bound_column: started_at
           upper_bound_column: ended_at
@@ -400,7 +400,7 @@ models:
 
   # test that each customer can have subscriptions that start and end on the same date
   - name: subscriptions
-    tests:
+    data_tests:
       - dbt_utils.mutually_exclusive_ranges:
           lower_bound_column: started_at
           upper_bound_column: ended_at
@@ -431,7 +431,7 @@ version: 2
 
 models:
   - name: subscriptions
-    tests:
+    data_tests:
       - dbt_utils.mutually_exclusive_ranges:
           lower_bound_column: coalesce(started_at, '1900-01-01')
           upper_bound_column: coalesce(ended_at, '2099-12-31')
@@ -505,7 +505,7 @@ seeds:
   - name: util_even_numbers
     columns:
       - name: i
-        tests:
+        data_tests:
           - dbt_utils.sequential_values:
               interval: 2
 
@@ -513,7 +513,7 @@ seeds:
   - name: util_hours
     columns:
       - name: date_hour
-        tests:
+        data_tests:
           - dbt_utils.sequential_values:
               interval: 1
               datepart: 'hour'
@@ -545,7 +545,7 @@ case we recommend using this test instead.
 
 ```yaml
 - name: revenue_by_product_by_month
-  tests:
+  data_tests:
     - dbt_utils.unique_combination_of_columns:
         combination_of_columns:
           - month
@@ -556,7 +556,7 @@ An optional `quote_columns` argument (`default=false`) can also be used if a col
 
 ```yaml
 - name: revenue_by_product_by_month
-  tests:
+  data_tests:
     - dbt_utils.unique_combination_of_columns:
         combination_of_columns:
           - month
@@ -580,25 +580,25 @@ models:
   - name: model_name
     columns:
       - name: user_id
-        tests:
+        data_tests:
           - dbt_utils.accepted_range:
               min_value: 0
               inclusive: false
 
       - name: account_created_at
-        tests:
+        data_tests:
           - dbt_utils.accepted_range:
               max_value: "getdate()"
               #inclusive is true by default
 
       - name: num_returned_orders
-        tests:
+        data_tests:
           - dbt_utils.accepted_range:
               min_value: 0
               max_value: "num_orders"
 
       - name: num_web_sessions
-        tests:
+        data_tests:
           - dbt_utils.accepted_range:
               min_value: 0
               inclusive: false
@@ -615,7 +615,7 @@ Certain tests support the optional `group_by_columns` argument to provide more g
 - Some data checks can only be expressed within a group (e.g. ID values should be unique within a group but can be repeated between groups)
 - Some data checks are more precise when done by group (e.g. not only should table rowcounts be equal but the counts within each group should be equal)
 
-This feature is currently available for the following tests:
+This feature is currently available for the following data tests:
 
 - equal_rowcount()
 - fewer_rows_than()
@@ -631,7 +631,7 @@ To use this feature, the names of grouping variables can be passed as a list. Fo
   - name: data_test_at_least_one
     columns:
       - name: field
-        tests:
+        data_tests:
           - dbt_utils.at_least_one:
               group_by_columns: ['customer_segment']
 ```

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ version: 2
 
 models:
   - name: model_name
-    data_tests:
+    tests:
       - dbt_utils.equal_rowcount:
           compare_model: ref('other_table_name')
 
@@ -105,7 +105,7 @@ version: 2
 
 models:
   - name: model_name
-    data_tests:
+    tests:
       - dbt_utils.fewer_rows_than:
           compare_model: ref('other_table_name')
 ```
@@ -124,13 +124,13 @@ version: 2
 models:
   # compare the entire table 
   - name: model_name
-    data_tests:
+    tests:
       - dbt_utils.equality:
           compare_model: ref('other_table_name')
 
   # only compare some of the columns
   - name: model_name_compare_columns
-    data_tests:
+    tests:
       - dbt_utils.equality:
           compare_model: ref('other_table_name')
           compare_columns:
@@ -140,7 +140,7 @@ models:
 
   # compare all columns except the ones on the ignore list
   - name: model_name_exclude_columns
-    data_tests:
+    tests:
       - dbt_utils.equality:
           compare_model: ref('other_table_name')
           exclude_columns:
@@ -163,7 +163,7 @@ version: 2
 
 models:
   - name: model_name
-    data_tests:
+    tests:
       - dbt_utils.expression_is_true:
           expression: "col_a + col_b = total"
 ```
@@ -178,7 +178,7 @@ version: 2
 
 models:
   - name: model_name
-    data_tests:
+    tests:
       - dbt_utils.expression_is_true:
           expression: "col_a + col_b = total"
           config:
@@ -191,11 +191,11 @@ models:
   - name: model_name
     columns:
       - name: col_a
-        data_tests:
+        tests:
           - dbt_utils.expression_is_true:
               expression: '>= 1'
       - name: col_b
-        data_tests:
+        tests:
           - dbt_utils.expression_is_true:
               expression: '= 1'
               config:
@@ -213,7 +213,7 @@ version: 2
 
 models:
   - name: model_name
-    data_tests:
+    tests:
       - dbt_utils.recency:
           datepart: day
           field: created_at
@@ -234,7 +234,7 @@ models:
   - name: model_name
     columns:
       - name: col_name
-        data_tests:
+        tests:
           - dbt_utils.at_least_one
 ```
 
@@ -253,7 +253,7 @@ models:
   - name: model_name
     columns:
       - name: column_name
-        data_tests:
+        tests:
           - dbt_utils.not_constant
 ```
 
@@ -270,7 +270,7 @@ models:
   - name: model_name
     columns:
       - name: column_name
-        data_tests:
+        tests:
           - dbt_utils.not_empty_string
 ```
 
@@ -284,7 +284,7 @@ models:
   - name: model_name
     columns:
       - name: column_name
-        data_tests:
+        tests:
           - dbt_utils.not_empty_string:
               trim_whitespace: false
               
@@ -303,7 +303,7 @@ models:
   - name: model_name
     columns:
       - name: from_column
-        data_tests:
+        tests:
           - dbt_utils.cardinality_equality:
               field: other_column_name
               to: ref('other_model_name')
@@ -323,7 +323,7 @@ models:
   - name: my_model
     columns:
       - name: id
-        data_tests:
+        tests:
           - dbt_utils.not_null_proportion:
               at_least: 0.95
 ```
@@ -343,7 +343,7 @@ models:
   - name: my_model
     columns:
       - name: city
-        data_tests:
+        tests:
           - dbt_utils.not_accepted_values:
               values: ['Barcelona', 'New York']
 ```
@@ -361,7 +361,7 @@ models:
   - name: model_name
     columns:
       - name: id
-        data_tests:
+        tests:
           - dbt_utils.relationships_where:
               to: ref('other_model_name')
               field: client_id
@@ -383,7 +383,7 @@ version: 2
 models:
   # test that age ranges do not overlap
   - name: age_brackets
-    data_tests:
+    tests:
       - dbt_utils.mutually_exclusive_ranges:
           lower_bound_column: min_age
           upper_bound_column: max_age
@@ -391,7 +391,7 @@ models:
 
   # test that each customer can only have one subscription at a time
   - name: subscriptions
-    data_tests:
+    tests:
       - dbt_utils.mutually_exclusive_ranges:
           lower_bound_column: started_at
           upper_bound_column: ended_at
@@ -400,7 +400,7 @@ models:
 
   # test that each customer can have subscriptions that start and end on the same date
   - name: subscriptions
-    data_tests:
+    tests:
       - dbt_utils.mutually_exclusive_ranges:
           lower_bound_column: started_at
           upper_bound_column: ended_at
@@ -431,7 +431,7 @@ version: 2
 
 models:
   - name: subscriptions
-    data_tests:
+    tests:
       - dbt_utils.mutually_exclusive_ranges:
           lower_bound_column: coalesce(started_at, '1900-01-01')
           upper_bound_column: coalesce(ended_at, '2099-12-31')
@@ -505,7 +505,7 @@ seeds:
   - name: util_even_numbers
     columns:
       - name: i
-        data_tests:
+        tests:
           - dbt_utils.sequential_values:
               interval: 2
 
@@ -513,7 +513,7 @@ seeds:
   - name: util_hours
     columns:
       - name: date_hour
-        data_tests:
+        tests:
           - dbt_utils.sequential_values:
               interval: 1
               datepart: 'hour'
@@ -545,7 +545,7 @@ case we recommend using this test instead.
 
 ```yaml
 - name: revenue_by_product_by_month
-  data_tests:
+  tests:
     - dbt_utils.unique_combination_of_columns:
         combination_of_columns:
           - month
@@ -556,7 +556,7 @@ An optional `quote_columns` argument (`default=false`) can also be used if a col
 
 ```yaml
 - name: revenue_by_product_by_month
-  data_tests:
+  tests:
     - dbt_utils.unique_combination_of_columns:
         combination_of_columns:
           - month
@@ -580,25 +580,25 @@ models:
   - name: model_name
     columns:
       - name: user_id
-        data_tests:
+        tests:
           - dbt_utils.accepted_range:
               min_value: 0
               inclusive: false
 
       - name: account_created_at
-        data_tests:
+        tests:
           - dbt_utils.accepted_range:
               max_value: "getdate()"
               #inclusive is true by default
 
       - name: num_returned_orders
-        data_tests:
+        tests:
           - dbt_utils.accepted_range:
               min_value: 0
               max_value: "num_orders"
 
       - name: num_web_sessions
-        data_tests:
+        tests:
           - dbt_utils.accepted_range:
               min_value: 0
               inclusive: false
@@ -631,7 +631,7 @@ To use this feature, the names of grouping variables can be passed as a list. Fo
   - name: data_test_at_least_one
     columns:
       - name: field
-        data_tests:
+        tests:
           - dbt_utils.at_least_one:
               group_by_columns: ['customer_segment']
 ```

--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -1,7 +1,7 @@
 name: 'dbt_utils'
 version: '0.1.0'
 
-require-dbt-version: [">=1.8.0", "<2.0.0"]
+require-dbt-version: [">=1.3.0", "<2.0.0"]
 
 config-version: 2
 

--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -1,7 +1,7 @@
 name: 'dbt_utils'
 version: '0.1.0'
 
-require-dbt-version: [">=1.3.0", "<2.0.0"]
+require-dbt-version: [">=1.8.0", "<2.0.0"]
 
 config-version: 2
 

--- a/integration_tests/data/schema_tests/schema.yml
+++ b/integration_tests/data/schema_tests/schema.yml
@@ -4,7 +4,7 @@ seeds:
   - name: data_test_sequential_values
     columns:
       - name: my_even_sequence
-        tests:
+        data_tests:
           - dbt_utils.sequential_values:
               interval: 2
           - dbt_utils.sequential_values:
@@ -15,7 +15,7 @@ seeds:
   - name: data_test_sequential_timestamps
     columns:
       - name: my_timestamp
-        tests:
+        data_tests:
           - dbt_utils.sequential_values:
               interval: 1
               datepart: 'hour'

--- a/integration_tests/models/datetime/schema.yml
+++ b/integration_tests/models/datetime/schema.yml
@@ -2,6 +2,6 @@ version: 2
 
 models:
   - name: test_date_spine
-    tests:
+    data_tests:
       - dbt_utils.equality:
           compare_model: ref('data_date_spine')

--- a/integration_tests/models/generic_tests/schema.yml
+++ b/integration_tests/models/generic_tests/schema.yml
@@ -4,7 +4,7 @@ seeds:
   - name: data_test_not_constant
     columns:
       - name: field
-        tests:
+        data_tests:
           - dbt_utils.not_constant
           - dbt_utils.not_constant:
               group_by_columns: ['col_a']
@@ -12,13 +12,13 @@ seeds:
   - name: data_test_at_least_one
     columns:
       - name: field
-        tests:
+        data_tests:
           - dbt_utils.at_least_one
           - dbt_utils.at_least_one:
               group_by_columns: ['field']
 
   - name: data_test_expression_is_true
-    tests:
+    data_tests:
       - dbt_utils.expression_is_true:
           expression: col_a + col_b = 1
       - dbt_utils.expression_is_true:
@@ -27,11 +27,11 @@ seeds:
             where: col_b = 0.5
     columns:
       - name: col_a
-        tests:
+        data_tests:
           - dbt_utils.expression_is_true:
               expression: + col_b = 1
       - name: col_b
-        tests:
+        data_tests:
           - dbt_utils.expression_is_true:
               expression: = 0.5
               config:
@@ -40,7 +40,7 @@ seeds:
   - name: data_people
     columns:
       - name: is_active
-        tests:
+        data_tests:
           - dbt_utils.cardinality_equality:
               field: is_active
               to: ref('data_people')
@@ -48,28 +48,28 @@ seeds:
   - name: data_test_not_accepted_values
     columns:
       - name: city
-        tests:
+        data_tests:
           - dbt_utils.not_accepted_values:
               values: ['Madrid', 'Berlin']
 
   - name: data_test_relationships_where_table_2
     columns:
       - name: id
-        tests:
+        data_tests:
           - dbt_utils.relationships_where:
               to: ref('data_test_relationships_where_table_1')
               field: id
               from_condition: id <> 4
 
   - name: data_test_mutually_exclusive_ranges_no_gaps
-    tests:
+    data_tests:
       - dbt_utils.mutually_exclusive_ranges:
           lower_bound_column: lower_bound
           upper_bound_column: upper_bound
           gaps: not_allowed
 
   - name: data_test_mutually_exclusive_ranges_with_gaps
-    tests:
+    data_tests:
       - dbt_utils.mutually_exclusive_ranges:
           lower_bound_column: valid_from
           upper_bound_column: coalesce(valid_to, '2099-01-01')
@@ -83,7 +83,7 @@ seeds:
           gaps: required
 
   - name: data_test_mutually_exclusive_ranges_with_gaps_zero_length
-    tests:
+    data_tests:
       - dbt_utils.mutually_exclusive_ranges:
           lower_bound_column: valid_from
           upper_bound_column: valid_to
@@ -91,7 +91,7 @@ seeds:
           zero_length_range_allowed: true
 
   - name: data_unique_combination_of_columns
-    tests:
+    data_tests:
       - dbt_utils.unique_combination_of_columns:
           combination_of_columns:
             - month
@@ -100,7 +100,7 @@ seeds:
   - name: data_cardinality_equality_a
     columns:
       - name: same_name
-        tests:
+        data_tests:
           - dbt_utils.cardinality_equality:
               to: ref('data_cardinality_equality_b')
               field: same_name
@@ -111,7 +111,7 @@ seeds:
   - name: data_test_accepted_range
     columns:
       - name: id
-        tests:
+        data_tests:
           - dbt_utils.accepted_range:
               min_value: -1
               max_value: 11
@@ -130,7 +130,7 @@ seeds:
   - name: data_not_null_proportion
     columns:
       - name: point_5
-        tests:
+        data_tests:
           - dbt_utils.not_null_proportion:
               at_least: 0.5
               at_most: 0.5
@@ -138,12 +138,12 @@ seeds:
               at_least: 0
               group_by_columns: ['point_9']
       - name: point_9
-        tests:
+        data_tests:
           - dbt_utils.not_null_proportion:
               at_least: 0.9
 
   - name: data_test_equality_a
-    tests:
+    data_tests:
       - dbt_utils.equality:
           compare_model: ref('data_test_equality_a')
       - dbt_utils.equality:
@@ -161,7 +161,7 @@ seeds:
             - col_c
 
   - name: data_test_equality_floats_a
-    tests:
+    data_tests:
       # test precision only
       - dbt_utils.equality:
           compare_model: ref('data_test_equality_floats_b')
@@ -173,7 +173,7 @@ seeds:
           warn_if: "<0"
 
   - name: data_test_equality_floats_columns_a
-    tests:
+    data_tests:
     # Positive assertion tests
       - dbt_utils.equality:
           compare_model: ref('data_test_equality_floats_columns_b')
@@ -195,7 +195,7 @@ seeds:
 
 models:
   - name: recency_time_included
-    tests:
+    data_tests:
       - dbt_utils.recency:
           datepart: day
           field: created_at
@@ -212,7 +212,7 @@ models:
           group_by_columns: ['col1', 'col2']
 
   - name: recency_time_excluded
-    tests:
+    data_tests:
       - dbt_utils.recency:
           datepart: day
           field: created_at
@@ -227,7 +227,7 @@ models:
           warn_if: "<0"
 
   - name: test_equal_rowcount
-    tests:
+    data_tests:
       - dbt_utils.equal_rowcount:
           compare_model: ref('test_equal_rowcount')
       - dbt_utils.equal_rowcount:
@@ -235,7 +235,7 @@ models:
           group_by_columns: ['field']
 
   - name: test_equal_column_subset
-    tests:
+    data_tests:
       - dbt_utils.equality:
           compare_model: ref('data_people')
           compare_columns:
@@ -244,7 +244,7 @@ models:
             - email
 
   - name: test_fewer_rows_than
-    tests:
+    data_tests:
       - dbt_utils.fewer_rows_than:
           compare_model: ref('data_test_fewer_rows_than_table_2')
       - dbt_utils.fewer_rows_than:
@@ -252,7 +252,7 @@ models:
           group_by_columns: ['col_a']
 
   - name: equality_less_columns
-    tests:
+    data_tests:
       - dbt_utils.equality:
           compare_model: ref('data_test_equality_a')
           exclude_columns:

--- a/integration_tests/models/geo/schema.yml
+++ b/integration_tests/models/geo/schema.yml
@@ -2,12 +2,12 @@ version: 2
 
 models:
   - name: test_haversine_distance_km
-    tests:
+    data_tests:
       - assert_equal:
           actual: actual
           expected: expected
   - name: test_haversine_distance_mi
-    tests:
+    data_tests:
       - assert_equal:
           actual: actual
           expected: expected

--- a/integration_tests/models/sql/schema.yml
+++ b/integration_tests/models/sql/schema.yml
@@ -2,7 +2,7 @@ version: 2
 
 models:
   - name: test_get_single_value
-    tests:
+    data_tests:
       - assert_equal:
           actual: date_actual
           expected: date_expected
@@ -17,7 +17,7 @@ models:
           expected: string_expected
 
   - name: test_get_single_value_default
-    tests:
+    data_tests:
       - assert_equal:
           actual: date_actual
           expected: date_expected
@@ -32,71 +32,71 @@ models:
           expected: string_expected
 
   - name: test_generate_series
-    tests:
+    data_tests:
       - dbt_utils.equality:
           compare_model: ref('data_generate_series')
 
   - name: test_get_column_values
     columns:
       - name: count_a
-        tests:
+        data_tests:
           - accepted_values:
               values:
                 - '1'
 
       - name: count_b
-        tests:
+        data_tests:
           - accepted_values:
               values:
                 - '1'
 
       - name: count_c
-        tests:
+        data_tests:
           - accepted_values:
               values:
                 - '1'
 
       - name: count_d
-        tests:
+        data_tests:
           - accepted_values:
               values:
                 - '1'
 
       - name: count_e
-        tests:
+        data_tests:
           - accepted_values:
               values:
                 - '1'
 
       - name: count_f
-        tests:
+        data_tests:
           - accepted_values:
               values:
                 - '1'
 
       - name: count_g
-        tests:
+        data_tests:
           - accepted_values:
               values:
                 - '5'
 
   - name: test_get_column_values_where
-    tests:
+    data_tests:
       - dbt_utils.equality:
           compare_model: ref('data_get_column_values_where_expected')
 
   - name: test_get_filtered_columns_in_relation
-    tests:
+    data_tests:
       - dbt_utils.equality:
           compare_model: ref('data_filtered_columns_in_relation_expected')
 
   - name: test_get_relations_by_prefix_and_union
     columns:
       - name: event
-        tests:
+        data_tests:
           - not_null
       - name: user_id
-        tests:
+        data_tests:
           - dbt_utils.at_least_one
           - not_null
           - unique
@@ -104,94 +104,94 @@ models:
   - name: test_nullcheck_table
     columns:
       - name: field_1
-        tests:
+        data_tests:
           - not_empty_string
 
       - name: field_2
-        tests:
+        data_tests:
           - not_empty_string
 
       - name: field_3
-        tests:
+        data_tests:
           - not_empty_string
 
   - name: test_safe_add
-    tests:
+    data_tests:
       - assert_equal:
           actual: actual
           expected: expected
   
   - name: test_safe_subtract
-    tests:
+    data_tests:
       - assert_equal:
           actual: actual
           expected: expected
 
   - name: test_safe_divide
-    tests:
+    data_tests:
       - assert_equal:
           actual: actual
           expected: expected
 
   - name: test_pivot
-    tests:
+    data_tests:
       - dbt_utils.equality:
           compare_model: ref('data_pivot_expected')
 
   - name: test_pivot_apostrophe
-    tests:
+    data_tests:
       - dbt_utils.equality:
           compare_model: ref('data_pivot_expected_apostrophe')
 
   - name: test_unpivot_original_api
-    tests:
+    data_tests:
       - dbt_utils.equality:
           compare_model: ref('data_unpivot_original_api_expected')
 
   - name: test_unpivot
-    tests:
+    data_tests:
       - dbt_utils.equality:
           compare_model: ref('data_unpivot_expected')
 
   - name: test_unpivot_bool
-    tests:
+    data_tests:
       - dbt_utils.equality:
           compare_model: ref('data_unpivot_bool_expected')
 
   - name: test_star
-    tests:
+    data_tests:
       - dbt_utils.equality:
           compare_model: ref('data_star_expected')
 
   - name: test_star_quote_identifiers
-    tests:
+    data_tests:
       - assert_equal:
           actual: actual
           expected: expected
 
   - name: test_star_prefix_suffix
-    tests:
+    data_tests:
       - dbt_utils.equality:
           compare_model: ref('data_star_prefix_suffix_expected')
 
   - name: test_star_aggregate
-    tests:
+    data_tests:
       - dbt_utils.equality:
           compare_model: ref('data_star_aggregate_expected')
 
   - name: test_star_uppercase
-    tests:
+    data_tests:
       - dbt_utils.equality:
           compare_model: ref('data_star_expected')
 
   - name: test_star_no_columns
     columns: 
       - name: canary_column #If the no-columns state isn't hit, this table won't be queryable because there will be a missing comma
-        tests: 
+        data_tests: 
           - not_null
 
   - name: test_generate_surrogate_key
-    tests:
+    data_tests:
       - assert_equal:
           actual: actual_column_1_only
           expected: expected_column_1_only
@@ -200,49 +200,49 @@ models:
           expected: expected_all_columns
 
   - name: test_union
-    tests:
+    data_tests:
       - dbt_utils.equality:
           compare_model: ref('data_union_expected')
 
   - name: test_union_where
     columns:
       - name: id
-        tests:
+        data_tests:
           - dbt_utils.expression_is_true:
               expression: "= 1"
       - name: favorite_number
-        tests:
+        data_tests:
           - dbt_utils.not_constant
   
   - name: test_union_no_source_column
-    tests:
+    data_tests:
       - expect_table_columns_to_match_set:
           column_list: ["id", "name", "favorite_color", "favorite_number"]
 
   - name: test_union_exclude_lowercase
-    tests:
+    data_tests:
       - dbt_utils.equality:
           compare_model: ref('data_union_exclude_expected')
 
   - name: test_union_exclude_uppercase
-    tests:
+    data_tests:
       - dbt_utils.equality:
           compare_model: ref('data_union_exclude_expected')
 
   - name: test_get_relations_by_pattern
-    tests:
+    data_tests:
       - dbt_utils.equality:
           compare_model: ref('data_union_events_expected')
 
   - name: test_deduplicate
-    tests:
+    data_tests:
       - dbt_utils.equality:
           compare_model: ref('data_deduplicate_expected')
 
   - name: test_not_empty_string_failing
     columns:
       - name: string_trim_whitespace_true
-        tests:
+        data_tests:
           - dbt_utils.not_empty_string:
               config:
                 severity: error
@@ -252,15 +252,15 @@ models:
   - name: test_not_empty_string_passing
     columns:
       - name: string_trim_whitespace_true
-        tests:
+        data_tests:
           - dbt_utils.not_empty_string
       - name: string_trim_whitespace_false
-        tests:
+        data_tests:
           - dbt_utils.not_empty_string:
               trim_whitespace: false
 
   - name: test_width_bucket
-    tests:
+    data_tests:
       - assert_equal:
           actual: actual
           expected: expected

--- a/integration_tests/models/web/schema.yml
+++ b/integration_tests/models/web/schema.yml
@@ -2,19 +2,19 @@ version: 2
 
 models:
   - name: test_urls
-    tests:
+    data_tests:
       - assert_equal:
           actual: actual
           expected: expected
           
   - name: test_url_host
-    tests:
+    data_tests:
       - assert_equal:
           actual: actual
           expected: expected
           
   - name: test_url_path
-    tests:
+    data_tests:
       - assert_equal:
           actual: actual
           expected: expected


### PR DESCRIPTION
resolves #894

This is a:
- [x] just an update to the integration_tests (non-breaking change)

All pull requests from community contributors should target the `main` branch (default).

## Description & motivation
<!---
Describe your changes, and why you're making them.
-->

With the new dbt-core `v1.8`, the syntax for data tests have updated from `tests:` to `data_tests:`. This PR updates that syntax to get rid of the warning message.

## Checklist
- [x] This code is associated with an Issue which has been triaged and [accepted for development](https://docs.getdbt.com/docs/contributing/oss-expectations#pull-requests). 
- [ ] I have verified that these changes work locally on the following warehouses (Note: it's okay if you do not have access to all warehouses, this helps us understand what has been covered)
    - [ ] BigQuery
    - [ ] Postgres
    - [ ] Redshift
    - [ ] Snowflake
- [ ] I followed guidelines to ensure that my changes will work on "non-core" adapters by:
    - [ ] dispatching any new macro(s) so non-core adapters can also use them (e.g. [the `star()` source](https://github.com/dbt-labs/dbt-utils/blob/main/macros/sql/star.sql))
    - [ ] using the `limit_zero()` macro in place of the literal string: `limit 0`
    - [ ] using `dbt.type_*` macros instead of explicit datatypes (e.g. `dbt.type_timestamp()` instead of `TIMESTAMP`
- [ ] I have updated the README.md (if applicable)
- [ ] I have added tests & descriptions to my models (and macros if applicable)
- [ ] I have added an entry to CHANGELOG.md
