### PR TITLE
Revert pruning in `at_least_one` test

### DIFF
--- a/integration_tests/data/schema_tests/data_test_at_least_one.csv
+++ b/integration_tests/data/schema_tests/data_test_at_least_one.csv
@@ -1,2 +1,3 @@
-field
-a
+field,value
+a,1
+b,

--- a/integration_tests/models/generic_tests/schema.yml
+++ b/integration_tests/models/generic_tests/schema.yml
@@ -14,8 +14,12 @@ seeds:
       - name: field
         data_tests:
           - dbt_utils.at_least_one
+      - name: value
+        data_tests:
           - dbt_utils.at_least_one:
               group_by_columns: ['field']
+              error_if: "<1"
+              warn_if: "<0"
 
   - name: data_test_expression_is_true
     data_tests:

--- a/macros/generic_tests/at_least_one.sql
+++ b/macros/generic_tests/at_least_one.sql
@@ -4,20 +4,39 @@
 
 {% macro default__test_at_least_one(model, column_name, group_by_columns) %}
 
+{% set pruned_cols = [column_name] %}
+
 {% if group_by_columns|length() > 0 %}
   {% set select_gb_cols = group_by_columns|join(' ,') + ', ' %}
   {% set groupby_gb_cols = 'group by ' + group_by_columns|join(',') %}
+  {% set pruned_cols = group_by_columns %}
+
+  {% if column_name not in pruned_cols %}
+    {% do pruned_cols.append(column_name) %}
+  {% endif %}
+
 {% endif %}
+
+{% set select_pruned_cols = pruned_cols|join(' ,') %}
 
 select *
 from (
+    with pruned_rows as (
+      select
+        {{ select_pruned_cols }}
+      from {{ model }}
+      {% if group_by_columns|length() == 0 %}
+        where {{ column_name }} is not null
+        limit 1
+      {% endif %}
+    )
     select
         {# In TSQL, subquery aggregate columns need aliases #}
         {# thus: a filler col name, 'filler_column' #}
       {{select_gb_cols}}
       count({{ column_name }}) as filler_column
 
-    from {{ model }}
+    from pruned_rows
 
     {{groupby_gb_cols}}
 

--- a/macros/generic_tests/at_least_one.sql
+++ b/macros/generic_tests/at_least_one.sql
@@ -4,38 +4,20 @@
 
 {% macro default__test_at_least_one(model, column_name, group_by_columns) %}
 
-{% set pruned_cols = [column_name] %}
-
 {% if group_by_columns|length() > 0 %}
-
   {% set select_gb_cols = group_by_columns|join(' ,') + ', ' %}
   {% set groupby_gb_cols = 'group by ' + group_by_columns|join(',') %}
-  {% set pruned_cols = group_by_columns %}
-
-  {% if column_name not in pruned_cols %}
-    {% do pruned_cols.append(column_name) %}
-  {% endif %}
-
 {% endif %}
-
-{% set select_pruned_cols = pruned_cols|join(' ,') %}
 
 select *
 from (
-    with pruned_rows as (
-      select
-        {{ select_pruned_cols }}
-      from {{ model }}
-      where {{ column_name }} is not null
-      limit 1
-    )
     select
         {# In TSQL, subquery aggregate columns need aliases #}
         {# thus: a filler col name, 'filler_column' #}
       {{select_gb_cols}}
       count({{ column_name }}) as filler_column
 
-    from pruned_rows
+    from {{ model }}
 
     {{groupby_gb_cols}}
 

--- a/macros/generic_tests/at_least_one.sql
+++ b/macros/generic_tests/at_least_one.sql
@@ -7,6 +7,7 @@
 {% set pruned_cols = [column_name] %}
 
 {% if group_by_columns|length() > 0 %}
+
   {% set select_gb_cols = group_by_columns|join(' ,') + ', ' %}
   {% set groupby_gb_cols = 'group by ' + group_by_columns|join(',') %}
   {% set pruned_cols = group_by_columns %}


### PR DESCRIPTION
resolves #838 

### Problem

<!---
  Describe the problem this PR is solving. What is the application state
  before this PR is merged?
-->

The pruning logic introduced in #776 disrupted the grouping behavior in the `at_least_one` test.

Specifically, the initial `pruned_rows` CTE includes a `limit 1` statement, which selects a single record where the target column is not null.

As a result, the test passes inappropriately when the `group_by_columns` parameter is configured, as long as the target column has at least one not-null value.

Essentially, the `group_by_columns` parameter currently has no effect on the test. It evaluates target column values as a single group, regardless of whether or not the parameter is present.

### Solution

<!---
  Describe the way this PR solves the above problem. Add as much detail as you
  can to help reviewers understand your changes. Include any alternatives and
  tradeoffs you considered.
-->

Restore the `at_least_one` test to its prior state.

Since the goal of #776 was to improve the performance of the test, I also considered a set-logic approach to evaluating a column at the group level:
- identify all group-by column values
- identify group-by column values with at least one not-null target column value
- return group-by column values without at least one not-null target column value as errors

In BigQuery, however, this version of the test took twice as long as the simple reverted version.

## Checklist
- [x] This code is associated with an [issue](https://github.com/dbt-labs/dbt-utils/issues) which has been triaged and [accepted for development](https://docs.getdbt.com/docs/contributing/oss-expectations#pull-requests).
- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-utils/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [ ] I have updated the README.md (if applicable)
