### PR TITLE
feat: improve clickhouse support

### DIFF
--- a/macros/sql/get_table_types_sql.sql
+++ b/macros/sql/get_table_types_sql.sql
@@ -12,6 +12,18 @@
 {% endmacro %}
 
 
+{% macro clickhouse__get_table_types_sql() %}
+            case table_type
+                when 'BASE TABLE' then 'table'
+                when 'VIEW' then 'view'
+                when 'FOREIGN TABLE' then 'foreigntable'
+                when 'LOCAL TEMPORARY' then 'localtemporary'
+                when 'SYSTEM VIEW' then 'systemview'
+                else lower(table_type)
+            end as {{ adapter.quote('table_type') }}
+{% endmacro %}
+
+
 {% macro postgres__get_table_types_sql() %}
             case table_type
                 when 'BASE TABLE' then 'table'

--- a/macros/sql/get_tables_by_pattern_sql.sql
+++ b/macros/sql/get_tables_by_pattern_sql.sql
@@ -16,6 +16,19 @@
 
 {% endmacro %}
 
+{% macro clickhouse__get_tables_by_pattern_sql(schema_pattern, table_pattern, exclude='') %}
+
+        select distinct
+            table_schema as {{ adapter.quote('table_schema') }},
+            table_name as {{ adapter.quote('table_name') }},
+            {{ dbt_utils.get_table_types_sql() }}
+        from information_schema.tables
+        where table_schema ilike '{{ schema_pattern }}'
+        and table_name ilike '{{ table_pattern }}'
+        and table_name not ilike '{{ exclude }}'
+
+{% endmacro %}
+
 {% macro redshift__get_tables_by_pattern_sql(schema_pattern, table_pattern, exclude='', database=target.database) %}
 
     {% set sql %}


### PR DESCRIPTION
resolves # (no associated issue)

### Problem

This adds ClickHouse support to a few `dbt-utils` macros:
- `get_table_types_sql`
- `get_tables_by_pattern_sql`

Incompatible SQL was  observed when using the [dbt codegen generate_source macro](https://github.com/dbt-labs/dbt-codegen?tab=readme-ov-file#generate_source-source), with [dbt-clickhouse plugin](https://github.com/ClickHouse/dbt-clickhouse)
- `dbt run-operation generate_source -d`

### Solution

Add `clickhouse_` support to macros:
- `get_table_types_sql`
- `get_tables_by_pattern_sql`

## Checklist
- [ ] This code is associated with an [issue](https://github.com/dbt-labs/dbt-utils/issues) which has been triaged and [accepted for development](https://docs.getdbt.com/docs/contributing/oss-expectations#pull-requests).
- [ ] I have read [the contributing guide](https://github.com/dbt-labs/dbt-utils/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [ ] I have run this code in development and it appears to resolve the stated issue
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [ ] I have updated the README.md (if applicable)
