### PR TITLE
Replace hyperlink for using a SQL expression in a data test

### DIFF
--- a/README.md
+++ b/README.md
@@ -536,7 +536,7 @@ We generally recommend testing this uniqueness condition by either:
 
 - generating a [surrogate_key](#generate_surrogate_key-source) for your model and testing
 the uniqueness of said key, OR
-- passing the `unique` test a concatenation of the columns (as discussed [here](https://docs.getdbt.com/docs/building-a-dbt-project/testing-and-documentation/testing/#testing-expressions)).
+- passing the `unique` test a concatenation of the columns (as discussed [here](https://docs.getdbt.com/reference/resource-properties/data-tests#test-an-expression)).
 
 However, these approaches can become non-perfomant on large data sets, in which
 case we recommend using this test instead.


### PR DESCRIPTION
### Problem

While writing up https://github.com/dbt-labs/docs.getdbt.com/issues/6436, noticed that the content of a link got moved to a different page in the dbt product documentation.

### Solution

Replace with the link to the new page + section heading.

## Checklist
- [ ] This code is associated with an [issue](https://github.com/dbt-labs/dbt-utils/issues) which has been triaged and [accepted for development](https://docs.getdbt.com/docs/contributing/oss-expectations#pull-requests).
- [ ] I have read [the contributing guide](https://github.com/dbt-labs/dbt-utils/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [ ] I have run this code in development and it appears to resolve the stated issue
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [ ] I have updated the README.md (if applicable)
