### PR TITLE
Move profiles config to project flags

### DIFF
--- a/integration_tests/ci/sample.profiles.yml
+++ b/integration_tests/ci/sample.profiles.yml
@@ -2,10 +2,6 @@
 # HEY! This file is used in the dbt-utils integrations tests with CircleCI.
 # You should __NEVER__ check credentials into version control. Thanks for reading :)
 
-config:
-    send_anonymous_usage_stats: False
-    use_colors: True
-
 integration_tests:
   target: postgres
   outputs:

--- a/integration_tests/dbt_project.yml
+++ b/integration_tests/dbt_project.yml
@@ -20,6 +20,10 @@ clean-targets:         # directories to be removed by `dbt clean`
     - "dbt_modules"
     - "dbt_packages"
 
+flags:
+    send_anonymous_usage_stats: False
+    use_colors: True
+
 dispatch:
   - macro_namespace: 'dbt_utils'
     search_order: ['dbt_utils_integration_tests', 'dbt_utils']


### PR DESCRIPTION
resolves #925

### Problem

The [migration guide for v1.8](https://docs.getdbt.com/docs/dbt-versions/core-upgrade/upgrading-to-v1.8#managing-changes-to-legacy-behaviors) includes:

> - Custom defaults of [global config flags](https://docs.getdbt.com/reference/global-configs/about-global-configs) should be set in the flags dictionary in [dbt_project.yml](https://docs.getdbt.com/reference/dbt_project.yml), instead of in [profiles.yml](https://docs.getdbt.com/docs/core/connect-data-platform/profiles.yml). Support for profiles.yml has been deprecated.

### Solution

Move from `config:` from `profiles.yml` to `flags:` in `dbt_project.yml`.

## Checklist
- [x] This code is associated with an [issue](https://github.com/dbt-labs/dbt-utils/issues) which has been triaged and [accepted for development](https://docs.getdbt.com/docs/contributing/oss-expectations#pull-requests).
- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-utils/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have updated the README.md (if applicable)
