### PR TITLE
Link to tests that support `group_by_columns`

### DIFF
--- a/README.md
+++ b/README.md
@@ -617,13 +617,13 @@ Certain tests support the optional `group_by_columns` argument to provide more g
 
 This feature is currently available for the following data tests:
 
-- equal_rowcount()
-- fewer_rows_than()
-- recency()
-- at_least_one()
-- not_constant()
-- sequential_values()
-- not_null_proportion()
+- [equal_rowcount](#equal_rowcount-source)
+- [fewer_rows_than](#fewer_rows_than-source)
+- [recency](#recency-source)
+- [at_least_one](#at_least_one-source)
+- [not_constant](#not_constant-source)
+- [sequential_values](#sequential_values-source)
+- [not_null_proportion](#not_null_proportion-source)
 
 To use this feature, the names of grouping variables can be passed as a list. For example, to test for at least one valid value by group, the `group_by_columns` argument could be used as follows:
 


### PR DESCRIPTION
resolves #930

### Problem

There is a list of macro names without links.

### Solution

Add links to make them easier to look up.

### 🎩 

<img width="473" alt="image" src="https://github.com/dbt-labs/dbt-utils/assets/44704949/97968bc2-957d-4fc8-b93e-93b341c881d1">


## Checklist
- [x] This code is associated with an [issue](https://github.com/dbt-labs/dbt-utils/issues) which has been triaged and [accepted for development](https://docs.getdbt.com/docs/contributing/oss-expectations#pull-requests).
- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-utils/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] Tests are not required/relevant for this PR
- [x] I have updated the README.md (if applicable)
