### PR TITLE
Update get_table_types_sql.sql

### DIFF
--- a/macros/sql/get_table_types_sql.sql
+++ b/macros/sql/get_table_types_sql.sql
@@ -30,3 +30,13 @@
                 else lower(table_type)
             end as {{ adapter.quote('table_type') }}
 {% endmacro %}
+
+{% macro bigquery__get_table_types_sql() %}
+            case table_type
+                when 'BASE TABLE' then 'table'
+                when 'CLONE' then 'table'
+                when 'EXTERNAL TABLE' then 'external'
+                when 'MATERIALIZED VIEW' then 'materializedview'
+                else lower(table_type)
+            end as {{ adapter.quote('table_type') }}
+{% endmacro %}


### PR DESCRIPTION
treat CLONE type tables in BigQuery as 'table'

resolves #955 

### Problem

Compilation of models using `get_relations_by_pattern` macro fail if the macro returns [BigQuery `clone` type tables](https://cloud.google.com/bigquery/docs/table-clones-intro).

### Solution

We should treat clone type tables as regular tables in BigQuery. From what I can tell, we can add an additional jinja block [here](https://github.com/dbt-labs/dbt-utils/blob/main/macros/sql/get_table_types_sql.sql) to allow clone tables.

## Checklist
- [x] This code is associated with an [issue](https://github.com/dbt-labs/dbt-utils/issues) which has been triaged and [accepted for development](https://docs.getdbt.com/docs/contributing/oss-expectations#pull-requests).
- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-utils/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have updated the README.md (if applicable)
