### PR TITLE
Update BQ deduplicate macro to support partition pruning downstream

### DIFF
--- a/macros/sql/deduplicate.sql
+++ b/macros/sql/deduplicate.sql
@@ -93,12 +93,19 @@
 --  clause in BigQuery:
 --  https://github.com/dbt-labs/dbt-utils/issues/335#issuecomment-788157572
 #}
-{%- macro bigquery__deduplicate(relation, partition_by, order_by) -%}
+{%- macro bigquery__deduplicate(relation, partition_by, order_by, partition_by_pass_thru=false) -%}
 
     select unique.*
+    {%- if partition_by_pass_thru %}
+    except({{ partition_by }}),
+    {{ partition_by }}
+    {%- endif %}
     from (
         select
-            array_agg (
+            {%- if partition_by_pass_thru %}
+            {{ partition_by }},
+            {%- endif %}
+            array_agg(
                 original
                 order by {{ order_by }}
                 limit 1


### PR DESCRIPTION
resolves https://github.com/dbt-labs/dbt-utils/issues/928

### Problem

The current BQ deduplicate macro will not work for a view as it doesn't allow partition pruning downstream of the macro. 

### Solution

Add an an optional parameter that explicitly selects the `partition by` columns outside of the `array_agg`

## Checklist
- [x] This code is associated with an [issue](https://github.com/dbt-labs/dbt-utils/issues) which has been triaged and [accepted for development](https://docs.getdbt.com/docs/contributing/oss-expectations#pull-requests).
- [ ] I have read [the contributing guide](https://github.com/dbt-labs/dbt-utils/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [ ] I have run this code in development and it appears to resolve the stated issue
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [ ] I have updated the README.md (if applicable)
