### PR TITLE
fix(date_spine): Replace ordinal with column name in BQ window function

### DIFF
--- a/macros/sql/date_spine.sql
+++ b/macros/sql/date_spine.sql
@@ -53,7 +53,7 @@ all_periods as (
         {{
             dbt.dateadd(
                 datepart,
-                "row_number() over (order by 1) - 1",
+                "row_number() over (order by generated_number) - 1",
                 start_date
             )
         }}


### PR DESCRIPTION
resolves #1036 

### Problem

The **`dbt_utils.date_spine`** macro generates SQL that uses a positional ordinal (**`ORDER BY 1`**) within a **`ROW_NUMBER()`** window function. This syntax is deprecated in Google BigQuery and causes a warning to be displayed whenever a model using this macro is run, indicating the functionality may be removed in future versions. The use of ordinals is also less robust and readable than using an explicit column name.

### Solution

This pull request resolves the issue by replacing the positional ordinal **`1`** with the explicit column name **`generated_number`** inside the **`all_periods`** CTE of the **`date_spine`** macro.

The **`generated_number`** column is created by the upstream **`dbt_utils.generate_series`** macro, making it the correct and stable column to use for ordering. This change eliminates the deprecation warning in BigQuery and makes the generated SQL more explicit and maintainable, with no change to the macro's output or logic.

No new tests were added as this is a minor syntax correction to fix a deprecation warning, not a change in the macro's functionality.

## Checklist
- [X] This code is associated with an [issue](https://github.com/dbt-labs/dbt-utils/issues) which has been triaged and [accepted for development](https://docs.getdbt.com/docs/contributing/oss-expectations#pull-requests).
- [X] I have read [the contributing guide](https://github.com/dbt-labs/dbt-utils/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [X] I have run this code in development and it appears to resolve the stated issue
- [X] This PR includes tests, or tests are not required/relevant for this PR
- [ ] I have updated the README.md (if applicable)
