### PR TITLE
`dbt_utils.star`: Remove trailing whitespace in the comment when no column is returned

### DIFF
--- a/macros/sql/star.sql
+++ b/macros/sql/star.sql
@@ -14,17 +14,17 @@
     {% set cols = dbt_utils.get_filtered_columns_in_relation(from, except) %}
 
     {%- if cols|length <= 0 -%}
-        {% if flags.WHICH == 'compile' %}
-            {% set response %}
+        {%- if flags.WHICH == 'compile' -%}
+            {%- set response -%}
 *
-/* No columns were returned. Maybe the relation doesn't exist yet 
-or all columns were excluded. This star is only output during  
+/* No columns were returned. Maybe the relation doesn't exist yet
+or all columns were excluded. This star is only output during
 dbt compile, and exists to keep SQLFluff happy. */
-            {% endset %}
-            {% do return(response) %}
-        {% else %}
-            {% do return("/* no columns returned from star() macro */") %}
-        {% endif %}
+            {%- endset -%}
+            {%- do return(response) -%}
+        {%- else -%}
+            {%- do return("/* no columns returned from star() macro */") -%}
+        {%- endif -%}
     {%- else -%}
         {%- for col in cols %}
             {%- if relation_alias %}{{ relation_alias }}.{% else %}{%- endif -%}


### PR DESCRIPTION
resolves #959

### Problem

The comment contains trailing whitespaces. The macro statements also generate trailing whitespaces, which fails sqlfluff's linting of the compiled file.

### Solution

Remove the trailing whitespaces and use `{%- ... -%} instead of {% ... %}` in the macro statements.
## Checklist
- [ ] This code is associated with an [issue](https://github.com/dbt-labs/dbt-utils/issues) which has been triaged and [accepted for development](https://docs.getdbt.com/docs/contributing/oss-expectations#pull-requests).
- [ ] I have read [the contributing guide](https://github.com/dbt-labs/dbt-utils/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [ ] I have run this code in development and it appears to resolve the stated issue
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [ ] I have updated the README.md (if applicable)
