### PR TITLE
ADAP-1183: Update dbt-postgres ref in dev-requirements.txt to point to the monorepo

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -2,7 +2,7 @@ pytest
 pytest-dotenv
 dbt-core@git+https://github.com/dbt-labs/dbt-core.git#subdirectory=core
 dbt-tests-adapter@git+https://github.com/dbt-labs/dbt-adapters.git#subdirectory=dbt-tests-adapter
-dbt-postgres@git+https://github.com/dbt-labs/dbt-postgres.git
+dbt-postgres@git+https://github.com/dbt-labs/dbt-adapters.git#subdirectory=dbt-postgres
 dbt-redshift@git+https://github.com/dbt-labs/dbt-redshift.git
 dbt-snowflake@git+https://github.com/dbt-labs/dbt-snowflake.git
 dbt-bigquery@git+https://github.com/dbt-labs/dbt-bigquery.git


### PR DESCRIPTION
resolves #

### Problem

`dbt-postgres` migrated into the `dbt-adapters` monorepo. While the old `dbt-postgres` repo still exists, it is locked and will become stale.

### Solution

Update the ref in `dev-requirements.txt` to point to the new location.

## Checklist
- [ ] This code is associated with an [issue](https://github.com/dbt-labs/dbt-utils/issues) which has been triaged and [accepted for development](https://docs.getdbt.com/docs/contributing/oss-expectations#pull-requests).
- [ ] I have read [the contributing guide](https://github.com/dbt-labs/dbt-utils/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [ ] I have run this code in development and it appears to resolve the stated issue
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [ ] I have updated the README.md (if applicable)
