### PR TITLE
Handle empty values in `get_column_values` macro

### DIFF
--- a/macros/sql/get_column_values.sql
+++ b/macros/sql/get_column_values.sql
@@ -13,8 +13,11 @@
 
     {# Not all relations are tables. Renaming for internal clarity without breaking functionality for anyone using named arguments #}
     {# TODO: Change the method signature in a future 0.x.0 release #}
-    {%- set target_relation = table -%}
-
+    {%- set target_relation = table -%} 
+    {% if table is string %}
+        {{ log("target_relation" ~ target_relation ~ "is not in the valid database.schema.table format. Returning the default value: " ~ default, info=True) }}
+        {{ return(default) }}
+    {% endif %}
     {# adapter.load_relation is a convenience wrapper to avoid building a Relation when we already have one #}
     {% set relation_exists = (load_relation(target_relation)) is not none %}
 

--- a/macros/sql/get_query_results_as_dict.sql
+++ b/macros/sql/get_query_results_as_dict.sql
@@ -17,7 +17,14 @@
     {%- if execute -%}
         {% set sql_results_table = load_result('get_query_results').table.columns %}
         {% for column_name, column in sql_results_table.items() %}
-            {% do sql_results.update({column_name: column.values()}) %}
+            {% if column.values() %}
+                {% do sql_results.update({column_name: column.values()}) %}
+            {% else %}
+                {# If column is empty, assign a dummy value#}
+                {% do sql_results.update({column_name: ' '}) %}
+                {{ log('Column ' ~ column_name ~ ' has no values. Assigning empty value', info=True) }}
+            {% endif %}
+
         {% endfor %}
     {%- endif -%}
 

--- a/macros/sql/pivot.sql
+++ b/macros/sql/pivot.sql
@@ -65,22 +65,32 @@ Arguments:
                else_value=0,
                quote_identifiers=True,
                distinct=False) %}
-  {% for value in values %}
-    {{ agg }}(
-      {% if distinct %} distinct {% endif %}
-      case
-      when {{ column }} {{ cmp }} '{{ dbt.escape_single_quotes(value) }}'
-        then {{ then_value }}
-      else {{ else_value }}
-      end
-    )
-    {% if alias %}
-      {% if quote_identifiers %}
-            as {{ adapter.quote(prefix ~ value ~ suffix) }}
-      {% else %}
-        as {{ dbt_utils.slugify(prefix ~ value ~ suffix) }}
+
+  {# Check if values are empty or None #}
+  {% if values is none or values == [] %}
+    {{ log('Pivot: No values to pivot. Creating an empty column with the default then_value.', info=True) }}
+    {% set empty_column = prefix ~ 'empty' ~ suffix %}
+    {{ then_value }} as {{ adapter.quote(empty_column) }}
+
+  {% else %}
+    {# Regular pivot behavior with provided values #}
+    {% for value in values %}
+      {{ agg }}(
+        {% if distinct %} distinct {% endif %}
+        case
+        when {{ column }} {{ cmp }} '{{ dbt.escape_single_quotes(value) }}'
+          then {{ then_value }}
+        else {{ else_value }}
+        end
+      )
+      {% if alias %}
+        {% if quote_identifiers %}
+              as {{ adapter.quote(prefix ~ value ~ suffix) }}
+        {% else %}
+          as {{ dbt_utils.slugify(prefix ~ value ~ suffix) }}
+        {% endif %}
       {% endif %}
-    {% endif %}
-    {% if not loop.last %},{% endif %}
-  {% endfor %}
+      {% if not loop.last %},{% endif %}
+    {% endfor %}
+  {% endif %}
 {% endmacro %}


### PR DESCRIPTION
Branched from https://github.com/dbt-labs/dbt-utils/pull/1007

resolves (partially) #1009

### Problem

> As part of our CI process, we use the `--empty` tag to run and test modified models with no data.  However, when these models use dbt_utils macros that expect non-empty values, we encountered errors in the pipeline.
> 
> **Examples**
> 
> Create seeds/test_a.csv
> ```
> kpi,category,sign	
> A,C_1,+
> B,C_2,-
> B,C_3,
> ```
> Test 1. **Error we see  by triggering `dbt run --select test_dbt_utils_pivot --empty`**
> 
> models/test_dbt_utils_pivot.sql
> 
> ```
> select
>   {{ dbt_utils.pivot(
>       'category', 
>       [],
>       agg='sum',
>       quote_identifiers=true,
>   )
>   }}
> from {{ ref('test_a') }}
> ```
> ```
>   001003 (42000): SQL compilation error:
>   syntax error line 8 at position 0 unexpected 'from'.
> ```
> 
> Test 2. **Error we see  by triggering `dbt run --select test_dbt_utils_get_column_values --empty`**
> 
> models/test_dbt_utils_get_column_values.sql
> 
> ```
> select
>   {{ dbt_utils.pivot(
>       'category', 
>       dbt_utils.get_column_values(ref('test_a'), 'category',default=[]),
>       agg='sum',
>       quote_identifiers=true,
>   )
>   }}
> from {{ ref('test_a') }}
> ```
> ```
>   'str object' has no attribute 'database'
>   
>   > in macro load_relation (macros/adapters/relation.sql)
>   > called by macro default__get_column_values (macros/sql/get_column_values.sql)
>   > called by macro get_column_values (macros/sql/get_column_values.sql)
>   > called by model test_dbt_utils (models/test_dbt_utils.sql)
> ```
> 
> Test 3. **Error we see  by triggering `dbt run --select test_dbt_utils_get_query_results_as_dict --empty`**
> 
> models/test_dbt_utils_get_query_results_as_dict.sql
> 
> ```
> 
> {% set kpi_mapping_sql %}
>     SELECT * FROM {{ ref("test_a") }}
> {% endset %}
> 
> {%- set kpis = dbt_utils.get_query_results_as_dict(kpi_mapping_sql) -%}
> 
>  {% for kpi in kpis["KPI"] %}
> 
>     {% set category = kpis["CATEGORY"][loop.index0] %}
>     {% set sign = kpis["SIGN"][loop.index0] %}
>     select '{{ kpi }}' as kpi, '{{ category }}' as category, '{{ sign }}' as sign
>     {{ "UNION ALL" if not loop.last }}
> 
> {% endfor %}
> ```
> 
> 
> ```
>   001003 (42000): SQL compilation error:
>   syntax error line 5 at position 2 unexpected ')'.
> ```

### Solution

> 1. Changes with `pivot.sql`
> 
> > Added a condition to check if the values are empty (None or []).
> > If the values are empty, the macro returns the default `then_value` immediately.
> 
> 
> 2. Changes with `get_column_values.sql`
> > Due to -- empty, the target_relation is overridden by 'select * from "DATABASE"."SEEDS"."TEST_A" where false limit 0 '
> > Added a condition to check if the target_relation is in the valid database.schema.table format.
> > If not, the macro returns the default value immediately.
> 
> 3. Changes with `get_query_results_as_dict.sql`
> > Added a condition to check if the column is empty.
> > If yes, assign empty value to it.(I tested a few different dummy values and ' ' works for most cases.)"
> 

## Checklist
- [ ] This code is associated with an [issue](https://github.com/dbt-labs/dbt-utils/issues) which has been triaged and [accepted for development](https://docs.getdbt.com/docs/contributing/oss-expectations#pull-requests).
- [ ] I have read [the contributing guide](https://github.com/dbt-labs/dbt-utils/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [ ] I have run this code in development and it appears to resolve the stated issue
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [ ] I have updated the README.md (if applicable)