### PR TITLE
Add a sort parameter to star.sql

### DIFF
--- a/macros/sql/star.sql
+++ b/macros/sql/star.sql
@@ -1,4 +1,4 @@
-{% macro star(from, relation_alias=False, except=[], prefix='', suffix='', quote_identifiers=True) -%}
+{% macro star(from, relation_alias=False, except=[], prefix='', suffix='', quote_identifiers=True, sort=False) -%}
     {{ return(adapter.dispatch('star', 'dbt_utils')(from, relation_alias, except, prefix, suffix, quote_identifiers)) }}
 {% endmacro %}
 
@@ -26,6 +26,9 @@ dbt compile, and exists to keep SQLFluff happy. */
             {% do return("/* no columns returned from star() macro */") %}
         {% endif %}
     {%- else -%}
+        {%- if sort -%}
+            {% set cols = cols|sort %}
+        {%- endif -%}
         {%- for col in cols %}
             {%- if relation_alias %}{{ relation_alias }}.{% else %}{%- endif -%}
                 {%- if quote_identifiers -%}


### PR DESCRIPTION
Add a sort paramater that will sort in alphabetical order the return of the column name


### Problem

My use case was to do UNION ALL on severall intermediary queries (not materialized data) with large amount of columns (arround 130) not ordered. 

I tried to use the dbt_utils.union_relation but it work only on materialized data on I founded that overkilled to stock in database intermediary data just to do an UNION.

What I am currently doing to avoid that is as follow : 

```
{% set column_list = dbt_utils.get_filtered_columns_in_relation( ref('original_data'))|sort %}

with partial_table_transformed as (
SELECT 
      *,
      [transformation to compute new_column_A and new_column_B, that changed the order of all the original column such as join or group by]
FROM {{ ref('original_data') }}
WHERE need_to_be_transformed = 1
),

partial_table_not_transformed as (
SELECT 
      *
FROM {{ ref('original_data') }}
WHERE need_to_be_transformed = 0
),

SELECT
    {{ column_list | join(', ') }}, 
    new_column_A, 
    new_column_B
FROM partial_table_transformed
UNION ALL
SELECT
    {{ column_list | join(', ') }},
    NULL as new_column_A, 
    NULL as new_column_B, 
FROM partial_table_not_transformed

```

### Solution

It would be great to do as such : 

```
SELECT
    {{ dbt_utils.star(ref('original_data'), sort = True) }}
    new_column_A, 
    new_column_B
FROM partial_table_transformed
UNION ALL
SELECT
    {{ dbt_utils.star(ref('original_data'), sort = True) }}
    NULL as new_column_A, 
    NULL as new_column_B, 
FROM partial_table_not_transformed
```
## Checklist
- [x] This code is associated to this [issue](https://github.com/dbt-labs/dbt-utils/issues/937) which has been triaged and [accepted for development](https://docs.getdbt.com/docs/contributing/oss-expectations#pull-requests).
- [ ] I have read [the contributing guide](https://github.com/dbt-labs/dbt-utils/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [ ] I have run this code in development and it appears to resolve the stated issue
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [ ] I have updated the README.md (if applicable)
