### PR TITLE
Contributors shouldn't edit the `CHANGELOG.md` directly anymore

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -74,7 +74,7 @@ See here for details for running existing integration tests and adding new ones:
 
 ## Adding CHANGELOG Entry
 
-Unlike `dbt-core`, we edit the `CHANGELOG.md` directly.
+We use [automatically generated release notes](https://docs.github.com/en/repositories/releasing-projects-on-github/automatically-generated-release-notes) to generate `CHANGELOG` entries. **Note:** Do not edit the `CHANGELOG.md` directly. Your modifications will be lost.
 
 You don't need to worry about which `dbt-utils` version your change will go into. Just create the changelog entry at the top of CHANGELOG.md and open your PR against the `main` branch. All merged changes will be included in the next minor version of `dbt-utils`. The maintainers _may_ choose to "backport" specific changes in order to patch older minor versions. In that case, a maintainer will take care of that backport after merging your PR, before releasing the new version of `dbt-utils`.
 


### PR DESCRIPTION
resolves #914

### Problem

We use [automatically generated release notes](https://docs.github.com/en/repositories/releasing-projects-on-github/automatically-generated-release-notes) to generate `CHANGELOG` entries now, so our contributing guide is out-of-date.

### Solution

Bring the contributing guide up-to-date by updating the language and adding a hyperlink to the "automatically generated release notes" feature in GitHub.

## Checklist
- [x] This code is associated with an [issue](https://github.com/dbt-labs/dbt-utils/issues) which has been triaged and [accepted for development](https://docs.getdbt.com/docs/contributing/oss-expectations#pull-requests).
- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-utils/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [N/A] I have run this code in development and it appears to resolve the stated issue
- [N/A] This PR includes tests, or tests are not required/relevant for this PR
- [N/A] I have updated the README.md (if applicable)