### PR TITLE
Add documentation and usage example for ignore_time_component

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,7 +219,23 @@ models:
           field: created_at
           interval: 1
 ```
+
 This test supports the `group_by_columns` parameter; see [Grouping in tests](#grouping-in-tests) for details.
+
+The macro accepts an optional argument ignore_time_component , when set to true will ignore time part in timestamp. The default is `false`.
+
+```yaml
+version: 2
+
+models:
+  - name: model_name
+    tests:
+      - dbt_utils.recency:
+          datepart: day
+          field: created_at
+          interval: 1
+          ignore_time_component: true
+```
 
 ### at_least_one ([source](macros/generic_tests/at_least_one.sql))
 


### PR DESCRIPTION
resolves #

### Problem

<!---
  Describe the problem this PR is solving. What is the application state
  before this PR is merged?
-->
README does not have example for using `ignore_time_component` parameter in recency test. The only way to discover it is code search.

### Solution

<!---
  Describe the way this PR solves the above problem. Add as much detail as you
  can to help reviewers understand your changes. Include any alternatives and
  tradeoffs you considered.
-->
This PR adds explanation and usage example of `ignore_time_component` to README.

## Checklist
- [ ] This code is associated with an [issue](https://github.com/dbt-labs/dbt-utils/issues) which has been triaged and [accepted for development](https://docs.getdbt.com/docs/contributing/oss-expectations#pull-requests).
- [ ] I have read [the contributing guide](https://github.com/dbt-labs/dbt-utils/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [ ] I have run this code in development and it appears to resolve the stated issue
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [ ] I have updated the README.md (if applicable)
