### PR TITLE
feat(nulltest): add not_null option to unique_combination_of_columns.sql

### DIFF
--- a/README.md
+++ b/README.md
@@ -565,6 +565,17 @@ An optional `quote_columns` argument (`default=false`) can also be used if a col
 
 ```
 
+An optional `not_null` argument (`default=false`) can also be used to test for null values in each of the provided columns.
+```yaml
+- name: revenue_by_product_by_month
+  tests:
+    - dbt_utils.unique_combination_of_columns:
+        combination_of_columns:
+          - month
+          - group
+        not_null: true
+```
+
 ### accepted_range ([source](macros/generic_tests/accepted_range.sql))
 
 Asserts that a column's values fall inside an expected range. Any combination of `min_value` and `max_value` is allowed, and the range can be inclusive or exclusive. Provide [a `where` argument](https://docs.getdbt.com/reference/resource-configs/where) to filter to specific records only.

--- a/macros/generic_tests/unique_combination_of_columns.sql
+++ b/macros/generic_tests/unique_combination_of_columns.sql
@@ -1,8 +1,8 @@
-{% test unique_combination_of_columns(model, combination_of_columns, quote_columns=false) %}
-  {{ return(adapter.dispatch('test_unique_combination_of_columns', 'dbt_utils')(model, combination_of_columns, quote_columns)) }}
+{% test unique_combination_of_columns(model, combination_of_columns, quote_columns=false, not_null=false) %}
+  {{ return(adapter.dispatch('test_unique_combination_of_columns', 'dbt_utils')(model, combination_of_columns, quote_columns, not_null)) }}
 {% endtest %}
 
-{% macro default__test_unique_combination_of_columns(model, combination_of_columns, quote_columns=false) %}
+{% macro default__test_unique_combination_of_columns(model, combination_of_columns, quote_columns=false, not_null=false) %}
 
 {% if not quote_columns %}
     {%- set column_list=combination_of_columns %}
@@ -19,7 +19,6 @@
 
 {%- set columns_csv=column_list | join(', ') %}
 
-
 with validation_errors as (
 
     select
@@ -33,5 +32,16 @@ with validation_errors as (
 select *
 from validation_errors
 
+{% if not_null %}
+    {% for column in combination_of_columns %}
+        union all
+        select *
+        from (
+            select {{ columns_csv }}
+            from {{ model }}
+            where {{ column }} is null
+        )
+    {% endfor %}
+{% endif %}
 
 {% endmacro %}


### PR DESCRIPTION
Add option to enforce uniqueness and non-null constraints on composite primary key columns in one test.

This introduces an option to ensure that composite primary key columns are both unique and do not contain null values. This is beneficial as it reduces the need for duplicate tests by allowing these constraints to be specified directly in a single test.

resolves #963

### Problem
I perform unique and not null tests on all primary key columns. Previously, not_null data tests had to be specified repeatedly for the same columns that are also listed in the unique_combination_of_columns test.

### Solution
The proposed solution adds an optional for loop that performs not null tests on each column in the unique_combination_of_columns test. Gives neater code. The default parameter is false, so it should not be a breaking change.

One problem can be that putting them together in one test may make it difficult to see which part of the test failed.

## Checklist
- [ ] This code is associated with an [issue](https://github.com/dbt-labs/dbt-utils/issues) which has been triaged and [accepted for development](https://docs.getdbt.com/docs/contributing/oss-expectations#pull-requests).
- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-utils/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have updated the README.md (if applicable)
