### PR TITLE
support for unique where clauses for each relation passed to union_relations

### DIFF
--- a/macros/sql/union.sql
+++ b/macros/sql/union.sql
@@ -115,7 +115,11 @@
             from {{ relation }}
 
             {% if where -%}
-            where {{ where }}
+              {% if where is string -%}
+                where {{ where }}
+              {% else %}
+                where {{ where[loop.index0] }}
+              {%- endif %}
             {%- endif %}
         )
 


### PR DESCRIPTION
resolves #

https://github.com/dbt-labs/dbt-utils/issues/895

This is a:
- [ ] documentation update
- [ ] bug fix with no breaking changes
- [x] new functionality
- [ ] a breaking change

All pull requests from community contributors should target the `main` branch (default).

## Description & motivation

currently when a where clause is passed to union_relations, it is used for every relation that was passed. In some situations, this approach is not ideal. The proposed code change here maintains current functionality of passing strings to the where param but also allows for lists to be passed just like how the relations are passed to the relations parameter. Support for specific where clauses for each relation allows for more flexibility in the way the macro can be deployed

## Checklist
- [x] This code is associated with an Issue which has been triaged and [accepted for development](https://docs.getdbt.com/docs/contributing/oss-expectations#pull-requests). 
- [x] I have verified that these changes work locally on the following warehouses (Note: it's okay if you do not have access to all warehouses, this helps us understand what has been covered)
    - [ ] BigQuery
    - [ ] Postgres
    - [x] Redshift
    - [ ] Snowflake
- [x] I followed guidelines to ensure that my changes will work on "non-core" adapters by:
    - [x] dispatching any new macro(s) so non-core adapters can also use them (e.g. [the `star()` source](https://github.com/dbt-labs/dbt-utils/blob/main/macros/sql/star.sql))
    - [ ] using the `limit_zero()` macro in place of the literal string: `limit 0`
    - [ ] using `dbt.type_*` macros instead of explicit datatypes (e.g. `dbt.type_timestamp()` instead of `TIMESTAMP`
- [ ] I have updated the README.md (if applicable)
- [ ] I have added tests & descriptions to my models (and macros if applicable)
- [ ] I have added an entry to CHANGELOG.md
