### PR TITLE
Add a PR checklist item for "I have read the contributing guide..." as a catch-all

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -20,9 +20,6 @@ Describe your changes, and why you're making them.
     - [ ] Postgres
     - [ ] Redshift
     - [ ] Snowflake
-- [ ] I followed guidelines to ensure that my changes will work on "non-core" adapters by:
-    - [ ] dispatching any new macro(s) so non-core adapters can also use them (e.g. [the `star()` source](https://github.com/dbt-labs/dbt-utils/blob/main/macros/sql/star.sql))
-    - [ ] using the `limit_zero()` macro in place of the literal string: `limit 0`
-    - [ ] using `dbt.type_*` macros instead of explicit datatypes (e.g. `dbt.type_timestamp()` instead of `TIMESTAMP`
+- [ ] I have read [the contributing guide](https://github.com/dbt-labs/dbt-utils/blob/main/CONTRIBUTING.md) and understand what's expected of me
 - [ ] I have updated the README.md (if applicable)
 - [ ] I have added tests & descriptions to my models (and macros if applicable)


### PR DESCRIPTION
resolves #904

This is a:
- [x] under the hood change

## Problem

Our PR template is pretty long, which makes it onerous to use. Many items are already covered in our contribution guidelines in [their own section](https://github.com/dbt-labs/dbt-utils/blob/85ade29c3e69bed3a13812c716c19eea9a0551c4/CONTRIBUTING.md#implementation-guidelines).

## Solution

Replace (4) checklist items with (1) checklist item that says:

> - [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-utils/blob/main/CONTRIBUTING.md) and understand what's expected of me


## Checklist
- [x] This code is associated with an Issue which has been triaged and [accepted for development](https://docs.getdbt.com/docs/contributing/oss-expectations#pull-requests).
- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-utils/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have updated the README.md (if applicable)
- [x] I have added tests & descriptions to my models (and macros if applicable)