### PR TITLE
Feature/cross server communication sql server

### DIFF
--- a/README.md
+++ b/README.md
@@ -1438,7 +1438,9 @@ sources:
 Error Handling
 
 If linked_servers[source] is missing, a compile-time error is raised:
+```
 Missing linked_server for source: source. Define in dbt_project.yml vars: linked_servers
+```
 If neither target_flag nor source_name is provided correctly:
 
 

--- a/README.md
+++ b/README.md
@@ -1382,6 +1382,70 @@ sum(case when payment_method = '1337pay' then amount end)
 ...
 ```
 ---
+
+### cross_server_ref – Reference Tables Across Linked SQL Servers ([source](macros/sql/cross_server_ref.sql)
+This macro allows you to reference tables across SQL Server linked servers or your current target environment dynamically, using variables defined in dbt_project.yml.
+
+Usage
+
+```
+SELECT DISTINCT MstrARIdfr AS agreement_identifier
+FROM {{ cross_server_ref('source', 'source_table') }}
+```
+When configured correctly, this resolves to:
+
+
+[LINKED_SERVER_NAME].[SOURCE_DATABASE].[SOURCE_SCHEMA].[source_table]
+
+For referencing your target tables, use:
+
+```
+SELECT * FROM {{ cross_server_ref('my_model_name', target_flag=true) }}
+```
+
+Or override schema:
+
+```
+SELECT * FROM {{ cross_server_ref('my_model_name', target_flag=true, target_schema='custom_schema') }}
+```
+
+dbt_project.yml Setup
+
+```
+vars:
+  linked_servers:
+    source: "LINKED_SERVER_NAME"  # Use lowercase key
+  source_databases:
+    source: "SOURCE_DATABASE"
+  source_schemas:
+    source: "SOURCE_SCHEMA"
+```
+Make sure the source key matches the lowercase form of the source system name used in the macro call.
+
+Source Declaration (Optional)
+If you're defining sources: for documentation or consistency, use:
+
+```
+version: 2
+sources:
+  - name: SOURCE
+    database: SOURCE_DATABASE
+    schema: source_schema
+    tables:
+      - name: source_table_name
+```
+
+Error Handling
+
+If linked_servers[source] is missing, a compile-time error is raised:
+Missing linked_server for source: source. Define in dbt_project.yml vars: linked_servers
+If neither target_flag nor source_name is provided correctly:
+
+
+Invalid cross_server_ref parameters. Use either:
+1. cross_server_ref('source_name', 'table_name') for sources
+2. cross_server_ref('table_name', target_flag=true) for targets
+
 ## Materializations
 
 ### insert_by_period 

--- a/macros/sql/cross_server_ref.sql
+++ b/macros/sql/cross_server_ref.sql
@@ -1,0 +1,39 @@
+{% macro cross_server_ref(
+    source_name=none,
+    table_name=none,
+    target_flag=false,
+    target_schema=none
+) %}
+  {% if target_flag %}
+    {# TARGET REFERENCE #}
+    {% set final_schema = target_schema if target_schema else target.schema %}
+    {{ adapter.quote(target.database) }}.{{ adapter.quote(final_schema) }}.{{ adapter.quote(table_name) }}
+  
+  {% elif source_name and table_name %}
+    {# SOURCE REFERENCE - CASE-INSENSITIVE #}
+    {% set source_name_lower = source_name | lower %}
+    {% set linked_server = var('linked_servers', {})[source_name_lower] %}
+    
+    {% if not linked_server %}
+      {{ exceptions.raise_compiler_error(
+        "Missing linked_server for source: " ~ source_name ~ ". " ~
+        "Define in dbt_project.yml vars: linked_servers"
+      ) }}
+    {% endif %}
+    
+    {% set database = var('source_databases', {}).get(source_name_lower, 'DACO_STANDARDIZED') %}
+    {% set schema = var('source_schemas', {}).get(source_name_lower, 'daco_bmat') %}
+    
+    {{ adapter.quote(linked_server) }}.
+    {{ adapter.quote(database) }}.
+    {{ adapter.quote(schema) }}.
+    {{ adapter.quote(table_name) }}
+  
+  {% else %}
+    {{ exceptions.raise_compiler_error(
+      "Invalid cross_server_ref parameters. Use either:\n" ~
+      "1. cross_server_ref('source_name', 'table_name') for sources\n" ~
+      "2. cross_server_ref('table_name', target_flag=true) for targets"
+    ) }}
+  {% endif %}
+{% endmacro %}


### PR DESCRIPTION
### Problem

By default, dbt-core can only connect to a single database server at a time. This means that both the source and target databases must reside on the same SQL Server instance. Reading from one server and writing to another is not supported out of the box.

### Solution

The cross_server_ref.sql macro leverages SQL Server’s linked server functionality, allowing you to seamlessly query data across multiple servers.

## Checklist
- [ ] This code is associated with an [issue](https://github.com/dbt-labs/dbt-utils/issues) which has been triaged and [accepted for development](https://docs.getdbt.com/docs/contributing/oss-expectations#pull-requests).
- [ x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-utils/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [ x] I have run this code in development and it appears to resolve the stated issue
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [ x] I have updated the README.md (if applicable)
