### PR TITLE
Expand description for the `at_least_one` data test

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,7 +223,7 @@ This test supports the `group_by_columns` parameter; see [Grouping in tests](#gr
 
 ### at_least_one ([source](macros/generic_tests/at_least_one.sql))
 
-Asserts that a column has at least one value.
+Asserts that a column has at least one value that is not `null`.
 
 **Usage:**
 


### PR DESCRIPTION
resolves #932

### Problem

The description for the `at_least_one` data test lacks specificity.

### Solution

Be more explicit by clarifying that it applies to non-`null` values.

## Checklist
- [x] This code is associated with an [issue](https://github.com/dbt-labs/dbt-utils/issues) which has been triaged and [accepted for development](https://docs.getdbt.com/docs/contributing/oss-expectations#pull-requests).
- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-utils/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] Tests are not required/relevant for this PR
- [x] I have updated the README.md (if applicable)
