### PR TITLE
Remove "I have added an entry to CHANGELOG.md" from the PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -26,4 +26,3 @@ Describe your changes, and why you're making them.
     - [ ] using `dbt.type_*` macros instead of explicit datatypes (e.g. `dbt.type_timestamp()` instead of `TIMESTAMP`
 - [ ] I have updated the README.md (if applicable)
 - [ ] I have added tests & descriptions to my models (and macros if applicable)
-- [ ] I have added an entry to CHANGELOG.md


### PR DESCRIPTION
resolves #902

This is a:
- [x] under the hood change

All pull requests from community contributors should target the `main` branch (default).

## Problem

We have a checklist item reminding contributors to manually update the changelog. But we have been using the "Generate release notes" button in GitHub in place of manual [changelog](https://github.com/dbt-labs/dbt-utils/blob/main/CHANGELOG.md) entries. So any changelog entries that are merged are just overwritten during the release.

Also, we have a long checklist, which lowers its utility.

## Solution

- Remove "I have added an entry to CHANGELOG.md" from the PR template 
- Checklist is one item shorter

## Checklist
- [x] This code is associated with an Issue which has been triaged and [accepted for development](https://docs.getdbt.com/docs/contributing/oss-expectations#pull-requests). 