### PR TITLE
equality test: don't always require a Relation

### DIFF
--- a/integration_tests/models/generic_tests/schema.yml
+++ b/integration_tests/models/generic_tests/schema.yml
@@ -151,6 +151,20 @@ seeds:
       - dbt_utils.equality:
           compare_model: ref('data_test_equality_a')
       - dbt_utils.equality:
+          name: equality_test_with_where_clause
+          compare_model: |
+            (select 1 as col_a, 1 as col_b, 3 as col_c
+            union all
+            select 1 as col_a, 2 as col_b, 1 as col_c) compare_subquery
+          compare_columns:
+            - col_a
+            - col_b
+            - col_c
+          # NOTE: this 'where' syntax only works when we provide compare_columns and do not specify
+          # the precision parameter.
+          config:
+            where: col_a <> 2
+      - dbt_utils.equality:
           compare_model: ref('data_test_equality_b')
           error_if: "<1" #sneaky way to ensure that the test is returning failing rows
           warn_if: "<0"

--- a/macros/generic_tests/equality.sql
+++ b/macros/generic_tests/equality.sql
@@ -25,12 +25,11 @@
 
 
 
--- setup
-{%- do dbt_utils._is_relation(model, 'test_equality') -%}
-
 {# Ensure there are no extra columns in the compare_model vs model #}
 {%- if not compare_columns -%}
+    {%- do dbt_utils._is_relation(model, 'test_equality') -%}
     {%- do dbt_utils._is_ephemeral(model, 'test_equality') -%}
+    {%- do dbt_utils._is_relation(compare_model, 'test_equality') -%}
     {%- do dbt_utils._is_ephemeral(compare_model, 'test_equality') -%}
 
     {%- set model_columns = adapter.get_columns_in_relation(model) -%}
@@ -75,6 +74,7 @@
             You cannot get the columns in an ephemeral model (due to not existing in the information schema),
             so if the user does not provide an explicit list of columns we must error in the case it is ephemeral
         #}
+        {%- do dbt_utils._is_relation(model, 'test_equality') -%}
         {%- do dbt_utils._is_ephemeral(model, 'test_equality') -%}
         {%- set compare_columns = adapter.get_columns_in_relation(model)-%}
 
@@ -102,6 +102,7 @@
     {#-
         If rounding is required, we need to get the types, so it cannot be ephemeral even if they provide column names
     -#}
+    {%- do dbt_utils._is_relation(model, 'test_equality') -%}
     {%- do dbt_utils._is_ephemeral(model, 'test_equality') -%}
     {%- set columns = adapter.get_columns_in_relation(model) -%}
 


### PR DESCRIPTION
resolves #704

### Problem

<!---
  Describe the problem this PR is solving. What is the application state
  before this PR is merged?
-->

The equality test only needs a Relation when it needs to examine the model schema using the adapter.  If the user provides all column names to compare, and does not use the 'precision' option, then no Relation is actually needed.  In this case, an arbitrary subquery can be passed instead.  For example, the output of the `get_where_subquery` macro can be used instead.

This was discussed at: https://github.com/dbt-labs/dbt-utils/issues/704#issuecomment-1341904751

> It would make sense to solve that by moving the is_relation check into here, as it's the only place that would cause a problem:

The issue seems to have been closed due to inactivity and the absence of a PR.

### Solution

<!---
  Describe the way this PR solves the above problem. Add as much detail as you
  can to help reviewers understand your changes. Include any alternatives and
  tradeoffs you considered.
-->

I moved the `_is_relation` checks to be just prior to the `adapter` calls.  If no `adapter` call is needed, then we don't assert that the model is a relation.

## Checklist
- [X] This code is associated with an [issue](https://github.com/dbt-labs/dbt-utils/issues) which has been triaged and [accepted for development](https://docs.getdbt.com/docs/contributing/oss-expectations#pull-requests).
- [X] I have read [the contributing guide](https://github.com/dbt-labs/dbt-utils/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [X] I have run this code in development and it appears to resolve the stated issue
- [X] This PR includes tests, or tests are not required/relevant for this PR
- [ ] I have updated the README.md (if applicable)
    - It's not clear to me that this merits documenting in the README.  Happy to update if you feel otherwise.

NOTE: i tested locally using postgres target.