### PR TITLE
Contributing guide instructions for allowing commits from maintainers

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,6 +12,8 @@ Remember: all PRs (apart from cosmetic fixes like typos) should be [associated w
 1. [Adding CHANGELOG Entry](#adding-changelog-entry)
 1. [Submitting a Pull Request](#submitting-a-pull-request)
 
+Enable greater collaboration by selecting ["Allow edits from maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork#enabling-repository-maintainer-permissions-on-existing-pull-requests) which will allow commits on your PR branch.
+
 ## About this document
 
 There are many ways to contribute to the ongoing development of `dbt-utils`, such as by participating in discussions and issues. We encourage you to first read our higher-level document: ["Expectations for Open Source Contributors"](https://docs.getdbt.com/docs/contributing/oss-expectations).


### PR DESCRIPTION
resolves #913

### Problem

We've had cases where ["Allow edits from maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork#enabling-repository-maintainer-permissions-on-existing-pull-requests) is not enabled by the contributor. This means that a maintainer can't push commits and all commits need to be initiated by the contributor instead. This lowers the collaboration possibilities and can ultimately necessitate closing the original PR and opening a new one.

### Solution

Provide a link within the contributing guide within the "external contributors" section that provides instructions for enabling commits from maintainers.

## Checklist
- [x] This code is associated with an [issue](https://github.com/dbt-labs/dbt-utils/issues) which has been triaged and [accepted for development](https://docs.getdbt.com/docs/contributing/oss-expectations#pull-requests).
- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-utils/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [N/A] I have run this code in development and it appears to resolve the stated issue
- [N/A] This PR includes tests, or tests are not required/relevant for this PR
- [N/A] I have updated the README.md (if applicable)