### PR TITLE
fix equal_rowcount between 2 different tables

### DIFF
--- a/macros/generic_tests/equal_rowcount.sql
+++ b/macros/generic_tests/equal_rowcount.sql
@@ -5,7 +5,7 @@
 {% macro default__test_equal_rowcount(model, compare_model, group_by_columns) %}
 
 {#-- Needs to be set at parse time, before we return '' below --#}
-{{ config(fail_calc = 'sum(coalesce(diff_count, 0))') }}
+{{ config(fail_calc = 'sum(diff_count)') }}
 
 {#-- Prevent querying of db in parsing mode. This works because this macro does not create any new refs. #}
 {%- if not execute -%}
@@ -60,7 +60,7 @@ final as (
 
         count_a,
         count_b,
-        abs(count_a - count_b) as diff_count
+        abs(coalesce(count_a, 0) - coalesce(count_b, 0)) as diff_count
 
     from a
     full join b


### PR DESCRIPTION
add coalesce to count_a and count_b before taking absolute difference so it doesn't result as null

resolves #986 

### Problem

<!---
  Describe the problem this PR is solving. What is the application state
  before this PR is merged?
-->
When `equal_rowcount` is applied between 2 tables of different groupby keys, the test still passes.
### Solution

<!---
  Describe the way this PR solves the above problem. Add as much detail as you
  can to help reviewers understand your changes. Include any alternatives and
  tradeoffs you considered.
-->
The root problem was caused by coalesce at `diff_count` because mismatching keys could cause null `diff_count`. Therefore coalesce should be applied where the absolute difference is taking place

## Checklist
- [x] This code is associated with an [issue](https://github.com/dbt-labs/dbt-utils/issues) which has been triaged and [accepted for development](https://docs.getdbt.com/docs/contributing/oss-expectations#pull-requests).
- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-utils/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have run this code in development and it appears to resolve the stated issue
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [ ] I have updated the README.md (if applicable)
