### PR TITLE
If both tables contain zero rows results in an error in Snowflake. Ths is caused by the consequence that group by 1 returns no rows, so the resulting test contains no rows. This is solved by removing the grouping if there are no group by columns defined

### DIFF
--- a/macros/generic_tests/equal_rowcount.sql
+++ b/macros/generic_tests/equal_rowcount.sql
@@ -12,7 +12,8 @@
     {{ return('') }}
 {% endif %}
 
-{% if group_by_columns|length() > 0 %}
+{% set has_grouping = group_by_columns|length() > 0 %}
+{% if has_grouping %}
   {% set select_gb_cols = group_by_columns|join(', ') + ', ' %}
   {% set join_gb_cols %}
     {% for c in group_by_columns %}
@@ -35,10 +36,12 @@ with a as (
       1 as id_dbtutils_test_equal_rowcount,
       count(*) as count_a 
     from {{ model }}
-    {{groupby_gb_cols}}
-
+    {% if has_grouping %}
+        {{groupby_gb_cols}}
+    {% endif %}
 
 ),
+
 b as (
 
     select 
@@ -46,9 +49,12 @@ b as (
       1 as id_dbtutils_test_equal_rowcount,
       count(*) as count_b 
     from {{ compare_model }}
-    {{groupby_gb_cols}}
+    {% if has_grouping %}
+        {{groupby_gb_cols}}
+    {% endif %}
 
 ),
+
 final as (
 
     select
@@ -63,11 +69,14 @@ final as (
         abs(count_a - count_b) as diff_count
 
     from a
+    {% if has_grouping %}
     full join b
     on
     a.id_dbtutils_test_equal_rowcount = b.id_dbtutils_test_equal_rowcount
     {{join_gb_cols}}
-
+    {% else %}
+        cross join b
+    {% endif %}
 
 )
 


### PR DESCRIPTION
In Snowflake a query like the following returns no rows.

```sql
select 1 as id_dbtutils_test_equal_rowcount,
  count(*)
from my_table
group by 1
```

If both tables do not contain a row the following error will be raised:

```log
13:10:13    None is not of type 'integer'

Failed validating 'type' in schema['properties']['failures']:
    {'type': 'integer'}

On instance['failures']:
    None
13:10:13  
```

This PR solves that issue