### PR TITLE
Update not_null_proportion.sql to handle function in group_by_columns

### DIFF
--- a/macros/generic_tests/not_null_proportion.sql
+++ b/macros/generic_tests/not_null_proportion.sql
@@ -9,7 +9,7 @@
 {% set at_most = kwargs.get('at_most', kwargs.get('arg', 1)) %}
 
 {% if group_by_columns|length() > 0 %}
-  {% set select_gb_cols = group_by_columns|join(' ,') + ', ' %}
+  {% set select_gb_cols = group_by_columns|join(' ,') + ' as group, ' %}
   {% set groupby_gb_cols = 'group by ' + group_by_columns|join(',') %}
 {% endif %}
 
@@ -22,7 +22,7 @@ with validation as (
 ),
 validation_errors as (
   select
-    {{select_gb_cols}}
+    {% if group_by_columns|length() > 0 %}"group",{% endif %}
     not_null_proportion
   from validation
   where not_null_proportion < {{ at_least }} or not_null_proportion > {{ at_most }}


### PR DESCRIPTION
resolves #

### Problem

<!---
  Describe the problem this PR is solving. What is the application state
  before this PR is merged?
-->

In not_null_proportion.sql, when function (e.g. date_trunc) is used in one of group_by_columns, it fails.

### Solution

<!---
  Describe the way this PR solves the above problem. Add as much detail as you
  can to help reviewers understand your changes. Include any alternatives and
  tradeoffs you considered.
-->

Assign alias to first column in validation CTE, which the alias is used in the following CTE.

## Checklist
- [ ] This code is associated with an [issue](https://github.com/dbt-labs/dbt-utils/issues) which has been triaged and [accepted for development](https://docs.getdbt.com/docs/contributing/oss-expectations#pull-requests).
- [ ] I have read [the contributing guide](https://github.com/dbt-labs/dbt-utils/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [ ] I have run this code in development and it appears to resolve the stated issue
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [ ] I have updated the README.md (if applicable)
