### PR TITLE
Use pull_request_target trigger

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ on:
     push:
         branches:
             - main
-    pull_request:
+    pull_request_target:
     workflow_dispatch:
 
 


### PR DESCRIPTION
resolves #971

### Problem

PRs from forks will fail CI because the PR trigger is `pull_request` so they do not have access to teh repo vars that are needed since the workflow runs in the context of the fork.  

### Solution

Update to trigger off `pull_request_target` and the workflow runs in the context of the base branch (this repo).

Does not require a release since it only affect local CI

## Checklist
- [ ] This code is associated with an [issue](https://github.com/dbt-labs/dbt-utils/issues) which has been triaged and [accepted for development](https://docs.getdbt.com/docs/contributing/oss-expectations#pull-requests).
- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-utils/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [ ] ~~I have run this code in development and it appears to resolve the stated issue~~
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [ ] ~~I have updated the README.md (if applicable)~~
