### PR TITLE
Update `dev-requirements.txt` to use the `dbt-adapters` monorepo

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -2,7 +2,7 @@ pytest
 pytest-dotenv
 dbt-core@git+https://github.com/dbt-labs/dbt-core.git#subdirectory=core
 dbt-tests-adapter@git+https://github.com/dbt-labs/dbt-adapters.git#subdirectory=dbt-tests-adapter
-dbt-postgres@git+https://github.com/dbt-labs/dbt-postgres.git
+dbt-postgres@git+https://github.com/dbt-labs/dbt-adapters.git#subdirectory=dbt-postgres
 dbt-redshift@git+https://github.com/dbt-labs/dbt-redshift.git
 dbt-snowflake@git+https://github.com/dbt-labs/dbt-snowflake.git
 dbt-bigquery@git+https://github.com/dbt-labs/dbt-bigquery.git

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -3,8 +3,8 @@ pytest-dotenv
 dbt-core@git+https://github.com/dbt-labs/dbt-core.git#subdirectory=core
 dbt-tests-adapter@git+https://github.com/dbt-labs/dbt-adapters.git#subdirectory=dbt-tests-adapter
 dbt-postgres@git+https://github.com/dbt-labs/dbt-adapters.git#subdirectory=dbt-postgres
-dbt-redshift@git+https://github.com/dbt-labs/dbt-redshift.git
-dbt-snowflake@git+https://github.com/dbt-labs/dbt-snowflake.git
-dbt-bigquery@git+https://github.com/dbt-labs/dbt-bigquery.git
+dbt-redshift@git+https://github.com/dbt-labs/dbt-adapters.git#subdirectory=dbt-redshift
+dbt-snowflake@git+https://github.com/dbt-labs/dbt-adapters.git#subdirectory=dbt-snowflake
+dbt-bigquery@git+https://github.com/dbt-labs/dbt-adapters.git#subdirectory=dbt-bigquery
 pytest-xdist
 tox>=3.13


### PR DESCRIPTION
resolves #990

### Problem

> `dbt-postgres` moved to the `dbt-adapters` monorepo. So `dbt_utils` is now pointing to a stale version of `dbt-postgres`

See https://github.com/dbt-labs/dbt-adapters/pull/615 for more detail.

### Solution

Update the refs so that it points to [`dbt-postgres` subdirectory](https://github.com/dbt-labs/dbt-adapters/tree/main/dbt-postgres) within the `dbt-adapters` monorepo.

## Checklist
- [x] This code is associated with an [issue](https://github.com/dbt-labs/dbt-utils/issues) which has been triaged and [accepted for development](https://docs.getdbt.com/docs/contributing/oss-expectations#pull-requests).
- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-utils/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have run this code in development and it appears to resolve the stated issue (except for [#992](https://github.com/dbt-labs/dbt-utils/issues/992))
- [x] Tests are not required/relevant for this PR