### PR TITLE
Add missing documentation for pivot `distinct` argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -1223,6 +1223,7 @@ This macro pivots values from rows to columns.
 - `then_value`: Value to use if comparison succeeds, default is 1
 - `else_value`: Value to use if comparison fails, default is 0
 - `quote_identifiers`: Whether to surround column aliases with double quotes, default is true
+- `distinct`: Whether to use `distinct` in the aggregation, default is false
 
 ### unpivot ([source](macros/sql/unpivot.sql))
 


### PR DESCRIPTION
## Summary
- Adds the missing `distinct` argument to the `pivot` macro's documentation in README.md
- The `distinct` parameter (default: `false`) controls whether `DISTINCT` is used inside the aggregation function

Closes #1054

## Test plan
- [x] Verified the `distinct` argument exists in the macro signature (`macros/sql/pivot.sql`) with default value `False`
- [x] Confirmed the new docs entry follows the same format as existing args